### PR TITLE
feat: fall back to recovery phrase on passkey failures

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -397,7 +397,7 @@ const AppContent: React.FC = () => {
             onRequestMigrationCheck={requestMigrationCheck}
             onUseRecoveryPhrase={() => {
               setPasskeySdkConnected(false);
-              setUserScreen('restore');
+              setUserScreen('generate');
             }}
           />
         );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,6 +395,10 @@ const AppContent: React.FC = () => {
             consumeFreshInstallSignal={sdk.consumeFreshInstallSignal}
             skipDetection={passkeySkipDetection}
             onRequestMigrationCheck={requestMigrationCheck}
+            onUseRecoveryPhrase={() => {
+              setPasskeySdkConnected(false);
+              setUserScreen('restore');
+            }}
           />
         );
 

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -22,6 +22,7 @@ import {
   signInPinnedToActiveCredential,
   removeStaleCredential,
   passkeyAvailability,
+  isGrapheneOsDevice,
 } from '@/services/passkeyService';
 import {
   PasskeyAlreadyExistsError,
@@ -84,6 +85,8 @@ interface PasskeyPageProps {
    * and App took over).
    */
   onRequestMigrationCheck?: () => Promise<'proceed' | 'handled'>;
+  /** Routes to the restore flow; the primary escape on ceremony failures. */
+  onUseRecoveryPhrase: () => void;
 }
 
 // 5s under the OS's ~60s WebAuthn inactivity ceiling: anything past
@@ -103,6 +106,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
   skipDetection = false,
   consumeFreshInstallSignal,
   onRequestMigrationCheck,
+  onUseRecoveryPhrase,
 }) => {
   // Post-AASA transition branches on `skipDetection`: straight to
   // 'creating' for the Create CTA, 'detecting' for Use Passkey.
@@ -379,7 +383,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
               ? 'Sign-in timed out. Please try again.'
               : isCancelled
                 ? 'Passkey prompt cancelled. Please try again.'
-                : (friendlyPasskeyError(e) ?? 'Could not sign in with your passkey. Please try again.'),
+                : (friendlyPasskeyError(e, { isGrapheneOs: isGrapheneOsDevice() }) ?? 'Could not sign in with your passkey. Please try again.'),
           );
           setErrorKind('sign-in-failed');
         }
@@ -633,7 +637,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
               ? (isLikelyTimeout(elapsedMs)
                 ? 'Sign-in timed out. Please try again.'
                 : 'Sign-in cancelled. Please try again.')
-              : (friendlyPasskeyError(e) ?? 'Could not sign in with your passkey. Please try again.'),
+              : (friendlyPasskeyError(e, { isGrapheneOs: isGrapheneOsDevice() }) ?? 'Could not sign in with your passkey. Please try again.'),
           );
           setErrorKind('sign-in-failed');
           return;
@@ -916,7 +920,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         } else if (isCancelled) {
           setError('Sign-in cancelled. Please try again.');
         } else {
-          setError(friendlyPasskeyError(e) ?? 'Something went wrong. Please try again.');
+          setError(friendlyPasskeyError(e, { isGrapheneOs: isGrapheneOsDevice() }) ?? 'Something went wrong. Please try again.');
         }
         setErrorKind('generic');
         logger.error(LogCategory.AUTH, 'Passkey wallet restore failed', {
@@ -1197,23 +1201,25 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       );
     }
 
