### PR TITLE
fix: the recovery phrase button no longer starts a new wallet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,9 +395,9 @@ const AppContent: React.FC = () => {
             consumeFreshInstallSignal={sdk.consumeFreshInstallSignal}
             skipDetection={passkeySkipDetection}
             onRequestMigrationCheck={requestMigrationCheck}
-            onUseRecoveryPhrase={() => {
+            onUseRecoveryPhrase={(mode) => {
               setPasskeySdkConnected(false);
-              setUserScreen('generate');
+              setUserScreen(mode === 'restore' ? 'restore' : 'generate');
             }}
           />
         );

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -86,11 +86,12 @@ interface PasskeyPageProps {
    */
   onRequestMigrationCheck?: () => Promise<'proceed' | 'handled'>;
   /**
-   * Starts create-via-seed onboarding (new seed, phrase shown for
-   * backup); the primary escape on ceremony failures. Restoring an
-   * existing phrase stays reachable from the home screen.
+   * Leaves the passkey flow for a seed phrase; the primary escape on
+   * ceremony failures. `'restore'` opens phrase entry for a returning
+   * user, whose passkey wallet has a phrase revealable from Settings ->
+   * Backup. `'create'` starts seed onboarding for a first-timer.
    */
-  onUseRecoveryPhrase: () => void;
+  onUseRecoveryPhrase: (mode: 'restore' | 'create') => void;
 }
 
 // 5s under the OS's ~60s WebAuthn inactivity ceiling: anything past
@@ -939,6 +940,11 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     return () => { cancelled = true; };
   }, [phase, error, onWalletReadyRef]);
 
+  // A returning user is signing in to a wallet that already exists, so
+  // sending them to seed onboarding would hand them a fresh empty
+  // wallet and look like their funds are gone.
+  const handleUseRecoveryPhrase = () => onUseRecoveryPhrase(isNewUser ? 'create' : 'restore');
+
   /** Clear error to re-trigger the current phase's effect. */
   const handleRetry = () => {
     setError(null);
@@ -1214,7 +1220,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     if (error && phase === 'detecting' && errorKind === 'sign-in-cancelled') {
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={() => {
@@ -1277,7 +1283,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       const retryOnly = isWeb && immediateGetSupported !== true;
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={() => {
@@ -1322,7 +1328,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       const retryOnly = !Capacitor.isNativePlatform() && immediateGetSupported !== true;
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={() => {
@@ -1372,7 +1378,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     if (error && ['creating', 'new-storing', 'connecting'].includes(phase)) {
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={handleRetry}>


### PR DESCRIPTION
This PR corrects the recovery phrase button that shows when a passkey sign-in fails.

The button started a new wallet. A user who signs in again already has a wallet, so the app showed them a new empty one. The user can think that the funds are gone. On the web the app asks for the passkey at each start, so a user sees this after one cancelled prompt.

The button now opens the screen to type an existing recovery phrase. A user who creates a wallet for the first time still gets a new phrase.