### PR TITLE
chore: simplify the legacy storage tier

### DIFF
--- a/src/services/secureStorage.test.ts
+++ b/src/services/secureStorage.test.ts
@@ -13,6 +13,7 @@ import { Preferences } from '@capacitor/preferences';
 import { wipeAllLocalData } from './accountDeletion';
 
 const INSTALL_MARKER_KEY = 'glow.secureStorageInitialized';
+const F3_MIGRATION_MARKER_KEY = 'glow.secureStorageF3Migrated';
 
 vi.mock('@capacitor/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@capacitor/core')>();
@@ -39,8 +40,10 @@ const vault: { deviceOnly: string | null; bound: string | null } = {
       storeSeedDeviceOnly: async ({ seed }: { seed: string }) => { vault.deviceOnly = seed; },
       retrieveSeedDeviceOnly: async () => ({ seed: vault.deviceOnly! }),
       clearSeedDeviceOnly: async () => { vault.deviceOnly = null; },
+      // Retired bound tier: no `storeSeed`, matching the real plugin.
+      // A legacy entry only ever comes from an old build, so a test that
+      // needs one assigns `vault.bound` directly.
       hasStoredSeed: async () => ({ stored: vault.bound !== null }),
-      storeSeed: async ({ seed }: { seed: string }) => { vault.bound = seed; },
       retrieveSeed: async () => ({ seed: vault.bound! }),
       clearSeed: async () => { vault.bound = null; },
     },