-    // Slow cancel on detecting: user dismissed a sheet, so they probably
-    // have a passkey and Try Again stays the primary action. Create is
-    // offered as a secondary escape (this branch only fires for a device
-    // with no passkey history), or a first-timer whose OS still put a
-    // sheet in front of them has no way forward at all.
-    // Bouncing through aasa-checking re-fires the detecting effect
-    // (which only depends on [phase]).
+    // Slow cancel on detecting: user dismissed a sheet. Recovery phrase
+    // leads, as on every ceremony-failure footer (product call: passkey
+    // issues fall back to the recovery phrase). Try Again bounces through
+    // aasa-checking to re-fire the detecting effect (which only depends
+    // on [phase]); Create covers the first-timer whose OS still put a
+    // sheet in front of them.
     if (error && phase === 'detecting' && errorKind === 'sign-in-cancelled') {
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={() => {
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+            Continue with Recovery Phrase
+          </PrimaryButton>
+          <SecondaryButton className="w-full" onClick={() => {
             setError(null);
             setErrorKind(null);
             setPhase('aasa-checking');
           }}>
             Try Again
-          </PrimaryButton>
+          </SecondaryButton>
           <SecondaryButton className="w-full" onClick={() => {
             setError(null);
             setErrorKind(null);
@@ -1258,21 +1264,25 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     }
 
     // Returning-user sign-in failures (cancel, transient
-    // CredentialNotFound, relay error). Native: retry only. Web: also
-    // offer Use Another Passkey (drops the active pin so the picker
-    // can surface siblings), with Create gated by `retryOnly`.
+    // CredentialNotFound, relay error). Recovery phrase leads; retry is
+    // secondary. Web additionally offers Use Another Passkey (drops the
+    // active pin so the picker can surface siblings), with Create gated
+    // by `retryOnly`.
     if (error && phase === 'detecting' && errorKind === 'sign-in-failed') {
       const isWeb = !Capacitor.isNativePlatform();
       const retryOnly = isWeb && immediateGetSupported !== true;
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={() => {
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+            Continue with Recovery Phrase
+          </PrimaryButton>
+          <SecondaryButton className="w-full" onClick={() => {
             setError(null);
             setErrorKind(null);
             setPhase('aasa-checking');
           }}>
             Try Again
-          </PrimaryButton>
+          </SecondaryButton>
           {isWeb && (
             <SecondaryButton className="w-full" onClick={() => {
               // Drop the active-cred pin so the next detect runs
@@ -1308,12 +1318,15 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       const retryOnly = !Capacitor.isNativePlatform() && immediateGetSupported !== true;
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={() => {
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+            Continue with Recovery Phrase
+          </PrimaryButton>
+          <SecondaryButton className="w-full" onClick={() => {
             setError(null);
             setPhase('aasa-checking');
           }}>
             Try Again
-          </PrimaryButton>
+          </SecondaryButton>
           {!retryOnly && (
             <SecondaryButton className="w-full" onClick={() => {
               setError(null);
@@ -1350,13 +1363,17 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       );
     }
 
-    // Error state on any auto-triggered phase: Retry + Back
+    // Error state on any auto-triggered phase: recovery phrase leads,
+    // Retry + Back stay as secondaries.
     if (error && ['creating', 'new-storing', 'connecting'].includes(phase)) {
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={handleRetry}>
-            Retry
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+            Continue with Recovery Phrase
           </PrimaryButton>
+          <SecondaryButton className="w-full" onClick={handleRetry}>
+            Retry
+          </SecondaryButton>
           <SecondaryButton className="w-full" onClick={handleErrorBack}>
             Go Back
           </SecondaryButton>

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -85,7 +85,11 @@ interface PasskeyPageProps {
    * and App took over).
    */
   onRequestMigrationCheck?: () => Promise<'proceed' | 'handled'>;
-  /** Routes to the restore flow; the primary escape on ceremony failures. */
+  /**
+   * Starts create-via-seed onboarding (new seed, phrase shown for
+   * backup); the primary escape on ceremony failures. Restoring an
+   * existing phrase stays reachable from the home screen.
+   */
   onUseRecoveryPhrase: () => void;
 }
 

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -155,7 +155,11 @@ interface NativePasskeyPlugin {
     breezApiKey?: string;
     defaultLabel?: string;
   }): Promise<void>;
-  checkAvailability(): Promise<PasskeyAvailability>;
+  /**
+   * `isGrapheneOs` is Android-only (the plugin flags Vanadium as the
+   * WebView provider); absent on iOS.
+   */
+  checkAvailability(): Promise<PasskeyAvailability & { isGrapheneOs?: boolean }>;
   register(opts: {
     label?: string;
     excludeCredentials?: string[];
@@ -892,6 +896,16 @@ export function prfAvailability(): Promise<boolean> {
 
 let availabilityPromise: Promise<PasskeyAvailability> | null = null;
 
+// Android-only signal from the native plugin (Vanadium as the WebView
+// provider means GrapheneOS). Read at error time for deterministic
+// passkey-failure copy; stays false until availability has resolved.
+let grapheneOs = false;
+
+/** True once availability has reported a GrapheneOS device. */
+export function isGrapheneOsDevice(): boolean {
+  return grapheneOs;
+}
+
 /**
  * Memoized `checkAvailability()`.
  *
@@ -912,6 +926,7 @@ export function passkeyAvailability(): Promise<PasskeyAvailability> {
   if (!availabilityPromise) {
     availabilityPromise = getPasskey().checkAvailability()
       .then((availability) => {
+        if ((availability as { isGrapheneOs?: boolean }).isGrapheneOs === true) grapheneOs = true;
         if (availability.type === 'notAssociated') availabilityPromise = null;
         return availability;
       })

--- a/src/utils/passkeyErrorCopy.test.ts
+++ b/src/utils/passkeyErrorCopy.test.ts
@@ -7,14 +7,31 @@ const withCode = (message: string, code: string): Error => {
   return e;
 };
 
+const GPM_LOOP =
+  'v1=breez_sdk_spark.PrfProviderException$AuthenticationFailed: v1=Google Password Manager: [15] Flow has timed out.';
+
 describe('friendlyPasskeyError', () => {
   it('maps the wrapped GPM auth-failed timeout (QA repro, code collapsed to GENERIC_ERROR)', () => {
-    const e = withCode(
-      'v1=breez_sdk_spark.PrfProviderException$AuthenticationFailed: v1=Google Password Manager: [15] Flow has timed out.',
-      'GENERIC_ERROR',
-    );
-    expect(friendlyPasskeyError(e)).toBe(
+    expect(friendlyPasskeyError(withCode(GPM_LOOP, 'GENERIC_ERROR'))).toBe(
       "Your device couldn't finish verifying your identity. Lock and unlock your device, then try again.",
+    );
+  });
+
+  it('maps the GPM loop to deterministic recovery-phrase copy on GrapheneOS', () => {
+    expect(friendlyPasskeyError(withCode(GPM_LOOP, 'GENERIC_ERROR'), { isGrapheneOs: true })).toBe(
+      "Passkeys aren't working with Google Password Manager on this device. Try again with another password provider, or continue with your recovery phrase.",
+    );
+  });
+
+  it('keeps generic copy on GrapheneOS when the provider is not Google Password Manager', () => {
+    expect(
+      friendlyPasskeyError(new Error('Bitwarden: operation timed out'), { isGrapheneOs: true }),
+    ).toBe('The passkey prompt timed out. Please try again.');
+  });
+
+  it('maps PRF_NOT_SUPPORTED with provider-switch advice', () => {
+    expect(friendlyPasskeyError(withCode('nope', 'PRF_NOT_SUPPORTED'))).toMatch(
+      /different password manager/,
     );
   });
 

--- a/src/utils/passkeyErrorCopy.ts
+++ b/src/utils/passkeyErrorCopy.ts
@@ -5,12 +5,28 @@
  * survives only inside the message. Returns null when nothing matches;
  * callers keep their own fallback copy and surface the raw text separately.
  */
-export function friendlyPasskeyError(e: unknown): string | null {
+export function friendlyPasskeyError(
+  e: unknown,
+  opts?: { isGrapheneOs?: boolean },
+): string | null {
   const code = (e as { code?: string })?.code ?? '';
   const raw = e instanceof Error ? e.message : String(e);
 
+  // GrapheneOS: sandboxed Play can't verify the screen lock, so a Google
+  // Password Manager ceremony loops on PIN prompts and dies as
+  // AuthenticationFailed / "[15] Flow has timed out". Deterministic there,
+  // so retrying with the same provider can't help; the copy stays
+  // OS-agnostic and steers to another provider or the recovery phrase.
+  if (
+    opts?.isGrapheneOs
+    && /google password manager/i.test(raw)
+    && (/authentication[ _]?failed/i.test(raw) || /timed? ?out/i.test(raw))
+  ) {
+    return "Passkeys aren't working with Google Password Manager on this device. Try again with another password provider, or continue with your recovery phrase.";
+  }
+
   if (code === 'PRF_NOT_SUPPORTED' || /PrfNotSupported/.test(raw)) {
-    return "This device or password manager doesn't support the security feature Glow passkeys need.";
+    return "This device or password manager doesn't support the security feature Glow passkeys need. Try a different password manager, or continue with your recovery phrase.";
   }
   // Covers Google Password Manager's device-unlock loop ending in
   // "[15] Flow has timed out"; lock-and-unlock mirrors Android's own


### PR DESCRIPTION
Whenever a passkey attempt fails, the primary button is now "Continue with Recovery Phrase". Retrying stays available as a secondary option, and the failure messages now suggest a different password manager or the recovery phrase instead of a retry that can't succeed.
