### PR TITLE
feat: deep link payment URIs into the send sheet

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -49,6 +49,12 @@
       "purpose": "any"
     }
   ],
+  "protocol_handlers": [
+    {
+      "protocol": "bitcoin",
+      "url": "/?pay=%s"
+    }
+  ],
   "shortcuts": [],
   "related_applications": [],
   "prefer_related_applications": false

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import './index.css';
 import { logger, LogCategory } from '@/services/logger';
 import { initWebViewportManager } from '@/utils/webViewportManager';
 import { installUserAgentStrippingFetch } from '@/utils/stripUserAgentFetch';
+import { startDeepLinks } from '@/utils/deepLink';
 import { logStartupDeviceInfo } from '@/utils/deviceInfo';
 import { startSdkInit } from '@/services/sdkReady';
 import { prfAvailability } from '@/services/passkeyService';
@@ -26,6 +27,12 @@ installUserAgentStrippingFetch();
 (BigInt.prototype as unknown as { toJSON: () => string }).toJSON = function () {
   return this.toString();
 };
+
+// Start listening for payment deep links (lightning:, bitcoin:, lnurlp:,
+// lnurlw:, keyauth:, glow:) before anything renders, so a link that
+// cold-started the app is buffered by the time there is a screen to open it on.
+// Self-guarding: no-op on web.
+startDeepLinks();
 
 // Pin the system bars to the Glow "surface" tone on native builds so they
 // blend with the app bar glassmorphism. setStyle controls icon brightness;

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { useWallet } from '../contexts/WalletContext';
 import { useToast } from '../contexts/ToastContext';
 import { logger, LogCategory } from '@/services/logger';
@@ -20,6 +20,7 @@ import BuyBitcoinDialog from '../features/buy/BuyBitcoinDialog';
 import { getBuyProviderSettings, filterProvidersByNetwork, isBuyBitcoinAvailable } from '../services/settings';
 import { useStatusBarColor } from '../hooks/useStatusBarColor';
 import { STATUS_BAR_WALLET_GLASS } from '../utils/statusBarManager';
