### PR TITLE
feat: show the recipient on the send confirmation screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,33 +213,23 @@ UI with primary color").
 
 ## Bitcoin Symbol (₿) in Amount Displays
 
-All sat amounts shown to the user include the ₿ symbol. Follow these conventions:
+Every sat amount rendered as JSX goes through `SatAmount` (`src/components/SatAmount.tsx`). It supplies the ₿ symbol, the space-grouped digits, the mono font, and the `word-spacing` that corrects that font. Never hand-roll the markup: the parts have to agree, and assembling them by hand is how they drift.
 
-**Standard pattern** — for inline amounts (buttons, labels, breakdowns):
 ```tsx
-<span className="inline-flex items-center">
-  <span className="text-[0.8em] opacity-70 mr-px">₿</span>
-  {formatWithSpaces(amount)}
-</span>
+<SatAmount sats={amount} />          // inherits size, so wrap it to scale
+<span className="text-4xl font-bold"><SatAmount sats={total} /></span>
 ```
 
-**Balance header** — ₿ is absolutely positioned left of the centered number:
+**Plain text** (error messages, alerts, string props) cannot use a component, so prefix with `₿` and group with `formatWithSpaces`, never `toLocaleString`:
 ```tsx
-<span className="absolute right-full top-1/2 -translate-y-1/2 mr-0.5 text-3xl text-spark-text-secondary opacity-70 font-mono">₿</span>
-```
-
-**Transaction list** — ₿ after the +/- sign:
-```tsx
-{isReceive ? '+' : '-'}<span className="text-[0.8em] opacity-70">₿</span>{amount}
-```
-
-**Plain text** (error messages, alerts, string props) — just prefix with `₿`:
-```tsx
-setError(`Amount must be at least ₿${minSats.toLocaleString()}`);
+setError(`Amount must be at least ₿${formatWithSpaces(minSats)}`);
 ```
 
 **Key rules:**
-- Use `formatWithThinSpaces` for large text (text-4xl+), `formatWithSpaces`/`formatWithCommas` for smaller text
+- `formatWithSpaces` is the only separator. No commas, and no narrower space character: U+2009 is absent from JetBrains Mono, so a thin space silently draws from a fallback font
+- The tightening exists because mono gives every space a full character cell, which makes an untightened separator read as a break in the number. It is calibrated for mono, so never put it on proportional text, where it would pull the groups into each other
+- Apply it only to digits. `word-spacing` hits every space in the element, so a ticker (`USDC`), a chain name, or a trailing label like "change" belongs outside the amount, as a sibling
+- Two displays are deliberately hand-rolled: the balance header positions ₿ absolutely and tightens via `.balance-display`, and the transaction list's token rows carry a per-asset symbol split off a pre-formatted string
 - Input field labels can use "sats" as a unit name (e.g., "Amount (sats)")
 - Range displays and placeholders use "sats" text, not ₿
 

--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -2,7 +2,8 @@ import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react'
 import type { GetInfoResponse, FiatCurrency } from '@breeztech/breez-sdk-spark';
 import { safeAreaTop } from '../utils/safeAreaInsets';
 import { getFiatSettings } from '../services/settings';
-import { formatWithThinSpaces, formatWithSpaces } from '../utils/formatNumber';
+import { formatWithSpaces } from '../utils/formatNumber';
+import { SatAmount } from './SatAmount';
 import { useAnimatedNumber } from '../hooks/useAnimatedNumber';
 import { MenuIcon, AlertTriangleIcon, CurrencyIcon, SpinnerIcon, SwapVerticalIcon } from './Icons';
 import { useStableBalance } from '../contexts/StableBalanceContext';
@@ -214,11 +215,11 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
     };
   }, [stableBalance.isActive, fiatCurrencyInfo, activeFiatIndex, displayBalance, btcBalanceSat, hasSecondaryData]);
 
