### PR TITLE
feat: open the transaction ID in a block explorer, copy it, share it

### DIFF
--- a/src/components/PaymentDetailsDialog.tsx
+++ b/src/components/PaymentDetailsDialog.tsx
@@ -11,6 +11,7 @@ import { useFiatData } from '../contexts/FiatDataContext';
 import { useContactsContext } from '../contexts/ContactsContext';
 import { getPaymentDescription, getProviderDisplayName, isCrossChainPayment } from '../utils/paymentDescription';
 import { formatChainName, getCrossChainDestination, formatReceiveAmount } from '../utils/crossChainFormat';
+import { explorerTxUrl } from '../utils/explorer';
 
 interface PaymentDetailsDialogProps {
   optionalPayment: Payment | null;
@@ -305,6 +306,9 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
                   value={payment.details.txId}
                   isVisible={visibleFields.txId}
                   onToggle={() => toggleField('txId')}
+                  href={explorerTxUrl(payment.details.txId)}
+                  copyable
+                  shareable
                 />
               </div>
             )}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode, forwardRef } from 'react';
 import { createPortal } from 'react-dom';
-import { Capacitor } from '@capacitor/core';
-import { Share } from '@capacitor/share';
 import { logger, LogCategory } from '@/services/logger';
 import { copyToClipboard } from '@/utils/clipboard';
+import { canShare, shareText } from '@/utils/share';
+import { openExternalUrl } from '@/utils/externalLink';
 import {
   CloseIcon,
   ChevronDownIcon,
@@ -205,10 +205,13 @@ export const CollapsibleCodeField: React.FC<{
   value: string;
   isVisible: boolean;
   onToggle: () => void;
+  /** Tapping the value opens this URL. */
   href?: string;
-  /** Show a tap-to-copy button next to the value. */
+  /** Show a copy button next to the value. */
   copyable?: boolean;
-}> = ({ label, value, isVisible, onToggle, href, copyable }) => {
+  /** Show a share button next to the value. */
+  shareable?: boolean;
+}> = ({ label, value, isVisible, onToggle, href, copyable, shareable }) => {
   const [copied, setCopied] = React.useState(false);
   const handleCopy = () => {
     copyToClipboard(value)
@@ -222,35 +225,48 @@ export const CollapsibleCodeField: React.FC<{
         });
       });
   };