+import { onDeepLink } from '../utils/deepLink';
 
 interface WalletPageProps {
   walletInfo: GetInfoResponse | null;
@@ -189,6 +190,16 @@ const WalletPage: React.FC<WalletPageProps> = ({
     setScannerOpenedFromSend(true);
     setIsQrScannerOpen(true);
   }, []);
+
+  // A tapped lightning: / bitcoin: / lnurlp: / lnurlw: / keyauth: / glow: link
+  // opens the send sheet on it. Unlike the QR path there is no pre-parse: the OS just
+  // switched the user into Glow, so an unreadable link has to say so on screen
+  // rather than land on the home page having apparently done nothing. The
+  // sheet parses `initialRawInput` itself and surfaces its own error.
+  useEffect(() => onDeepLink((input) => {
+    setPaymentInput(input);
+    openSendDialog();
+  }), [openSendDialog]);
 
   const handleQrScan = async (data: string | null) => {
     if (!data) return;

--- a/src/utils/deepLink.test.ts
+++ b/src/utils/deepLink.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { toPaymentInput } from './deepLink';
 
 const BOLT11 = 'lnbc1u1p3xyzqwpp5abcdefg';
@@ -37,5 +37,48 @@ describe('toPaymentInput', () => {
 
   it('passes through bare input and trims surrounding whitespace', () => {
     expect(toPaymentInput(`  ${BOLT11}\n`)).toBe(BOLT11);
+  });
+});
+
+/**
+ * An installed PWA handles `bitcoin:` by being launched at `/?pay=<uri>`
+ * (see `protocol_handlers` in public/manifest.json). The module is re-imported
+ * per case because it starts at most once per page load.
+ */
+describe('protocol handler launch', () => {
+  const startAt = async (url: string) => {
+    window.history.replaceState(null, '', url);
+    vi.resetModules();
+    const mod = await import('./deepLink');
+    mod.startDeepLinks();
+    return mod;
+  };
+
+  afterEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('opens on the launched payment and scrubs it from the address bar', async () => {
+    const { onDeepLink } = await startAt(`/?pay=${encodeURIComponent(`bitcoin:${ADDRESS}`)}`);
+
+    const seen: string[] = [];
+    onDeepLink((input) => seen.push(input));
+
+    expect(seen).toEqual([`bitcoin:${ADDRESS}`]);
+    expect(window.location.search).toBe('');
+  });
+
+  it('leaves unrelated query parameters alone', async () => {
+    await startAt(`/?utm=x&pay=${encodeURIComponent(`bitcoin:${ADDRESS}`)}`);
+    expect(window.location.search).toBe('?utm=x');
+  });
+
+  it('does nothing on an ordinary launch', async () => {
+    const { onDeepLink } = await startAt('/');
+
+    const seen: string[] = [];
+    onDeepLink((input) => seen.push(input));
+
+    expect(seen).toEqual([]);
   });
 });

--- a/src/utils/deepLink.test.ts
+++ b/src/utils/deepLink.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { toPaymentInput } from './deepLink';
+
+const BOLT11 = 'lnbc1u1p3xyzqwpp5abcdefg';
+const ADDRESS = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+describe('toPaymentInput', () => {
+  it('hands lightning: and bitcoin: links to the parser with the scheme intact', () => {
+    expect(toPaymentInput(`lightning:${BOLT11}`)).toBe(`lightning:${BOLT11}`);
+    expect(toPaymentInput(`bitcoin:${ADDRESS}?amount=0.001`)).toBe(`bitcoin:${ADDRESS}?amount=0.001`);
+  });
+
+  it('collapses the :// authority form the parser cannot strip', () => {
+    expect(toPaymentInput(`lightning://${BOLT11}`)).toBe(`lightning:${BOLT11}`);
+    expect(toPaymentInput(`LIGHTNING://${BOLT11}`)).toBe(`lightning:${BOLT11}`);
+    expect(toPaymentInput(`bitcoin://${ADDRESS}`)).toBe(`bitcoin:${ADDRESS}`);
+  });
+
+  it('leaves the LUD-17 schemes alone, since the parser takes both forms', () => {
+    expect(toPaymentInput('lnurlp://domain.com/pay?s=1')).toBe('lnurlp://domain.com/pay?s=1');
+    expect(toPaymentInput('lnurlw:domain.com/withdraw')).toBe('lnurlw:domain.com/withdraw');
+    expect(toPaymentInput('keyauth://domain.com/auth?k1=ab')).toBe('keyauth://domain.com/auth?k1=ab');
+  });
+
+  it('strips our own glow: scheme, which means nothing to the parser', () => {
+    expect(toPaymentInput(`glow:${BOLT11}`)).toBe(BOLT11);
+    expect(toPaymentInput(`glow://${BOLT11}`)).toBe(BOLT11);
+    expect(toPaymentInput(`GLOW://${BOLT11}`)).toBe(BOLT11);
+    expect(toPaymentInput('glow://user@domain.com')).toBe('user@domain.com');
+  });
+
+  it('returns null when there is no payload to act on', () => {
+    expect(toPaymentInput('glow:')).toBeNull();
+    expect(toPaymentInput('glow://')).toBeNull();
+    expect(toPaymentInput('   ')).toBeNull();
+  });
+
+  it('passes through bare input and trims surrounding whitespace', () => {
+    expect(toPaymentInput(`  ${BOLT11}\n`)).toBe(BOLT11);
+  });
+});

--- a/src/utils/deepLink.ts
+++ b/src/utils/deepLink.ts
@@ -1,0 +1,96 @@
+import { Capacitor } from '@capacitor/core';
+import { App } from '@capacitor/app';
+import { logger, LogCategory } from '@/services/logger';
+
+/**
+ * Payment deep links on native builds.
+ *
+ * The shell registers `lightning`, `bitcoin`, `lnurlp`, `lnurlw`, `keyauth`
+ * and `glow` (glow-app: `ios/App/App/Info.plist` +
+ * `android/app/src/main/AndroidManifest.xml`).
+ * Whatever the OS hands over lands here, gets normalised into something the
+ * SDK parser accepts, and is delivered to whoever is listening (in practice
+ * WalletPage, which opens the send sheet with it).
+ *
+ * No-op on web: `Capacitor.isNativePlatform()` is false and nothing is wired.
+ */
+
+type DeepLinkListener = (paymentInput: string) => void;
+
+/**
+ * Normalise an incoming deep link into an SDK-parseable payment input, or
+ * null if there is no payload to act on.
+ *
+ * Only two rewrites are needed, both because of what the SDK parser does
+ * and does not strip itself (spark-sdk `common/src/input/parser/mod.rs`):
+ *
+ *  - `glow:` is our own scheme and means nothing to the parser, so it comes
+ *    off entirely and the remainder is parsed on its own.
+ *  - The parser matches a literal `lightning:` / `bitcoin:` and nothing more,
+ *    so a `lightning://` link would reach it as `//lnbc1...` and fail.
+ *    Vendors do emit the authority form, so it is collapsed here.
+ *
+ * `lnurlp` / `lnurlw` / `keyauth` are deliberately left alone: the parser
+ * already accepts both `scheme:` and `scheme://` for those three.
+ */
+export function toPaymentInput(url: string): string | null {
+  const payload = url
+    .trim()
+    .replace(/^glow:(\/\/)?/i, '')
+    .replace(/^lightning:\/\//i, 'lightning:')
+    .replace(/^bitcoin:\/\//i, 'bitcoin:');
+  return payload.length > 0 ? payload : null;
+}
+
+let pending: string | null = null;
+let listener: DeepLinkListener | null = null;
+let started = false;
+
+function deliver(url: string): void {
+  const paymentInput = toPaymentInput(url);
+  if (!paymentInput) return;
+  // A cold start can surface the same launch URL through both the listener
+  // and getLaunchUrl below. Dropping a duplicate of what is already waiting
+  // covers that without timers.
+  // ponytail: single listener slot, WalletPage is the only consumer. Make it
+  // a stack like backButton.ts if a second screen ever needs deep links.
+  if (paymentInput === pending) return;
+  logger.debug(LogCategory.UI, 'Deep link received');
+  if (listener) listener(paymentInput);
+  else pending = paymentInput;
+}
+
+/** Start listening for deep links. Safe to call more than once. */
+export function startDeepLinks(): void {
+  if (started || !Capacitor.isNativePlatform()) return;
+  started = true;
+
+  void App.addListener('appUrlOpen', ({ url }) => deliver(url));
+
+  // The launch intent is consumed before any listener can attach, so a cold
+  // start from a deep link never fires `appUrlOpen` for it on Android.
+  void App.getLaunchUrl()
+    .then((result) => {
+      if (result?.url) deliver(result.url);
+    })
+    .catch(() => {
+      /* no launch URL, or web: nothing to replay */
+    });
+}
+
+/**
+ * Subscribe to deep links. A link that arrived before the subscriber existed
+ * (the cold-start case: the OS opens Glow, the SDK connects, and only then is
+ * there a screen to show it on) is replayed immediately. Returns a disposer.
+ */
+export function onDeepLink(fn: DeepLinkListener): () => void {
+  listener = fn;
+  if (pending !== null) {
+    const replayed = pending;
+    pending = null;
+    fn(replayed);
+  }
+  return () => {
+    if (listener === fn) listener = null;
+  };
+}

--- a/src/utils/deepLink.ts
+++ b/src/utils/deepLink.ts
@@ -12,7 +12,10 @@ import { logger, LogCategory } from '@/services/logger';
  * SDK parser accepts, and is delivered to whoever is listening (in practice
  * WalletPage, which opens the send sheet with it).
  *
- * No-op on web: `Capacitor.isNativePlatform()` is false and nothing is wired.
+ * An installed PWA gets a narrower version of the same thing through the
+ * manifest's `protocol_handlers`, which is limited to `bitcoin:` by the
+ * safelist. See `consumeProtocolHandlerLaunch` below. In a plain browser tab
+ * nothing is wired at all.
  */
 
 type DeepLinkListener = (paymentInput: string) => void;
@@ -60,10 +63,45 @@ function deliver(url: string): void {
   else pending = paymentInput;
 }
 
+/**
+ * The query parameter an installed PWA is launched with when it handles a
+ * registered protocol, per the `protocol_handlers` entry in manifest.json.
+ */
+const PROTOCOL_HANDLER_PARAM = 'pay';
+
+/**
+ * An installed PWA handles a protocol by being launched at a URL, not by
+ * receiving an event, so the payload arrives as a query parameter. Consume it
+ * and scrub it from the address bar, so a reload doesn't reopen the sheet on a
+ * payment the person has already dealt with.
+ *
+ * Only `bitcoin:` can reach here. The manifest may only claim schemes on the
+ * spec's safelist (which has `bitcoin` but not `lightning` or the LNURL ones)
+ * or invented `web+` ones, which nothing in the world emits.
+ */
+function consumeProtocolHandlerLaunch(): void {
+  const params = new URLSearchParams(window.location.search);
+  const launched = params.get(PROTOCOL_HANDLER_PARAM);
+  if (!launched) return;
+
+  params.delete(PROTOCOL_HANDLER_PARAM);
+  const query = params.toString();
+  window.history.replaceState(
+    null,
+    '',
+    `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`,
+  );
+  deliver(launched);
+}
+
 /** Start listening for deep links. Safe to call more than once. */
 export function startDeepLinks(): void {
-  if (started || !Capacitor.isNativePlatform()) return;
+  if (started) return;
   started = true;
+
+  consumeProtocolHandlerLaunch();
+
+  if (!Capacitor.isNativePlatform()) return;
 
   void App.addListener('appUrlOpen', ({ url }) => deliver(url));
 


### PR DESCRIPTION
Lightning and Bitcoin payment links were never associated with Glow, so phones didn't offer it as a way to open them. Now they are, and tapping one opens Glow with the send sheet already on that payment: Lightning invoices and offers, Lightning addresses, Bitcoin payment links, and LNURL pay, withdraw and auth links. A link Glow can't read says so on screen, rather than dropping you on the home screen with no explanation.

If you installed Glow from the browser instead, it now shows up as a choice for opening Bitcoin payment links. Only Bitcoin ones: browsers don't allow this for the Lightning and LNURL schemes.