-  // Stable balance secondary line
-  const stableSecondaryText = useMemo(() => {
+  // Stable balance secondary line. Sats only: the "change" label renders beside
+  // the amount rather than inside it, so it keeps a normal word space.
+  const stableSecondarySats = useMemo(() => {
     if (!stableBalance.isActive) return null;
-    if (btcBalanceSat > 0) return `${formatWithThinSpaces(btcBalanceSat)} change`;
-    return null;
+    return btcBalanceSat > 0 ? btcBalanceSat : null;
   }, [stableBalance.isActive, btcBalanceSat]);
 
   // Format primary balance display — strip the currency symbol so we can position it separately.
@@ -245,7 +246,7 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
   // Hide fiat secondary line while stable balance config is still loading
   // (activeLabel is set from cache but displayConfig hasn't loaded yet)
   const stableBalanceLoading = !!stableBalance.activeLabel && !stableBalance.isActive;
-  const hasSecondaryLine = stableBalance.isActive ? !!stableSecondaryText : (!stableBalanceLoading && !!currentFiat);
+  const hasSecondaryLine = stableBalance.isActive ? !!stableSecondarySats : (!stableBalanceLoading && !!currentFiat);
 
   return (
   <>
@@ -386,8 +387,11 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
             }} />
             <span className="text-spark-text-secondary text-sm font-mono">
               {stableBalance.isActive ? (
-                stableSecondaryText ? (
-                  <span className="inline-flex items-center"><span className="text-[0.8em] opacity-70 mr-px">₿</span>{stableSecondaryText}</span>
+                stableSecondarySats ? (
+                  <span className="inline-flex items-center">
+                    <SatAmount sats={stableSecondarySats} />
+                    <span className="ml-1">change</span>
+                  </span>
                 ) : (
                   <span className="invisible">$0.00</span>
                 )

--- a/src/components/FeeBreakdownCard.tsx
+++ b/src/components/FeeBreakdownCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatWithThinSpaces } from '../utils/formatNumber';
+import { SatAmount } from './SatAmount';
 
 /**
  * Reusable component for displaying payment fee breakdowns.
@@ -50,7 +50,7 @@ export const FeeBreakdownCard: React.FC<FeeBreakdownCardProps> = ({
             <span className={`font-mono text-sm ${item.highlight ? 'font-bold text-spark-primary' : 'text-spark-text-primary'}`}>
               {useRawStrings || typeof item.value === 'string'
                 ? String(item.value)
-                : Number(item.value) === 0 ? '0' : <span className="inline-flex items-center"><span className="text-[0.8em] opacity-70 mr-px">₿</span>{formatWithThinSpaces(item.value)}</span>
+                : Number(item.value) === 0 ? '0' : <SatAmount sats={item.value} />
               }
             </span>
           </div>

--- a/src/components/PaymentCelebration.tsx
+++ b/src/components/PaymentCelebration.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { Payment } from '@breeztech/breez-sdk-spark';
 import { useStableBalance } from '../contexts/StableBalanceContext';
+import { SatAmount } from './SatAmount';
 import { useFiatData } from '../contexts/FiatDataContext';
 import { getTokenAmountFromPayment, formatTokenAmount, buildTokenDisplayConfig } from '../utils/tokenFormatting';
 import GlowLogo from './GlowLogo';
@@ -40,10 +41,6 @@ const PaymentCelebration: React.FC<PaymentCelebrationProps> = ({ payment, onClos
       clearTimeout(closeTimer);
     };
   }, [onClose]);
-
-  const formatSatsAmount = (sats: number) => {
-    return sats.toLocaleString('en-US').replace(/,/g, '\u2009');
-  };
 
   // Determine display: token amount or sats
   // Always show token denomination for token payments, even if stable balance is off
@@ -107,8 +104,7 @@ const PaymentCelebration: React.FC<PaymentCelebrationProps> = ({ payment, onClos
           ) : (
             <span className="relative inline-flex items-center gap-1 text-5xl font-mono font-bold text-spark-primary">
               {isSent && '-'}
-              <span className="text-3xl opacity-70">₿</span>
-              {formatSatsAmount(Number(payment.amount))}
+              <SatAmount sats={Number(payment.amount)} />
             </span>
           )}
         </div>

--- a/src/components/PaymentDetailsDialog.tsx
+++ b/src/components/PaymentDetailsDialog.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import type { Payment, ConversionSide, TokenMetadata } from '@breeztech/breez-sdk-spark';
 import {
   DialogHeader, PaymentInfoCard, PaymentInfoRow,
   CollapsibleCodeField, CollapsibleSection, BottomSheetContainer, BottomSheetCard
 } from './ui';
-import { formatWithSpaces } from '../utils/formatNumber';
+import { SatAmount } from './SatAmount';
 import { useStableBalance } from '../contexts/StableBalanceContext';
 import { getTokenAmountFromPayment, formatTokenAmount, buildTokenDisplayConfig } from '../utils/tokenFormatting';
 import { useFiatData } from '../contexts/FiatDataContext';
@@ -74,10 +74,10 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
 
   // Format a conversion side's amount or fee in its native unit
   // Note: side.amount and side.fee are strings from WASM (u128 serialized as string)
-  const formatSideValue = (side: ConversionSide, isFee?: boolean): string => {
+  const formatSideValue = (side: ConversionSide, isFee?: boolean): ReactNode => {
     const value = BigInt(isFee ? side.fee : side.amount);
     if (side.asset.ticker === 'BTC') {
-      return `₿${formatWithSpaces(Number(value))}`;
+      return <SatAmount sats={Number(value)} />;
     }
     const config = stableBalance.displayConfig ?? buildTokenDisplayConfig(
       { ticker: side.asset.ticker, decimals: side.asset.decimals } as TokenMetadata,
@@ -87,12 +87,12 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
   };
 
   // Format a fee value in the payment's native denomination
-  const formatPaymentFee = (fee: bigint): string => {
+  const formatPaymentFee = (fee: bigint): ReactNode => {
     if (payment.details?.type === 'token') {
       const config = stableBalance.displayConfig ?? buildTokenDisplayConfig(payment.details.metadata, fiatCurrencies);
       return formatTokenAmount(fee, config, { fullPrecision: true });
     }
-    return `₿${formatWithSpaces(Number(fee))}`;
+    return <SatAmount sats={Number(fee)} />;
   };
 
   // When the conversion amount was adjusted (min limit floor or dust prevention),
@@ -105,9 +105,9 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
   const sign = payment.paymentType === 'receive' ? '+' : '-';
   const amountDisplay = hasTokenDisplay
     ? `${sign} ${formatTokenAmount(tokenInfo.amount, tokenDisplayConfig)}`
-    : `${sign} ₿${formatWithSpaces(payment.amount)}`;
+    : <>{sign} <SatAmount sats={payment.amount} /></>;
   const feeDisplay = payment.fees > 0
-    ? (isAmountAdjusted ? `₿${formatWithSpaces(Number(payment.fees))}` : formatPaymentFee(BigInt(payment.fees)))
+    ? (isAmountAdjusted ? <SatAmount sats={Number(payment.fees)} /> : formatPaymentFee(BigInt(payment.fees)))
     : null;
 
   // Cross-chain ("USD Transfer"): surface the destination (recipient address +

--- a/src/components/SatAmount.tsx
+++ b/src/components/SatAmount.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { formatWithSpaces } from '../utils/formatNumber';
+
+/**
+ * A sat amount: the ₿ symbol followed by space-grouped thousands.
+ *
+ * Owns the mono font together with the `word-spacing` that corrects it. Mono
+ * gives a space a full character cell, and -0.4em is calibrated against that,
+ * so a caller must never be able to set one without the other. Inherits its
+ * size, so wrap it to scale.
+ *
+ * Two displays stay hand-rolled: the balance header positions ₿ absolutely and
+ * tightens via `.balance-display`, and the transaction list's token rows carry
+ * a symbol that varies per asset.
+ */
+export const SatAmount: React.FC<{ sats: number | bigint; className?: string }> = ({ sats, className = '' }) => (
+  <span className={`inline-flex items-center font-mono [word-spacing:-0.4em] ${className}`}>
+    <span className="text-[0.8em] opacity-70 mr-px">₿</span>
+    {formatWithSpaces(sats)}
+  </span>
+);
+
+export default SatAmount;

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -1,16 +1,14 @@
 import React, { useMemo } from 'react';
 import { Payment } from '@breeztech/breez-sdk-spark';
 import type { ExtendedPayment } from '../utils/depositHelpers';
-import { formatWithCommas } from '../utils/formatNumber';
+import { formatWithSpaces } from '../utils/formatNumber';
+import { SatAmount } from './SatAmount';
 import { ArrowDownIcon, ArrowUpIcon, LightningBoltIcon, WalletIcon } from './Icons';
 import { useStableBalance } from '../contexts/StableBalanceContext';
 import { useFiatData } from '../contexts/FiatDataContext';
 import { useContactsContext } from '../contexts/ContactsContext';
 import { formatTokenAmount, buildTokenDisplayConfig, tokenAmountDisplaysAsZero } from '../utils/tokenFormatting';
 import { getPaymentDescription } from '../utils/paymentDescription';
-
-// Use centralized formatting utility
-const formatWithSpaces = formatWithCommas;
 
 // Hoisted static JSX elements (rendering-hoist-jsx optimization)
 const ReceiveIcon = <ArrowDownIcon size="sm" />;
@@ -195,12 +193,15 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onPayme
           {(tx.details?.type === 'token' || tx.conversionDetails)
             ? (() => {
                 const formatted = stableBalance.formatPaymentAmount(tx);
-                // Style the leading currency symbol (e.g. $, €) to match ₿ treatment
+                // Style the leading currency symbol (e.g. $, €) to match ₿ treatment.
+                // The tail is digits only, so it takes the same tightening as a sats
+                // row: a converted payment reaches this branch as "₿6 507". A
+                // symbol-last format (no match) keeps its space before the ticker.
                 const match = formatted.match(/^([^\d-]+)(.*)/);
-                if (match) return <><span className="text-[0.8em] opacity-70">{match[1]}</span>{match[2]}</>;
+                if (match) return <><span className="text-[0.8em] opacity-70">{match[1]}</span><span className="[word-spacing:-0.4em]">{match[2]}</span></>;
                 return formatted;
               })()
-            : <><span className="text-[0.8em] opacity-70">₿</span>{formatWithSpaces(Number(tx.amount))}</>
+            : <SatAmount sats={Number(tx.amount)} />
           }
         </span>
       </li>

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -145,7 +145,9 @@ export const PaymentInfoCard: React.FC<{
 
 export const PaymentInfoRow: React.FC<{
   label: string;
-  value: string | number;
+  /** Rendered in `font-mono`, so a grouped amount passed here must bring its own
+   *  digit tightening. See the amount rules in CLAUDE.md. */
+  value: ReactNode;
   isBold?: boolean;
   icon?: ReactNode;
   iconBgColor?: string;

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -10,6 +10,7 @@ import {
   LoadingSpinner,
 } from '../../components/ui';
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
+import { SatAmount } from '../../components/SatAmount';
 import type { Network } from '@breeztech/breez-sdk-spark';
 import { CurrencyIcon, MoonPayIcon, CashAppIcon } from '../../components/Icons';
 import { type BuyBitcoinProvider } from '../../services/settings';
@@ -165,7 +166,7 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
                         : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
                     }`}
                   >
-                    {formatQuickAmount(quickAmount, buy.tokenConfig, buy.isTokenMode)}
+                    {buy.isTokenMode && buy.tokenConfig ? formatQuickAmount(quickAmount, buy.tokenConfig) : <SatAmount sats={quickAmount} />}
                   </button>
                 ))}
               </div>

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -14,6 +14,7 @@ import {
   formatQuickAmount,
 } from '../../utils/tokenFormatting';
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
+import { SatAmount } from '../../components/SatAmount';
 import { useAmountInput } from '../../hooks/useAmountInput';
 import type { Sats } from '../../types/sats';
 import { dismissKeyboard } from '../../utils/keyboard';
@@ -208,7 +209,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
                   }
                 `}
               >
-                {formatQuickAmount(quickAmount, config, isTokenMode)}
+                {isTokenMode && config ? formatQuickAmount(quickAmount, config) : <SatAmount sats={quickAmount} />}
               </button>
             ))}
           </div>

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -18,6 +18,7 @@ import {
 import type { PaymentMethod } from '../../types/domain';
 import { useLightningAddress } from './hooks/useLightningAddress';
 import { useReceivePayment } from './hooks/useReceivePayment';
+import { formatWithSpaces } from '../../utils/formatNumber';
 import SparkAddressDisplay from './SparkAddressDisplay';
 import BitcoinAddressDisplay from './BitcoinAddressDisplay';
 import LightningAddressDisplay from './LightningAddressDisplay';
@@ -62,7 +63,7 @@ const QRCodeDisplay: React.FC<QRCodeDisplayProps> = ({ paymentData, feeSats, tit
 
         {feeSats > 0 && (
           <Alert type="warning" className="mt-8">
-            <center>A fee of ₿{feeSats.toLocaleString()} is applied to this transaction.</center>
+            <center>A fee of ₿{formatWithSpaces(feeSats)} is applied to this transaction.</center>
           </Alert>
         )}
       </div>

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -55,7 +55,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
     if (!initialRawInput) return;
     void (async () => {
       try {
-        await send.processInput(initialRawInput);
+        await send.processInput(initialRawInput, { requireReview: true });
       } catch (err) {
         logger.error(LogCategory.PAYMENT, 'Failed to process initial payment input', {
           error: formatError(err),
@@ -154,12 +154,14 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                 // Remount on contact-selection change so InputStep
                 // lazy-inits from the latest props.
                 key={`input-${selectedContactAddress ?? ''}`}
-                paymentInput={send.paymentInput?.rawInput || ''}
+                // `initialRawInput` seeds the field at mount so a scan that stops
+                // here for review shows the payload it scanned.
+                paymentInput={send.paymentInput?.rawInput || initialRawInput || ''}
                 selectedContactAddress={selectedContactAddress}
                 isLoading={send.isLoading}
                 error={send.error}
                 onClearError={send.clearError}
-                onContinue={(input) => send.processInput(input)}
+                onContinue={(input, opts) => send.processInput(input, opts)}
                 onScanQr={onScanQr}
                 onOpenContacts={() => {
                   setSelectedContactAddress(null);

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -10,6 +10,13 @@ import { formatError } from '@/utils/formatError';
 export type SendStep = 'input' | 'amount' | 'workflow' | 'processing' | 'result';
 export type ProcessingPhase = 'sending' | 'converting';
 
+export interface ProcessInputOptions {
+  /** Set by callers that submit an input the user did not type: a scan or a
+   *  paste. A destination carrying its own amount skips both the input and
+   *  amount steps, which are the only ones that pause for the user. */
+  requireReview?: boolean;
+}
+
 export interface UseSendPaymentReturn {
   // State
   currentStep: SendStep;
@@ -32,7 +39,7 @@ export interface UseSendPaymentReturn {
   // Actions
   clearError: () => void;
   reset: () => void;
-  processInput: (input?: string | null) => Promise<void>;
+  processInput: (input?: string | null, opts?: ProcessInputOptions) => Promise<void>;
   onAmountNext: (amount: bigint, includeFees?: boolean, tokenIdentifier?: string, conversionOptions?: ConversionOptions) => Promise<void>;
   handleSend: (options?: SendPaymentOptions) => Promise<void>;
   handleRun: (runner: () => Promise<void>, hasConversion?: boolean) => Promise<void>;
@@ -109,7 +116,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     }
   }, [wallet]);
 
-  const processInput = useCallback(async (input: string | null = null) => {
+  const processInput = useCallback(async (input: string | null = null, opts?: ProcessInputOptions) => {
     const currentInput = (input || paymentInput?.rawInput)?.trim();
     if (!currentInput) {
       setError('Please enter a payment destination');
@@ -177,6 +184,13 @@ export function useSendPayment(): UseSendPaymentReturn {
         effective.type === 'sparkAddress';
 
       if (isPayableAmountType && fixedSats !== undefined) {
+        // Stay on the input step so the scanned or pasted destination is on
+        // screen and Continue is a deliberate tap. Continue re-enters here
+        // without the flag and prepares as usual.
+        if (opts?.requireReview) {
+          setCurrentStep('input');
+          return;
+        }
         setAmountFixed(true);
         setAmount(String(fixedSats));
         await prepareSend(paymentRequest, BigInt(fixedSats), undefined, undefined, undefined, 'workflow');

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -12,6 +12,7 @@ import { useAmountInput, useUsdFiatOverride } from '../../../hooks/useAmountInpu
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { useHasPendingConversion } from '../../../contexts/WalletContext';
 import { dismissKeyboard } from '../../../utils/keyboard';
+import { SatAmount } from '../../../components/SatAmount';
 
 export interface AmountStepProps {
   paymentInput: string;
@@ -232,7 +233,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
                       : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
                 }`}
               >
-                {formatQuickAmount(quickAmount, config, isTokenMode)}
+                {isTokenMode && config ? formatQuickAmount(quickAmount, config) : <SatAmount sats={quickAmount} />}
               </button>
             );
           })}

--- a/src/features/send/steps/ConfirmStep.test.tsx
+++ b/src/features/send/steps/ConfirmStep.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import ConfirmStep from './ConfirmStep';
+
+function renderConfirmStep(destination?: { label: string; value: string }) {
+  render(
+    <WalletProvider client={createMockClient()} isConnected>
+      <FiatDataProvider>
+        <StableBalanceProvider>
+          <ConfirmStep
+            amountSats={50000n}
+            feesSat={10}
+            balanceSats={1000000}
+            destination={destination}
+            error={null}
+            isLoading={false}
+            onConfirm={vi.fn()}
+          />
+        </StableBalanceProvider>
+      </FiatDataProvider>
+    </WalletProvider>
+  );
+}
+
+describe('ConfirmStep destination', () => {
+  it('shows the destination alongside the Send action', () => {
+    const value = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+    renderConfirmStep({ label: 'To address', value });
+
+    const row = screen.getByTestId('send-destination');
+    // Middle-truncated, so both ends stay checkable against the source.
+    expect(row).toHaveTextContent(/^bc1qw508d6qejx.*0c5xw7kv8f3t4$/);
+    expect(row).toHaveAttribute('title', value);
+    expect(screen.getByTestId('send-confirm-button')).toBeEnabled();
+  });
+
+  it('renders without a destination when prepare produced no payment method', () => {
+    renderConfirmStep(undefined);
+    expect(screen.queryByTestId('send-destination')).toBeNull();
+  });
+});

--- a/src/features/send/steps/ConfirmStep.tsx
+++ b/src/features/send/steps/ConfirmStep.tsx
@@ -1,13 +1,59 @@
 import React from 'react';
 import { PrimaryButton, SecondaryButton, FormError } from '../../../components/ui';
 import { FeeBreakdownCard, SimpleFeeBreakdown } from '../../../components/FeeBreakdownCard';
-import { SpinnerIcon } from '../../../components/Icons';
+import { SpinnerIcon, CopyFilledIcon, CheckIcon } from '../../../components/Icons';
 import { formatWithThinSpaces } from '../../../utils/formatNumber';
 import { formatTokenAmount } from '../../../utils/tokenFormatting';
+import { truncateAddress } from '../../../utils/crossChainFormat';
+import { copyToClipboard } from '../../../utils/clipboard';
+import { logger, LogCategory } from '../../../services/logger';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { toSats } from '../../../types/sats';
 import type { ConversionEstimate } from '@breeztech/breez-sdk-spark';
+
+export interface SendDestination {
+  label: string;
+  value: string;
+}
+
+/** Middle-truncated so both ends stay checkable against the source, and the
+ *  copy button hands back the untruncated value. */
+const DestinationRow: React.FC<SendDestination> = ({ label, value }) => {
+  const [copied, setCopied] = React.useState(false);
+  const handleCopy = () => {
+    copyToClipboard(value)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(err => {
+        logger.error(LogCategory.UI, 'Failed to copy destination to clipboard', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  };
+
+  return (
+    <div className="flex items-center gap-2 p-3 bg-spark-dark border border-spark-border rounded-xl">
+      <div className="min-w-0 flex-1">
+        <p className="text-xs text-spark-text-muted mb-0.5">{label}</p>
+        <p className="text-sm font-mono text-spark-text-secondary truncate" title={value} data-testid="send-destination">
+          {truncateAddress(value, 32)}
+        </p>
+      </div>
+      <button
+        onClick={handleCopy}
+        className="shrink-0 p-1.5 rounded-md hover:bg-white/5 transition-colors"
+        aria-label={`Copy ${label}`}
+      >
+        {copied
+          ? <CheckIcon size="sm" className="text-spark-success" />
+          : <CopyFilledIcon size="sm" className="text-spark-text-secondary" />}
+      </button>
+    </div>
+  );
+};
 
 export interface ConfirmStepProps {
   amountSats: bigint | null;
@@ -16,6 +62,9 @@ export interface ConfirmStepProps {
   conversionEstimate?: ConversionEstimate | null;
   balanceSats?: number;
   tokenBalance?: bigint;
+  /** Who the payment pays. Absent only when there is no prepared payment method
+   *  to read it from, i.e. the prepare-failed render. */
+  destination?: SendDestination;
   error: string | null;
   isLoading: boolean;
   /** Force the send action disabled regardless of the balance check, e.g. when
@@ -25,7 +74,7 @@ export interface ConfirmStepProps {
   onConfirm: () => void;
 }
 
-const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncluded, conversionEstimate, balanceSats, tokenBalance, error, isLoading, disableConfirm, onBack, onConfirm }) => {
+const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncluded, conversionEstimate, balanceSats, tokenBalance, destination, error, isLoading, disableConfirm, onBack, onConfirm }) => {
   const stableBalance = useStableBalance();
   const isTokenMode = stableBalance.isActive && !!stableBalance.displayConfig && !!conversionEstimate;
   const balance = useBalanceValidation(isTokenMode, undefined, balanceSats, tokenBalance);
@@ -62,6 +111,8 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
           </span>
         </div>
       </div>
+
+      {destination && <DestinationRow {...destination} />}
 
       {/* Sats breakdown */}
       <SimpleFeeBreakdown amount={feesIncluded ? amount - fee : amount} fee={fee} amountLabel={feesIncluded ? 'Recipient gets' : 'Amount'} />

--- a/src/features/send/steps/ConfirmStep.tsx
+++ b/src/features/send/steps/ConfirmStep.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { PrimaryButton, SecondaryButton, FormError } from '../../../components/ui';
 import { FeeBreakdownCard, SimpleFeeBreakdown } from '../../../components/FeeBreakdownCard';
 import { SpinnerIcon, CopyFilledIcon, CheckIcon } from '../../../components/Icons';
-import { formatWithThinSpaces } from '../../../utils/formatNumber';
+import { SatAmount } from '../../../components/SatAmount';
 import { formatTokenAmount } from '../../../utils/tokenFormatting';
 import { truncateAddress } from '../../../utils/crossChainFormat';
 import { copyToClipboard } from '../../../utils/clipboard';
@@ -107,7 +107,7 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
         <p className="text-spark-text-muted text-sm mb-2">You're sending</p>
         <div className="flex items-baseline justify-center gap-2">
           <span className="text-4xl font-mono font-bold text-spark-text-primary">
-            <span className="inline-flex items-center"><span className="text-[0.8em] opacity-70 mr-px">₿</span>{formatWithThinSpaces(total)}</span>
+            <SatAmount sats={total} />
           </span>
         </div>
       </div>

--- a/src/features/send/steps/InputStep.tsx
+++ b/src/features/send/steps/InputStep.tsx
@@ -17,7 +17,7 @@ export interface InputStepProps {
   isLoading: boolean;
   error: string | null;
   onClearError?: () => void;
-  onContinue: (paymentInput: string) => void;
+  onContinue: (paymentInput: string, opts?: { requireReview?: boolean }) => void;
   onScanQr?: () => void;
   onOpenContacts?: () => void;
 }
@@ -60,7 +60,7 @@ const InputStep: React.FC<InputStepProps> = ({ paymentInput, selectedContactAddr
       if (text?.trim()) {
         setLocalPaymentInput(text);
         setSelectedContact(null);
-        onContinue(text);
+        onContinue(text, { requireReview: true });
       }
     } catch (err) {
       logger.error(LogCategory.UI, 'Failed to read clipboard contents', {
@@ -134,7 +134,7 @@ const InputStep: React.FC<InputStepProps> = ({ paymentInput, selectedContactAddr
                   e.preventDefault();
                   setLocalPaymentInput(text);
                   setSelectedContact(null);
-                  onContinue(text);
+                  onContinue(text, { requireReview: true });
                 }
               }}
               onFocus={() => setIsInputFocused(true)}

--- a/src/features/send/utils.test.ts
+++ b/src/features/send/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import type { SendPaymentMethod } from '@breeztech/breez-sdk-spark';
+import { getSendDestination } from './utils';
+
+// Only the fields getSendDestination reads; the rest of each variant is noise here.
+const method = (m: unknown) => m as SendPaymentMethod;
+
+describe('getSendDestination', () => {
+  it('reads the destination out of every send payment method', () => {
+    expect(getSendDestination(method({ type: 'bitcoinAddress', address: { address: 'bc1qtest' } })).value)
+      .toBe('bc1qtest');
+    expect(getSendDestination(method({ type: 'sparkAddress', address: 'sp1test' })).value)
+      .toBe('sp1test');
+    expect(getSendDestination(method({ type: 'sparkInvoice', sparkInvoiceDetails: { invoice: 'sparkrt1test' } })).value)
+      .toBe('sparkrt1test');
+    expect(getSendDestination(method({ type: 'bolt11Invoice', invoiceDetails: { invoice: { bolt11: 'lnbc1test' } } })).value)
+      .toBe('lnbc1test');
+    expect(getSendDestination(method({ type: 'crossChainAddress', recipientAddress: '0xtest' })).value)
+      .toBe('0xtest');
+  });
+
+  it('labels every variant', () => {
+    for (const type of ['bitcoinAddress', 'sparkAddress', 'sparkInvoice', 'bolt11Invoice', 'crossChainAddress']) {
+      const m = method({
+        type,
+        address: type === 'bitcoinAddress' ? { address: 'a' } : 'a',
+        sparkInvoiceDetails: { invoice: 'a' },
+        invoiceDetails: { invoice: { bolt11: 'a' } },
+        recipientAddress: 'a',
+      });
+      expect(getSendDestination(m).label).toBeTruthy();
+    }
+  });
+});

--- a/src/features/send/utils.ts
+++ b/src/features/send/utils.ts
@@ -1,5 +1,22 @@
 import type { SendInput } from '@/types/domain';
-import type { LnurlPayRequestDetails, LnurlAuthRequestDetails, LnurlWithdrawRequestDetails } from '@breeztech/breez-sdk-spark';
+import type { LnurlPayRequestDetails, LnurlAuthRequestDetails, LnurlWithdrawRequestDetails, SendPaymentMethod } from '@breeztech/breez-sdk-spark';
+
+/** Who a prepared payment pays, for the confirm step. Read from the prepare
+ *  response, not the raw input, so the row shows what the SDK resolved. */
+export function getSendDestination(method: SendPaymentMethod): { label: string; value: string } {
+  switch (method.type) {
+    case 'bitcoinAddress':
+      return { label: 'To address', value: method.address.address };
+    case 'sparkAddress':
+      return { label: 'To Spark address', value: method.address };
+    case 'sparkInvoice':
+      return { label: 'To Spark invoice', value: method.sparkInvoiceDetails.invoice };
+    case 'bolt11Invoice':
+      return { label: 'To invoice', value: method.invoiceDetails.invoice.bolt11 };
+    case 'crossChainAddress':
+      return { label: 'To address', value: method.recipientAddress };
+  }
+}
 
 export function getPaymentMethodName(input: SendInput | null): string {
   if (!input) return '';

--- a/src/features/send/workflows/BitcoinWorkflow.tsx
+++ b/src/features/send/workflows/BitcoinWorkflow.tsx
@@ -4,6 +4,7 @@ import type { PaymentStep } from '../../../types/domain';
 import { PrimaryButton } from '../../../components/ui';
 import { RadioCheckIcon } from '../../../components/Icons';
 import ConfirmStep from '../steps/ConfirmStep';
+import { getSendDestination } from '../utils';
 
 interface BitcoinWorkflowProps {
   method: Extract<SendPaymentMethod, { type: 'bitcoinAddress' }>;
@@ -100,7 +101,7 @@ const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, f
 
       {/* Confirm */}
       {step === 'confirm' && (
-        <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />
+        <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} destination={getSendDestination(method)} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />
       )}
     </>
   );

--- a/src/features/send/workflows/BitcoinWorkflow.tsx
+++ b/src/features/send/workflows/BitcoinWorkflow.tsx
@@ -4,6 +4,7 @@ import type { PaymentStep } from '../../../types/domain';
 import { PrimaryButton } from '../../../components/ui';
 import { RadioCheckIcon } from '../../../components/Icons';
 import ConfirmStep from '../steps/ConfirmStep';
+import { SatAmount } from '../../../components/SatAmount';
 import { getSendDestination } from '../utils';
 
 interface BitcoinWorkflowProps {
@@ -54,7 +55,7 @@ const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, f
                   <RadioCheckIcon className="absolute top-2 right-2" />
                 )}
                 <div>Slow</div>
-                <div className="text-xs opacity-70">₿{(fq.speedSlow.l1BroadcastFeeSat + fq.speedSlow.userFeeSat).toLocaleString()}</div>
+                <div className="text-xs opacity-70"><SatAmount sats={fq.speedSlow.l1BroadcastFeeSat + fq.speedSlow.userFeeSat} /></div>
               </button>
               <button
                 onClick={() => setSelectedFeeRate('medium')}
@@ -67,7 +68,7 @@ const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, f
                   <RadioCheckIcon className="absolute top-2 right-2" />
                 )}
                 <div>Medium</div>
-                <div className="text-xs opacity-70">₿{(fq.speedMedium.l1BroadcastFeeSat + fq.speedMedium.userFeeSat).toLocaleString()}</div>
+                <div className="text-xs opacity-70"><SatAmount sats={fq.speedMedium.l1BroadcastFeeSat + fq.speedMedium.userFeeSat} /></div>
               </button>
               <button
                 onClick={() => setSelectedFeeRate('fast')}
@@ -80,7 +81,7 @@ const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, f
                   <RadioCheckIcon className="absolute top-2 right-2" />
                 )}
                 <div>Fast</div>
-                <div className="text-xs opacity-70">₿{(fq.speedFast.l1BroadcastFeeSat + fq.speedFast.userFeeSat).toLocaleString()}</div>
+                <div className="text-xs opacity-70"><SatAmount sats={fq.speedFast.l1BroadcastFeeSat + fq.speedFast.userFeeSat} /></div>
               </button>
             </div>
           </div>

--- a/src/features/send/workflows/Bolt11Workflow.tsx
+++ b/src/features/send/workflows/Bolt11Workflow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { SendPaymentMethod, ConversionEstimate } from '@breeztech/breez-sdk-spark';
 import ConfirmStep from '../steps/ConfirmStep';
+import { getSendDestination } from '../utils';
 
 interface Bolt11WorkflowProps {
   method: Extract<SendPaymentMethod, { type: 'bolt11Invoice' }>;
@@ -27,7 +28,7 @@ const Bolt11Workflow: React.FC<Bolt11WorkflowProps> = ({ method, amountSats, fee
     feesSat = method.lightningFeeSats;
   }
 
-  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />;
+  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} destination={getSendDestination(method)} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />;
 };
 
 export default Bolt11Workflow;

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -11,7 +11,7 @@ import { ChevronDownIcon, CopyFilledIcon, CheckIcon, SpinnerIcon } from '../../.
 import { FeeBreakdownCard } from '../../../components/FeeBreakdownCard';
 import { useWallet } from '../../../contexts/WalletContext';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
-import { formatWithThinSpaces } from '../../../utils/formatNumber';
+import { SatAmount } from '../../../components/SatAmount';
 import { copyToClipboard } from '../../../utils/clipboard';
 import { formatTokenAmount } from '../../../utils/tokenFormatting';
 import { logger, LogCategory } from '@/services/logger';
@@ -586,10 +586,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
                     {formatTokenAmount(BigInt(quote.amountIn), { ...stableBalance.displayConfig, symbol: '', symbolPosition: 'after' })}
                   </span>
                 ) : (
-                  <span className="inline-flex items-center">
-                    <span className="text-[0.8em] opacity-70 mr-px">₿</span>
-                    {formatWithThinSpaces(Number(quote.amountIn))}
-                  </span>
+                  <SatAmount sats={Number(quote.amountIn)} />
                 )}
               </span>
             </div>

--- a/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
@@ -5,6 +5,7 @@ import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
 import { formatWithSpaces } from '../../../utils/formatNumber';
 import ProcessingStep from '../steps/ProcessingStep';
+import { SatAmount } from '../../../components/SatAmount';
 
 // Seconds the SDK waits for the withdrawal to settle before returning. The SDK
 // bounds the wait, so the await resolves with the outcome (a settled payment or
@@ -118,10 +119,7 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
           </div>
         ) : isFixed ? (
           <div className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary flex items-center justify-center text-2xl font-semibold">
-            <span className="inline-flex items-center">
-              <span className="text-[0.8em] opacity-70 mr-px">₿</span>
-              {formatWithSpaces(maxSats)}
-            </span>
+            <SatAmount sats={maxSats} />
           </div>
         ) : (
           <input

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -240,7 +240,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
       ? BigInt(prepareResponse.amountSats)
       : BigInt(balance.parseInputToSats(amount) || 0);
     return (
-      <ConfirmStep amountSats={confirmAmountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={error} isLoading={isLoading} onBack={() => { setPrepareResponse(null); setError(null); setStep('amount'); }} onConfirm={onConfirm} />
+      <ConfirmStep amountSats={confirmAmountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} destination={{ label: 'To', value: parsed.address ?? parsed.domain }} error={error} isLoading={isLoading} onBack={() => { setPrepareResponse(null); setError(null); setStep('amount'); }} onConfirm={onConfirm} />
     );
   }
 

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -10,6 +10,8 @@ import {
   formatQuickAmount,
 } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
+import { SatAmount } from '../../../components/SatAmount';
+import { formatWithSpaces } from '../../../utils/formatNumber';
 import { useAmountInput, useUsdFiatOverride } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { useHasPendingConversion } from '../../../contexts/WalletContext';
@@ -190,11 +192,11 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     // (token mode without stable balance) computes exact sats, so check it.
     if (!isTokenMode || !isStableBalanceActive) {
       if (minSats && sats < minSats) {
-        setError(`Amount must be at least ₿${minSats.toLocaleString()}`);
+        setError(`Amount must be at least ₿${formatWithSpaces(minSats)}`);
         return;
       }
       if (maxSats && sats > maxSats) {
-        setError(`Amount must be at most ₿${maxSats.toLocaleString()}`);
+        setError(`Amount must be at most ₿${formatWithSpaces(maxSats)}`);
         return;
       }
     }
@@ -326,7 +328,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
                       : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
                 }`}
               >
-                {formatQuickAmount(quickAmount, config, isTokenMode)}
+                {isTokenMode && config ? formatQuickAmount(quickAmount, config) : <SatAmount sats={quickAmount} />}
               </button>
             );
           })}

--- a/src/features/send/workflows/SparkWorkflow.tsx
+++ b/src/features/send/workflows/SparkWorkflow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { SendPaymentMethod, SendPaymentOptions, ConversionEstimate } from '@breeztech/breez-sdk-spark';
 import ConfirmStep from '../steps/ConfirmStep';
+import { getSendDestination } from '../utils';
 
 interface SparkWorkflowProps {
   method: Extract<SendPaymentMethod, { type: 'sparkAddress' }>;
@@ -17,7 +18,7 @@ const SparkWorkflow: React.FC<SparkWorkflowProps> = ({ method, amountSats, feesI
   // Currently no fee exposed for spark address
   const feesSat: number | null = method.type === 'sparkAddress' ? null : null;
   const handleSend = () => onSend();
-  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />;
+  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} destination={getSendDestination(method)} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />;
 };
 
 export default SparkWorkflow;

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -6,7 +6,7 @@ import { SimpleAlert } from '../components/AlertCard';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
 import { CloseIcon, CheckIcon, WarningIcon, RadioCheckIcon } from '../components/Icons';
 import { isDepositRejected, removeRejectedDeposit } from '../services/depositState';
-import { formatWithSpaces } from '../utils/formatNumber';
+import { SatAmount } from '../components/SatAmount';
 import SlideInPage from '@/components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 
@@ -248,7 +248,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                       <div className="flex items-center justify-between py-2">
                         <span className="text-spark-text-secondary text-sm">Amount</span>
                         <span className="font-mono text-sm font-medium text-spark-text-primary">
-                          <span className="inline-flex items-center"><span className="text-[0.8em] opacity-70 mr-px">₿</span>{formatWithSpaces(amount)}</span>
+                          <SatAmount sats={amount} />
                         </span>
                       </div>
 
@@ -358,7 +358,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                         <RadioCheckIcon className="absolute top-2 right-2" />
                       )}
                       <div>Slow</div>
-                      <div className="text-xs opacity-70">₿{formatWithSpaces(feeEstimates.slow)}</div>
+                      <div className="text-xs opacity-70"><SatAmount sats={feeEstimates.slow} /></div>
                     </button>
                     <button
                       onClick={() => setSelectedFeeRate('medium')}
@@ -371,7 +371,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                         <RadioCheckIcon className="absolute top-2 right-2" />
                       )}
                       <div>Medium</div>
-                      <div className="text-xs opacity-70">₿{formatWithSpaces(feeEstimates.medium)}</div>
+                      <div className="text-xs opacity-70"><SatAmount sats={feeEstimates.medium} /></div>
                     </button>
                     <button
                       onClick={() => setSelectedFeeRate('fast')}
@@ -384,7 +384,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                         <RadioCheckIcon className="absolute top-2 right-2" />
                       )}
                       <div>Fast</div>
-                      <div className="text-xs opacity-70">₿{formatWithSpaces(feeEstimates.fast)}</div>
+                      <div className="text-xs opacity-70"><SatAmount sats={feeEstimates.fast} /></div>
                     </button>
                   </div>
                 </div>

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -4,24 +4,11 @@
 const THOUSAND_SEPARATOR_REGEX = /\B(?=(\d{3})+(?!\d))/g;
 
 /**
- * Format number with space as thousand separator
+ * Group a number into thousands with a plain space. The one separator for
+ * user-facing amounts; mono displays tighten it with `word-spacing`, see
+ * the amount rules in CLAUDE.md.
  */
 export function formatWithSpaces(num: number | bigint): string {
   return num.toString().replace(THOUSAND_SEPARATOR_REGEX, ' ');
-}
-
-/**
- * Format number with thin space (U+2009) as thousand separator
- * Better for monospace fonts
- */
-export function formatWithThinSpaces(num: number | bigint): string {
-  return num.toString().replace(THOUSAND_SEPARATOR_REGEX, '\u2009');
-}
-
-/**
- * Format number with comma as thousand separator
- */
-export function formatWithCommas(num: number): string {
-  return num.toString().replace(THOUSAND_SEPARATOR_REGEX, ',');
 }
 

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -268,14 +268,12 @@ export const TOKEN_QUICK_AMOUNTS = [1, 5, 10];
 /** Quick amount presets for sat-denominated inputs. */
 export const SATS_QUICK_AMOUNTS = [1000, 10000, 100000];
 
-/** Format a quick amount button label respecting symbol position. */
-export function formatQuickAmount(amt: number, config: TokenDisplayConfig | null, isTokenMode: boolean): string {
-  if (isTokenMode && config) {
-    return config.symbolPosition === 'before'
-      ? `${config.symbol}${amt}`
-      : `${amt} ${config.symbol}`;
-  }
-  return `₿${amt.toLocaleString('en-US').replace(/,/g, '\u2009')}`;
+/** Format a token-denominated quick amount label, respecting symbol position.
+ *  Sat-denominated buttons render `SatAmount` instead. */
+export function formatQuickAmount(amt: number, config: TokenDisplayConfig): string {
+  return config.symbolPosition === 'before'
+    ? `${config.symbol}${amt}`
+    : `${amt} ${config.symbol}`;
 }
 
 /**


### PR DESCRIPTION
The send confirmation screen shows the amount and the fees. This PR adds the recipient, so all the payment details are in one place before you send. The new row shows the address or the invoice. The app shortens long values in the middle, and a button copies the full value. The row appears for Bitcoin, Spark and Lightning sends. Cross-chain sends already show it.

This PR also changes what happens when you scan or paste a payment request that already includes an amount. The app fills the field and waits for you to press `Continue`. This gives you a moment to check the request first.

This PR also makes the space between digit groups smaller. Amounts like `₿6 507` had a gap that was too wide, because the app used a character that the font does not include. All amounts now use the same style, so the transaction list matches the other screens.