@@ -109,5 +112,58 @@ describe('secure storage install marker', () => {
     // The account must survive the next launch.
     const relaunch = await coldStart();
     expect(await relaunch.deviceOnlyStorage.hasStoredSeed()).toBe(true);
+  });
+});
+
+/**
+ * The bound tier is read-only, and moving its entry into device-only
+ * storage is the only way a pre-app-lock install reaches its seed.
+ */
+describe('retired biometric-bound tier', () => {
+  beforeEach(async () => {
+    vault.deviceOnly = null;
+    vault.bound = null;
+    localStorage.clear();
+    await Preferences.clear();
+  });
+
+  /**
+   * What an old build left behind: a blob in the bound slot plus both
+   * markers. With only one, the F3 migration pass clears the slot on
+   * the next launch, which is correct but not the case under test.
+   */
+  async function plantLegacyInstall() {
+    vault.bound = JSON.stringify({
+      version: 1,
+      seed: { type: 'mnemonic', mnemonic: SEED.mnemonic },
+      createdAt: new Date().toISOString(),
+    });
+    const now = new Date().toISOString();
+    await Preferences.set({ key: INSTALL_MARKER_KEY, value: now });
+    await Preferences.set({ key: F3_MIGRATION_MARKER_KEY, value: now });
+  }
+
+  it('still drains a legacy seed and can then wipe it', async () => {
+    await plantLegacyInstall();
+
+    const { secureStorage, deviceOnlyStorage } = await coldStart();
+    expect(await secureStorage.hasStoredSeed()).toBe(true);
+    expect(await secureStorage.retrieveSeed()).toEqual(SEED);
+
+    // The drain: forward into device-only, then retire the old slot.
+    await deviceOnlyStorage.storeSeed(SEED);
+    await secureStorage.clearSeed();
+
+    expect(vault.bound).toBeNull();
+    expect(await secureStorage.hasStoredSeed()).toBe(false);
+    expect(await deviceOnlyStorage.hasStoredSeed()).toBe(true);
+  });
+
+  it('exposes no way to write the tier back', async () => {
+    const { secureStorage } = await coldStart();
+    // Compile-time guaranteed by DrainOnlySecureStorage; asserted at
+    // runtime too, because the type would not catch a stray re-add on
+    // the class itself.
+    expect('storeSeed' in secureStorage).toBe(false);
   });
 });

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -58,8 +58,8 @@ interface NativeVaultPlugin {
   authenticate(options?: { reason?: string }): Promise<void>;
   /** Biometrics-or-passcode prompt (iOS); clears biometry lockout. */
   authenticateDeviceOwner(options?: { reason?: string }): Promise<void>;
+  // Retired biometric-bound tier: read and clear only.
   hasStoredSeed(): Promise<{ stored: boolean }>;
-  storeSeed(options: { seed: string }): Promise<void>;
   retrieveSeed(): Promise<{ seed: string }>;
   clearSeed(): Promise<void>;
   // Device-only tier (encrypted at rest, no biometric gate).
@@ -306,6 +306,14 @@ export interface SecureStorage {
    */
   clearSeed(): Promise<void>;
 }
+
+/**
+ * The retired biometric-bound tier: readable and clearable, never
+ * written. Legacy installs still have an entry here, which is moved
+ * into device-only storage on first unlock. The native plugin has no
+ * write path for it either.
+ */
+export type DrainOnlySecureStorage = Omit<SecureStorage, 'storeSeed'>;
 
 // ============================================
 // Error mapping + utilities
@@ -563,7 +571,7 @@ async function cleanupStaleEntriesOnFreshInstall(): Promise<void> {
  * which causes the wallet startup code in `useBreezSdk` to fall
  * through to the passkey onboarding flow. After the user completes
  * the passkey ceremony (a single extra tap), the seed is re-persisted
- * via `storeSeed`, which now uses the F3 access control.
+ * into the device-only tier.
  *
  * We considered a read-then-rewrite approach (decrypt with F2,
  * re-encrypt with F3) but rejected it because:
@@ -591,7 +599,7 @@ async function migrateToF3IfNeeded(): Promise<void> {
   }
 }
 
-class NativeSecureStorage implements SecureStorage {
+class NativeSecureStorage implements DrainOnlySecureStorage {
   /**
    * Single in-flight `retrieveSeed` promise so concurrent callers share the
    * same biometric prompt instead of stacking two prompts on top of each
@@ -617,28 +625,6 @@ class NativeSecureStorage implements SecureStorage {
     }
   }
 
-  async storeSeed(seed: Seed): Promise<void> {
-    await ensureSharedInitialized();
-    const blob: PersistedSeedBlob = {
-      version: 1,
-      seed: serializeSeedForStorage(seed),
-      createdAt: new Date().toISOString(),
-    };
-    try {
-      // The plugin treats the seed parameter as opaque bytes, so we
-      // JSON-encode the blob on this side and JSON-decode in retrieveSeed.
-      // Storage policy (Keychain accessibility, Keystore key params) is
-      // owned by the plugin's native side.
-      await getNativeVault().storeSeed({ seed: JSON.stringify(blob) });
-      await markVaultInitialized();
-      logSecureStorageSuccess('storeSeed');
-    } catch (err) {
-      const code = mapNativeVaultErrorCode(err);
-      logSecureStorageFailure('storeSeed', code);
-      throw new SecureStorageError(code, getErrorMessage(err) ?? 'Failed to persist seed.');
-    }
-  }
-
   async retrieveSeed(): Promise<Seed> {
     await ensureSharedInitialized();
     // De-duplicate concurrent callers so we only show one biometric prompt.
@@ -653,8 +639,8 @@ class NativeSecureStorage implements SecureStorage {
 
   private async doRetrieve(): Promise<Seed> {
     // The plugin handles both the biometric prompt and the Keychain /
-    // Keystore read. On success it returns the opaque string we passed
-    // to storeSeed; on failure it rejects with one of our typed
+    // Keystore read. On success it returns the opaque string an earlier
+    // build persisted; on failure it rejects with one of our typed
     // SecureStorageErrorCode strings.
     let result: { seed: string };
     try {
@@ -918,7 +904,7 @@ export async function recoverBiometryWithPasscode(reason: string): Promise<void>
 // Factory + singleton
 // ============================================
 
-function createSecureStorage(): SecureStorage {
+function createSecureStorage(): DrainOnlySecureStorage {
   return Capacitor.isNativePlatform() ? new NativeSecureStorage() : new NoopSecureStorage();
 }
 
@@ -929,8 +915,8 @@ function createDeviceOnlyStorage(): SecureStorage {
 /**
  * Module-level singletons.
  *
- * `secureStorage`: biometric-bound tier (legacy installs only; migrated
- * to device-only at first unlock).
+ * `secureStorage`: retired biometric-bound tier, read-only (legacy
+ * installs only; moved into device-only at first unlock).
  * `deviceOnlyStorage`: encrypted at rest, no biometric gate (the default).
  *
  * Both resolve to `NoopSecureStorage` on non-native hosts.
@@ -938,7 +924,7 @@ function createDeviceOnlyStorage(): SecureStorage {
  * Import as:
  *   `import { secureStorage, deviceOnlyStorage } from '@/services/secureStorage';`
  */
-export const secureStorage: SecureStorage = createSecureStorage();
+export const secureStorage: DrainOnlySecureStorage = createSecureStorage();
 export const deviceOnlyStorage: SecureStorage = createDeviceOnlyStorage();
 
 // ============================================


### PR DESCRIPTION
The older of the two on-device storage paths hasn't been written to since app lock shipped. Everything goes through the current one now.

Removes the leftover write side and narrows the type so it can't quietly come back. Adds coverage for the one thing that path still does: handing an existing entry over to current storage on first launch, then clearing itself.

No behaviour change, nothing for existing users to notice.