### PR TITLE
ci: add code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# Code scanning for the TypeScript sources.
+#
+# No build step and no dependency install: CodeQL analyses JavaScript
+# and TypeScript straight from source, which keeps this cheap enough to
+# run alongside the existing checks.
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+  schedule:
+    # Weekly, off the hour to dodge the scheduler stampede.
+    - cron: '31 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
Adds CodeQL analysis of the TypeScript sources.

No build or dependency install is needed, so it runs alongside the existing checks rather than adding a slow step.

Nothing here changes the app. Results appear under the repo's Security tab.