### PR TITLE
Remove the decorative icons from the wallet and backup screens

### DIFF
--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -3,7 +3,7 @@ import { Payment } from '@breeztech/breez-sdk-spark';
 import type { ExtendedPayment } from '../utils/depositHelpers';
 import { formatWithSpaces } from '../utils/formatNumber';
 import { SatAmount } from './SatAmount';
-import { ArrowDownIcon, ArrowUpIcon, LightningBoltIcon, WalletIcon } from './Icons';
+import { ArrowDownIcon, ArrowUpIcon, LightningBoltIcon } from './Icons';
 import { useStableBalance } from '../contexts/StableBalanceContext';
 import { useFiatData } from '../contexts/FiatDataContext';
 import { useContactsContext } from '../contexts/ContactsContext';
@@ -16,8 +16,6 @@ const ReceiveIcon = <ArrowDownIcon size="sm" />;
 const SendIcon = <ArrowUpIcon size="sm" />;
 
 const LightningIcon = <LightningBoltIcon size="xs" />;
-
-const EmptyStateIcon = <WalletIcon className="w-10 h-10 text-spark-text-muted" />;
 
 // Hoisted helper functions (rendering-hoist-jsx optimization)
 const formatTimeAgo = (timestamp: number): string => {
@@ -106,9 +104,6 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onPayme
     }
     return (
       <div className="flex flex-col items-center justify-center py-20 px-6" data-testid="empty-state">
-        <div className="w-20 h-20 rounded-2xl bg-spark-surface border border-spark-border flex items-center justify-center mb-6">
-          {EmptyStateIcon}
-        </div>
         <h3 className="text-lg font-semibold text-spark-text-primary mb-2">No payments yet</h3>
         <p className="text-spark-text-muted text-sm text-center max-w-xs">
           Your payment history will appear here once you send or receive your first payment.

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { WarningIcon, SpinnerIcon, EyeIcon, FaceIdIcon, FingerprintIcon, PasskeyIcon } from '../components/Icons';
+import { WarningIcon, PasskeyIcon } from '../components/Icons';
 import SlideInPage from '../components/layout/SlideInPage';
 import { PinGate } from '../components/PinEntry';
 import { LoadingSpinner } from '../components/ui';
@@ -274,13 +274,6 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
             >
-              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-                {isLoading ? (
-                  <SpinnerIcon size="xl" className="text-spark-primary" />
-                ) : (
-                  <EyeIcon size="xl" className="text-spark-primary" />
-                )}
-              </div>
               <span className="font-display font-semibold text-spark-text-primary">
                 {isLoading ? 'Authenticating...' : 'Tap to reveal phrase'}
               </span>
@@ -303,17 +296,6 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
             >
-              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-                {isLoading ? (
-                  <SpinnerIcon size="xl" className="text-spark-primary" />
-                ) : mnemonic ? (
-                  <EyeIcon size="xl" className="text-spark-primary" />
-                ) : biometry?.kind === 'face' ? (
-                  <FaceIdIcon size="xl" className="text-spark-primary" />
-                ) : (
-                  <FingerprintIcon size="xl" className="text-spark-primary" />
-                )}
-              </div>
               <span className="font-display font-semibold text-spark-text-primary">
                 {isLoading ? 'Authenticating...' : 'Tap to reveal phrase'}
               </span>
@@ -350,15 +332,6 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
             >
-              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-                {isLoading ? (
-                  <SpinnerIcon size="xl" className="text-spark-primary" />
-                ) : biometry?.kind === 'face' && fallbackTier === 'biometric' ? (
-                  <FaceIdIcon size="xl" className="text-spark-primary" />
-                ) : (
-                  <FingerprintIcon size="xl" className="text-spark-primary" />
-                )}
-              </div>
               <span className="font-display font-semibold text-spark-text-primary">
                 {isLoading ? 'Authenticating...' : 'Tap to reveal phrase'}
               </span>

--- a/src/pages/GeneratePage.tsx
+++ b/src/pages/GeneratePage.tsx
@@ -4,7 +4,7 @@ import { PrimaryButton } from '../components/ui';
 import LoadingSpinner from '../components/LoadingSpinner';
 import PageLayout from '../components/layout/PageLayout';
 import { AlertCard } from '../components/AlertCard';
-import { CheckIcon, CopyIcon, KeyIcon } from '../components/Icons';
+import { CheckIcon, CopyIcon } from '../components/Icons';
 import { logger, LogCategory } from '@/services/logger';
 import { copyToClipboard } from '@/utils/clipboard';
 
@@ -81,13 +81,6 @@ const GeneratePage: React.FC<GeneratePageProps> = ({
   return (
     <PageLayout onBack={onBack} footer={footer} title="Get Started" onClearError={onClearError}>
       <div className="max-w-xl mx-auto w-full space-y-4">
-        {/* Icon */}
-        <div className="flex justify-center mb-4">
-          <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-            <KeyIcon size="xl" className="text-spark-primary" />
-          </div>
-        </div>
-
         <p className="text-spark-text-secondary text-center mb-6">
           Write down these words in order. This is your only backup to recover your funds.
         </p>

--- a/src/pages/RestorePage.tsx
+++ b/src/pages/RestorePage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PageLayout from '../components/layout/PageLayout';
 import { PrimaryButton } from '../components/ui';
 import { SimpleAlert } from '../components/AlertCard';
-import { UploadIcon } from '../components/Icons';
 import { useScreenCaptureProtection } from '@/utils/screenSecurity';
 
 interface RestorePageProps {
@@ -61,13 +60,6 @@ const RestorePage: React.FC<RestorePageProps> = ({
   return (
     <PageLayout footer={footer} onBack={onBack} title="Restore from Backup" onClearError={onClearError}>
        <div className="max-w-xl mx-auto w-full space-y-4">
-        {/* Icon */}
-        <div className="flex justify-center mb-6">
-          <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-            <UploadIcon size="xl" className="text-spark-primary" />
-          </div>
-        </div>
-
         <p className="text-spark-text-secondary text-center mb-6">
           Enter your 12 or 24-word recovery phrase to restore Glow. Words should be separated by spaces.
         </p>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import SlideInPage from '../components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs, exportDatabaseState } from '@/services/logExport';
 import { useSecretTap } from '@/hooks/useSecretTap';
+import { isPasskeyMode } from '@/services/passkeyService';
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -255,8 +256,9 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
             </div>
           </div>
 
-          {/* Passkey & Labels */}
-          {isDevMode && (
+          {/* Passkey & Labels. Every page in the hub acts on the active
+              passkey, so a mnemonic-only wallet has nothing to open. */}
+          {isDevMode && isPasskeyMode() && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
               <h3 className="font-display font-semibold text-spark-text-primary mb-3">Passkey</h3>
               <button


### PR DESCRIPTION
Some screens showed a large icon in a colored box above their text. The icon repeated what the heading and the text below it already said.

The icons are gone from the empty payment list, from Get Started, from Restore from Backup, and from the three "Tap to reveal phrase" buttons in Backup. Those buttons also no longer show a spinner while they authenticate. The button text changes to "Authenticating..." instead.

Settings no longer shows the `Passkey & Labels` entry for a wallet that uses a recovery phrase.