+  const logFailure = (message: string) => (err: unknown) => {
+    logger.error(LogCategory.UI, message, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  };
   return (
     <CollapsibleSection label={label} isVisible={isVisible} onToggle={onToggle}>
       <div className="flex items-start gap-2">
         <div className="overflow-x-auto flex-1 min-w-0">
           {href ? (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-xs break-all flex items-center gap-1 group"
+            <button
+              onClick={() => openExternalUrl(href).catch(logFailure('Failed to open link'))}
+              className="font-mono text-xs break-all text-left flex items-start gap-1 group"
+              aria-label={`Open ${label}`}
             >
               <span className="text-spark-text-secondary">{value}</span>
               <ExternalLinkIcon className="w-3.5 h-3.5 shrink-0 text-spark-primary opacity-70 group-hover:opacity-100 transition-opacity" />
-            </a>
+            </button>
           ) : (
             <code className="text-spark-text-secondary font-mono text-xs break-all">
               {value}
             </code>
           )}
         </div>
-        {copyable && !href && (
+        {copyable && (
           <button
             onClick={handleCopy}
             className="shrink-0 p-1 rounded-md hover:bg-white/5 transition-colors"
-            aria-label="Copy"
+            aria-label={`Copy ${label}`}
           >
             {copied
               ? <CheckIcon size="sm" className="text-spark-success" />
               : <CopyFilledIcon size="sm" className="text-spark-text-secondary" />}
+          </button>
+        )}
+        {shareable && canShare() && (
+          <button
+            onClick={() => shareText(label, value).catch(logFailure('Failed to share'))}
+            className="shrink-0 p-1 rounded-md hover:bg-white/5 transition-colors"
+            aria-label={`Share ${label}`}
+          >
+            <ShareIcon size="sm" className="text-spark-text-secondary" />
           </button>
         )}
       </div>
@@ -278,15 +294,7 @@ export const CopyableText: React.FC<{
   'data-testid'?: string;
 }> = ({ text, truncate = false, hideText = false, showShare = false, onCopied, onShareError, label = 'Address', additionalActions, textColor = 'text-spark-text-muted', textToCopy, textToShare, shareLabel, 'data-testid': testId }) => {
   const [copied, setCopied] = React.useState(false);
-  // Share is available via @capacitor/share on native (Android System
-  // WebView does not implement navigator.share, which is why the
-  // button only appeared on iOS before) and via the Web Share API on
-  // the web. Fixed for the page lifetime; read once at init.
-  const [canShare] = React.useState(
-    () =>
-      Capacitor.isNativePlatform() ||
-      (typeof navigator !== 'undefined' && !!navigator.share),
-  );
+  const [shareAvailable] = React.useState(canShare);
 
   const handleCopy = () => {
     const textToUse = textToCopy || text;
@@ -303,25 +311,8 @@ export const CopyableText: React.FC<{
       });
   };
 
-  const handleShare = async () => {
-    const textToUse = textToShare || text;
-    const shareTitle = shareLabel || label;
-    try {
-      if (Capacitor.isNativePlatform()) {
-        await Share.share({ title: shareTitle, text: textToUse });
-      } else {
-        await navigator.share({ title: shareTitle, text: textToUse });
-      }
-    } catch (err) {
-      // Web AbortError = user dismissed the sheet; the native plugin
-      // rejects a dismissed share with a "canceled"/"Share canceled"
-      // message. Neither is an error worth surfacing.
-      const name = (err as Error).name;
-      const message = (err as Error).message ?? '';
-      if (name !== 'AbortError' && !/cancel/i.test(message)) {
-        onShareError?.();
-      }
-    }
+  const handleShare = () => {
+    shareText(shareLabel || label, textToShare || text).catch(() => onShareError?.());
   };
 
   // Truncate text for display if requested
@@ -361,7 +352,7 @@ export const CopyableText: React.FC<{
           {copied ? 'Copied!' : 'Copy'}
         </button>
 
-        {showShare && canShare && (
+        {showShare && shareAvailable && (
           <button
             onClick={handleShare}
             className="flex items-center gap-2 px-4 py-2 border border-spark-border text-spark-text-secondary rounded-xl font-medium text-sm hover:text-spark-text-primary hover:border-spark-border-light transition-colors"

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -7,6 +7,7 @@ import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
 import { CloseIcon, CheckIcon, WarningIcon, RadioCheckIcon } from '../components/Icons';
 import { isDepositRejected, removeRejectedDeposit } from '../services/depositState';
 import { SatAmount } from '../components/SatAmount';
+import { explorerTxUrl } from '../utils/explorer';
 import SlideInPage from '@/components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 
@@ -191,18 +192,6 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
     return selectedDeposit.amountSats - getSelectedFee();
   };
 
-  // Get mempool.space URL for a transaction
-  const getMempoolUrl = (txid: string) => {
-    // Check URL params for network
-    const urlParams = new URLSearchParams(window.location.search);
-    const network = urlParams.get('network') ?? 'mainnet';
-
-    if (network === 'testnet') {
-      return `https://mempool.space/testnet/tx/${txid}`;
-    }
-    return `https://mempool.space/tx/${txid}`;
-  };
-
   return (
     <SlideInPage title="Get Refund" onClose={onBack} slideFrom={animationDirection}>
       <div className="p-4">
@@ -259,7 +248,9 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                           value={dep.txid}
                           isVisible={expandedTxIds[txKey] || false}
                           onToggle={() => setExpandedTxIds(prev => ({ ...prev, [txKey]: !prev[txKey] }))}
-                          href={getMempoolUrl(dep.txid)}
+                          href={explorerTxUrl(dep.txid)}
+                          copyable
+                          shareable
                         />
 
                         {isRefunded && refundedTxId && (
@@ -268,7 +259,9 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                             value={refundedTxId}
                             isVisible={expandedTxIds[refundKey] || false}
                             onToggle={() => setExpandedTxIds(prev => ({ ...prev, [refundKey]: !prev[refundKey] }))}
-                            href={getMempoolUrl(refundedTxId)}
+                            href={explorerTxUrl(refundedTxId)}
+                            copyable
+                            shareable
                           />
                         )}
                       </div>
@@ -490,6 +483,9 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                       value={refundTxId}
                       isVisible={isTxIdVisible}
                       onToggle={() => setIsTxIdVisible(prev => !prev)}
+                      href={explorerTxUrl(refundTxId)}
+                      copyable
+                      shareable
                     />
                   </PaymentInfoCard>
                 )}

--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -5,6 +5,7 @@ import { BottomSheetContainer, BottomSheetCard, DialogHeader, PrimaryButton, Sec
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
 import { SpinnerIcon, WarningIcon } from '../components/Icons';
 import { rejectDeposit, removeRejectedDeposit } from '../services/depositState';
+import { explorerTxUrl } from '../utils/explorer';
 import { logger, LogCategory } from '@/services/logger';
 
 interface UnclaimedDepositDetailsPageProps {
@@ -114,6 +115,9 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
               value={deposit.txid}
               isVisible={isTxIdVisible}
               onToggle={() => setIsTxIdVisible(prev => !prev)}
+              href={explorerTxUrl(deposit.txid)}
+              copyable
+              shareable
             />
           </PaymentInfoCard>
 

--- a/src/utils/explorer.ts
+++ b/src/utils/explorer.ts
@@ -1,0 +1,10 @@
+/**
+ * Block explorer link for a Bitcoin L1 transaction.
+ *
+ * Only deposit and withdraw payments carry an L1 txid. Token payments carry a
+ * Spark `txHash` and cross-chain payments settle on the destination chain:
+ * neither belongs on mempool.space.
+ */
+// ponytail: mainnet only. Regtest is a dev-only override with no public
+// explorer, so its links dead-end; branch on the network if that ever matters.
+export const explorerTxUrl = (txid: string): string => `https://mempool.space/tx/${txid}`;

--- a/src/utils/share.test.ts
+++ b/src/utils/share.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { shareText } from './share';
+
+const mockNavigatorShare = (impl: () => Promise<void>) =>
+  vi.stubGlobal('navigator', { ...navigator, share: impl });
+
+describe('shareText on web', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('resolves when the user dismisses the sheet', async () => {
+    const abort = new Error('dismissed');
+    abort.name = 'AbortError';
+    mockNavigatorShare(() => Promise.reject(abort));
+
+    await expect(shareText('Transaction ID', 'abc')).resolves.toBeUndefined();
+  });
+
+  it('rejects on a real failure', async () => {
+    mockNavigatorShare(() => Promise.reject(new Error('not allowed')));
+
+    await expect(shareText('Transaction ID', 'abc')).rejects.toThrow('not allowed');
+  });
+});

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,0 +1,29 @@
+import { Capacitor } from '@capacitor/core';
+import { Share } from '@capacitor/share';
+
+/**
+ * Native share sheet on Capacitor, Web Share API on the web. Android System
+ * WebView does not implement `navigator.share`, which is why the plugin path
+ * exists. Fixed for the page lifetime, so it is safe to read once.
+ */
+export const canShare = (): boolean =>
+  Capacitor.isNativePlatform() || (typeof navigator !== 'undefined' && !!navigator.share);
+
+/**
+ * Share plain text. A dismissed sheet resolves: web rejects with `AbortError`
+ * and the native plugin with a "canceled" message, neither worth surfacing.
+ * Rejects only on a real failure.
+ */
+export async function shareText(title: string, text: string): Promise<void> {
+  try {
+    if (Capacitor.isNativePlatform()) {
+      await Share.share({ title, text });
+    } else {
+      await navigator.share({ title, text });
+    }
+  } catch (err) {
+    const name = (err as Error).name;
+    const message = (err as Error).message ?? '';
+    if (name !== 'AbortError' && !/cancel/i.test(message)) throw err;
+  }
+}


### PR DESCRIPTION
Tapping the transaction ID did nothing, and only the recipient address could be copied.

Tapping the ID now opens the transaction on mempool.space, in an in-app browser view so returning to Glow is one tap. A copy button and a share button sit beside it. Copy stays on its own button, so a stray tap on the ID cannot overwrite whatever is on the clipboard.

This covers payment details for on-chain deposits and withdrawals, unclaimed deposit details, the refund list, and the transaction ID shown after a refund. Those are the only places with a Bitcoin transaction to look up: Lightning and Spark payments never touch the chain.

Closes #316.

## Test plan

On a device, open an on-chain deposit or withdrawal from the payments list and expand the transaction ID:

- Tap the ID: mempool.space opens in an in-app view showing that transaction, and closing it returns to the same screen.
- Tap copy: the icon turns into a check mark for two seconds and the ID pastes correctly.
- Tap share: the system share sheet opens with the ID as its text, and dismissing it does nothing else.