### PR TITLE
fix: add a minimum bottom inset to sheets in the browser

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -356,6 +356,13 @@ html.keyboard-visible .hide-on-keyboard {
      iOS / web fallback. See src/utils/safeAreaInsets.ts. */
   padding-bottom: calc(1em + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
 }
+/* In-browser web has no home-indicator inset (env() is 0, and the
+   painted strip only exists under ios-standalone-bottom-gap), so sheets
+   sat nearly flush at the screen bottom (#299). Floor the inset term;
+   platforms with a real inset keep it (max picks the larger). */
+html:not(.ios-standalone-bottom-gap) .bottom-sheet-content-pad {
+  padding-bottom: calc(1em + max(var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)), 1em));
+}
 html.keyboard-visible .bottom-sheet-content-pad:focus-within {
   padding-bottom: 1em;
 }


### PR DESCRIPTION
Closes #299

This PR adds bottom padding to the bottom sheets in the mobile web browser.

On iOS, the installed app (PWA) shows padding and a painted strip below the sheet content. The browser page has no strip, and the safe-area inset is `0`. So the sheet content sat almost flush at the screen bottom.

The sheet padding now has a minimum inset of `1em`, in addition to the base `1em`. The rule applies only outside the iOS standalone mode. Platforms with a real inset keep their value, because the rule uses the larger of the two (`max()`).

**Note:** when the keyboard is open and a field has focus, the padding stays `1em` on all platforms. This is not changed. If the button must sit higher above the keyboard, that is a separate small change.