### PR TITLE
fix: ignore repeat taps while a send is running

### DIFF
--- a/src/features/send/hooks/useSendPayment.test.tsx
+++ b/src/features/send/hooks/useSendPayment.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { useSendPayment } from './useSendPayment';
+
+function renderSendPayment(client: BreezSdk) {
+  return renderHook(() => useSendPayment(), {
+    wrapper: ({ children }) => (
+      <WalletProvider client={client} isConnected>
+        <FiatDataProvider>
+          <StableBalanceProvider>{children}</StableBalanceProvider>
+        </FiatDataProvider>
+      </WalletProvider>
+    ),
+  });
+}
+
+// A repeat call in the same tick must not reach the SDK. `isLoading` cannot do
+// that on its own: React state settles on the next render, so the latch is a ref.
+describe('useSendPayment in-flight guard', () => {
+  it('sends once when handleSend is called twice before the re-render', async () => {
+    const client = createMockClient();
+    const { result } = renderSendPayment(client);
+
+    // The mock parses this as a bolt11 with an embedded amount, so the hook
+    // prepares straight away and lands on the confirm step.
+    await act(async () => {
+      await result.current.processInput('lnbc1test');
+    });
+    await waitFor(() => expect(result.current.prepareResponse).not.toBeNull());
+
+    await act(async () => {
+      await Promise.all([result.current.handleSend(), result.current.handleSend()]);
+    });
+
+    expect(client.sendPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs once when handleRun is called twice before the re-render', async () => {
+    const client = createMockClient();
+    const { result } = renderSendPayment(client);
+    const runner = vi.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      await Promise.all([result.current.handleRun(runner), result.current.handleRun(runner)]);
+    });
+
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a retry after the first attempt settles', async () => {
+    const client = createMockClient();
+    const { result } = renderSendPayment(client);
+    const runner = vi.fn().mockRejectedValue(new Error('boom'));
+
+    await act(async () => {
+      await result.current.handleRun(runner);
+    });
+    await act(async () => {
+      await result.current.handleRun(runner);
+    });
+
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import type { PrepareSendPaymentResponse, FeePolicy, SendPaymentOptions, SdkEvent, ConversionOptions } from '@breeztech/breez-sdk-spark';
 import type { SendInput } from '@/types/domain';
 import { useWallet, useWalletInfo } from '../../../contexts/WalletContext';
@@ -64,6 +64,11 @@ export function useSendPayment(): UseSendPaymentReturn {
   const [amountFixed, setAmountFixed] = useState(false);
   const [tokenIdentifier, setTokenIdentifier] = useState<string | null>(null);
   const [conversionOptions, setConversionOptions] = useState<ConversionOptions | null>(null);
+
+  // Every send workflow funnels through handleSend/handleRun, so one latch here
+  // covers all of them. It has to be a ref: `isLoading` only settles on the next
+  // render, which is too late to keep a repeat call out.
+  const inFlightRef = useRef(false);
 
   // Balance is read live from the wallet info context, which is auto-refreshed
   // by useBreezSdk on `synced`/`paymentSucceeded`/`claimedDeposits` events. We
@@ -250,7 +255,8 @@ export function useSendPayment(): UseSendPaymentReturn {
   }, [paymentInput?.paymentRequest, parsedInputType, prepareSend]);
 
   const handleSend = useCallback(async (options?: SendPaymentOptions) => {
-    if (!prepareResponse) return;
+    if (!prepareResponse || inFlightRef.current) return;
+    inFlightRef.current = true;
     const hasConversion = !!prepareResponse.conversionEstimate;
     logger.info(LogCategory.PAYMENT, 'handleSend called', {
       hasConversion,
@@ -294,6 +300,7 @@ export function useSendPayment(): UseSendPaymentReturn {
       setError(`Payment failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
       setPaymentResult('failure');
     } finally {
+      inFlightRef.current = false;
       if (listenerId) {
         wallet.removeEventListener(listenerId).catch(() => {});
       }
@@ -304,6 +311,8 @@ export function useSendPayment(): UseSendPaymentReturn {
   }, [wallet, prepareResponse]);
 
   const handleRun = useCallback(async (runner: () => Promise<void>, hasConversion?: boolean) => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
     setProcessingPhase(hasConversion ? 'converting' : 'sending');
     setCurrentStep('processing');
     setIsLoading(true);
@@ -342,6 +351,7 @@ export function useSendPayment(): UseSendPaymentReturn {
       setError(`Operation failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
       setPaymentResult('failure');
     } finally {
+      inFlightRef.current = false;
       if (listenerId) {
         wallet.removeEventListener(listenerId).catch(() => {});
       }
@@ -352,6 +362,7 @@ export function useSendPayment(): UseSendPaymentReturn {
   }, [wallet]);
 
   const reset = useCallback(() => {
+    inFlightRef.current = false;
     setCurrentStep('input');
     setAmount('');
     setPrepareResponse(null);

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type {
   ConversionOptions,
   CrossChainAddressDetails,
@@ -92,6 +92,10 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
   // Chain card expand/copy state
   const [expandedChain, setExpandedChain] = useState<string | null>(null);
   const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
+  // The ref is the actual guard; `isSending` only drives the button, and state
+  // does not reach it until the next render.
+  const [isSending, setIsSending] = useState(false);
+  const sendingRef = useRef(false);
 
   // Stable balance detection
   const useUsdb = stableBalance.isActive && !!stableBalance.tokenIdentifier && stableBalance.btcFiatRate > 0 && !!stableBalance.displayConfig;
@@ -312,10 +316,15 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
   };
 
   const handleSend = () => {
-    if (!prepareResponse) return;
+    if (!prepareResponse || sendingRef.current) return;
+    sendingRef.current = true;
+    setIsSending(true);
     const response = prepareResponse;
     onRun(async () => {
       await wallet.sendPayment({ prepareResponse: response });
+    }).finally(() => {
+      sendingRef.current = false;
+      setIsSending(false);
     });
   };
 
@@ -629,7 +638,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
             <SecondaryButton onClick={goBackFromConfirm} className="flex-1">
               Back
             </SecondaryButton>
-            <PrimaryButton onClick={handleSend} className="flex-1" disabled={false}>
+            <PrimaryButton onClick={handleSend} className="flex-1" disabled={isSending}>
               Send
             </PrimaryButton>
           </div>

--- a/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import type { LnurlWithdrawRequestDetails, LnurlWithdrawResponse } from '@breeztech/breez-sdk-spark';
 import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
 import { logger, LogCategory } from '../../../services/logger';
@@ -38,6 +38,9 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
   const [amount, setAmount] = useState<string>(String(maxSats));
   const [error, setError] = useState<string | null>(null);
   const [isWaiting, setIsWaiting] = useState(false);
+  // Calls the SDK directly rather than through the send hook, so it needs its own
+  // latch: `isWaiting` swaps in the spinner only on the next render.
+  const withdrawingRef = useRef(false);
 
   const description = parsed.defaultDescription?.trim();
   const sourceHost = useMemo(() => {
@@ -69,6 +72,8 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
   // otherwise. The SDK waits up to completionTimeoutSecs for settlement, so the
   // await resolves with the outcome and the spinner can't hang.
   const onReceive = async () => {
+    if (withdrawingRef.current) return;
+    withdrawingRef.current = true;
     const sats = isFixed ? maxSats : amountNum;
     setError(null);
     setIsWaiting(true);
@@ -85,6 +90,8 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
       logger.error(LogCategory.PAYMENT, 'LNURL withdraw failed', { error: formatError(err) });
       setError(`Withdraw failed: ${formatError(err)}`);
       setIsWaiting(false);
+    } finally {
+      withdrawingRef.current = false;
     }
   };
 


### PR DESCRIPTION
On a slow device, tapping Send more than once could start the action more than once. Each send screen now ignores the extra taps while the first one is still running.

The cross-chain Send button also stayed active during a send. It now greys out until the attempt finishes.

If an attempt fails, the button works again, so a retry still goes through.

Covers every send screen, plus the LNURL withdraw screen.

Adds a test that fails if the behaviour comes back.