### PR TITLE
fix: improve the options shown when a passkey fails

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,9 +395,9 @@ const AppContent: React.FC = () => {
             consumeFreshInstallSignal={sdk.consumeFreshInstallSignal}
             skipDetection={passkeySkipDetection}
             onRequestMigrationCheck={requestMigrationCheck}
-            onUseRecoveryPhrase={(mode) => {
+            onUseRecoveryPhrase={() => {
               setPasskeySdkConnected(false);
-              setUserScreen(mode === 'restore' ? 'restore' : 'generate');
+              setUserScreen('generate');
             }}
           />
         );

--- a/src/components/AlertCard.tsx
+++ b/src/components/AlertCard.tsx
@@ -50,13 +50,6 @@ const variantStyles: Record<AlertVariant, {
   },
 };
 
-const defaultIcons: Record<AlertVariant, ReactNode> = {
-  info: <InfoIcon size="md" className="text-spark-electric" />,
-  warning: <WarningIcon size="md" className="text-spark-primary" />,
-  success: <CheckCircleIcon size="md" className="text-spark-success" />,
-  error: <ErrorIcon size="md" className="text-spark-primary" />,
-};
-
 export interface AlertCardProps {
   /** Visual style variant */
   variant: AlertVariant;
@@ -64,7 +57,11 @@ export interface AlertCardProps {
   title: string;
   /** Content displayed below the title */
   children: ReactNode;
-  /** Custom icon (optional, defaults based on variant) */
+  /**
+   * Opt-in badge beside the title. There is no per-variant default: the
+   * title already names the condition, so a generic glyph only repeated it
+   * and pushed the body into a narrower column.
+   */
   icon?: ReactNode;
   /** Additional CSS classes */
   className?: string;
@@ -78,19 +75,18 @@ export const AlertCard: React.FC<AlertCardProps> = ({
   className = '',
 }) => {
   const styles = variantStyles[variant];
-  const displayIcon = icon ?? defaultIcons[variant];
 
   return (
     <div className={`border rounded-2xl p-4 ${styles.container} ${className}`}>
       <div className="flex items-center gap-3 mb-2">
-        {displayIcon && (
+        {icon && (
           <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${styles.iconBg}`}>
-            {displayIcon}
+            {icon}
           </div>
         )}
         <h3 className={`font-display font-bold ${styles.title}`}>{title}</h3>
       </div>
-      <div className={`pl-[52px] ${styles.body}`}>
+      <div className={`${icon ? 'pl-[52px]' : ''} ${styles.body}`}>
         {children}
       </div>
     </div>

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -37,7 +37,7 @@ import {
 
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs } from '@/services/logExport';
-import { friendlyPasskeyError } from '@/utils/passkeyErrorCopy';
+import { friendlyPasskeyError, isDeterministicFailureCopy } from '@/utils/passkeyErrorCopy';
 import { useLatest } from '../hooks/useLatest';
 
 /**
@@ -86,12 +86,11 @@ interface PasskeyPageProps {
    */
   onRequestMigrationCheck?: () => Promise<'proceed' | 'handled'>;
   /**
-   * Leaves the passkey flow for a seed phrase; the primary escape on
-   * ceremony failures. `'restore'` opens phrase entry for a returning
-   * user, whose passkey wallet has a phrase revealable from Settings ->
-   * Backup. `'create'` starts seed onboarding for a first-timer.
+   * Starts create-via-seed onboarding (new seed, phrase shown for
+   * backup); the primary escape on ceremony failures. Restoring an
+   * existing phrase stays reachable from the home screen.
    */
-  onUseRecoveryPhrase: (mode: 'restore' | 'create') => void;
+  onUseRecoveryPhrase: () => void;
 }
 
 // 5s under the OS's ~60s WebAuthn inactivity ceiling: anything past
@@ -940,11 +939,6 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     return () => { cancelled = true; };
   }, [phase, error, onWalletReadyRef]);
 
-  // A returning user is signing in to a wallet that already exists, so
-  // sending them to seed onboarding would hand them a fresh empty
-  // wallet and look like their funds are gone.
-  const handleUseRecoveryPhrase = () => onUseRecoveryPhrase(isNewUser ? 'create' : 'restore');
-
   /** Clear error to re-trigger the current phase's effect. */
   const handleRetry = () => {
     setError(null);
@@ -1220,7 +1214,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     if (error && phase === 'detecting' && errorKind === 'sign-in-cancelled') {
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={() => {
@@ -1283,7 +1277,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       const retryOnly = isWeb && immediateGetSupported !== true;
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={() => {
@@ -1291,7 +1285,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             setErrorKind(null);
             setPhase('aasa-checking');
           }}>
-            Try Again
+            {isDeterministicFailureCopy(error) ? 'Try Another Provider' : 'Try Again'}
           </SecondaryButton>
           {isWeb && (
             <SecondaryButton className="w-full" onClick={() => {
@@ -1328,14 +1322,14 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       const retryOnly = !Capacitor.isNativePlatform() && immediateGetSupported !== true;
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={() => {
             setError(null);
             setPhase('aasa-checking');
           }}>
-            Try Again
+            {isDeterministicFailureCopy(error) ? 'Try Another Provider' : 'Try Again'}
           </SecondaryButton>
           {!retryOnly && (
             <SecondaryButton className="w-full" onClick={() => {
@@ -1378,15 +1372,20 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     if (error && ['creating', 'new-storing', 'connecting'].includes(phase)) {
       return (
         <div className="max-w-xl mx-auto space-y-3">
-          <PrimaryButton className="w-full" onClick={handleUseRecoveryPhrase}>
+          <PrimaryButton className="w-full" onClick={onUseRecoveryPhrase}>
             Continue with Recovery Phrase
           </PrimaryButton>
           <SecondaryButton className="w-full" onClick={handleRetry}>
-            Retry
+            {isDeterministicFailureCopy(error) ? 'Try Another Provider' : 'Retry'}
           </SecondaryButton>
-          <SecondaryButton className="w-full" onClick={handleErrorBack}>
-            Go Back
-          </SecondaryButton>
+          {/* Dropped on a deterministic failure: it would only offer the
+              label picker, which cannot fix a provider that has no PRF.
+              The header back arrow still leaves the flow. */}
+          {!isDeterministicFailureCopy(error) && (
+            <SecondaryButton className="w-full" onClick={handleErrorBack}>
+              Go Back
+            </SecondaryButton>
+          )}
         </div>
       );
     }
@@ -1473,7 +1472,11 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             <AlertCard
               variant="error"
               title={
-                errorKind === 'already-exists'
+                // Ahead of the phase branches: a deterministic failure reads
+                // the same whether it surfaced on connect or on sign-in.
+                isDeterministicFailureCopy(error)
+                  ? 'Passkey Not Supported'
+                : errorKind === 'already-exists'
                   ? 'Passkey already exists'
                   : errorKind === 'sign-in-cancelled'
                     ? 'Sign-in cancelled'

--- a/src/utils/passkeyErrorCopy.test.ts
+++ b/src/utils/passkeyErrorCopy.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { friendlyPasskeyError } from './passkeyErrorCopy';
+import { friendlyPasskeyError, isDeterministicFailureCopy } from './passkeyErrorCopy';
+
+const DETERMINISTIC = 'Please try again with another password provider, or continue with a recovery phrase.';
 
 const withCode = (message: string, code: string): Error => {
   const e = new Error(message);
@@ -19,7 +21,7 @@ describe('friendlyPasskeyError', () => {
 
   it('maps the GPM loop to deterministic recovery-phrase copy on GrapheneOS', () => {
     expect(friendlyPasskeyError(withCode(GPM_LOOP, 'GENERIC_ERROR'), { isGrapheneOs: true })).toBe(
-      "Passkeys aren't working with Google Password Manager on this device. Try again with another password provider, or continue with your recovery phrase.",
+      DETERMINISTIC,
     );
   });
 
@@ -29,10 +31,8 @@ describe('friendlyPasskeyError', () => {
     ).toBe('The passkey prompt timed out. Please try again.');
   });
 
-  it('maps PRF_NOT_SUPPORTED with provider-switch advice', () => {
-    expect(friendlyPasskeyError(withCode('nope', 'PRF_NOT_SUPPORTED'))).toMatch(
-      /different password manager/,
-    );
+  it('maps PRF_NOT_SUPPORTED to the same deterministic copy as the GPM loop', () => {
+    expect(friendlyPasskeyError(withCode('nope', 'PRF_NOT_SUPPORTED'))).toBe(DETERMINISTIC);
   });
 
   it('maps a bare AUTHENTICATION_FAILED code regardless of message', () => {
@@ -52,5 +52,34 @@ describe('friendlyPasskeyError', () => {
   it('returns null for unknown errors so callers keep their fallback copy', () => {
     expect(friendlyPasskeyError(new Error('some novel failure'))).toBeNull();
     expect(friendlyPasskeyError('not even an Error')).toBeNull();
+  });
+});
+
+describe('isDeterministicFailureCopy', () => {
+  // Hiding the retry action rests on these two, so they are asserted
+  // through friendlyPasskeyError rather than against pasted strings: a
+  // copy edit that misses one side fails here instead of shipping a
+  // footer whose only remaining action is the recovery phrase.
+  it('flags the GPM loop on GrapheneOS', () => {
+    const copy = friendlyPasskeyError(withCode(GPM_LOOP, 'GENERIC_ERROR'), { isGrapheneOs: true });
+    expect(isDeterministicFailureCopy(copy)).toBe(true);
+  });
+
+  it('flags PRF_NOT_SUPPORTED', () => {
+    expect(isDeterministicFailureCopy(friendlyPasskeyError(withCode('nope', 'PRF_NOT_SUPPORTED')))).toBe(true);
+  });
+
+  it('leaves retryable failures alone', () => {
+    // The same GPM error off GrapheneOS is the retryable lock-and-unlock case.
+    expect(isDeterministicFailureCopy(friendlyPasskeyError(withCode(GPM_LOOP, 'GENERIC_ERROR')))).toBe(false);
+    expect(isDeterministicFailureCopy(friendlyPasskeyError(new Error('The operation timed out.')))).toBe(false);
+    expect(isDeterministicFailureCopy(friendlyPasskeyError(new TypeError('Failed to fetch')))).toBe(false);
+    expect(isDeterministicFailureCopy(friendlyPasskeyError(withCode('x', 'PRF_EVALUATION_FAILED')))).toBe(false);
+  });
+
+  it('treats an unmatched error and a missing message as retryable', () => {
+    expect(isDeterministicFailureCopy(friendlyPasskeyError(new Error('some novel failure')))).toBe(false);
+    expect(isDeterministicFailureCopy(null)).toBe(false);
+    expect(isDeterministicFailureCopy('Could not sign in with your passkey. Please try again.')).toBe(false);
   });
 });

--- a/src/utils/passkeyErrorCopy.ts
+++ b/src/utils/passkeyErrorCopy.ts
@@ -5,10 +5,17 @@
  * survives only inside the message. Returns null when nothing matches;
  * callers keep their own fallback copy and surface the raw text separately.
  */
-export function friendlyPasskeyError(
-  e: unknown,
-  opts?: { isGrapheneOs?: boolean },
-): string | null {
+
+type FailureKind =
+  | 'gpm-loop'
+  | 'prf-unsupported'
+  | 'auth-failed'
+  | 'timeout'
+  | 'prf-eval'
+  | 'config'
+  | 'network';
+
+function classify(e: unknown, opts?: { isGrapheneOs?: boolean }): FailureKind | null {
   const code = (e as { code?: string })?.code ?? '';
   const raw = e instanceof Error ? e.message : String(e);
 
@@ -22,29 +29,69 @@ export function friendlyPasskeyError(
     && /google password manager/i.test(raw)
     && (/authentication[ _]?failed/i.test(raw) || /timed? ?out/i.test(raw))
   ) {
-    return "Passkeys aren't working with Google Password Manager on this device. Try again with another password provider, or continue with your recovery phrase.";
+    return 'gpm-loop';
   }
 
   if (code === 'PRF_NOT_SUPPORTED' || /PrfNotSupported/.test(raw)) {
-    return "This device or password manager doesn't support the security feature Glow passkeys need. Try a different password manager, or continue with your recovery phrase.";
+    return 'prf-unsupported';
   }
   // Covers Google Password Manager's device-unlock loop ending in
   // "[15] Flow has timed out"; lock-and-unlock mirrors Android's own
   // recovery hint for a stale screen-lock verification.
   if (code === 'AUTHENTICATION_FAILED' || /authentication[ _]?failed/i.test(raw)) {
-    return "Your device couldn't finish verifying your identity. Lock and unlock your device, then try again.";
+    return 'auth-failed';
   }
   if (/timed? ?out/i.test(raw)) {
-    return 'The passkey prompt timed out. Please try again.';
+    return 'timeout';
   }
   if (code === 'PRF_EVALUATION_FAILED' || /PrfEvaluationFailed/.test(raw)) {
-    return "Your password manager couldn't process the passkey. Please try again.";
+    return 'prf-eval';
   }
   if (code === 'CONFIGURATION_ERROR' || /PrfProviderException\$Configuration/.test(raw)) {
-    return "Passkeys aren't configured correctly for this app. Please update Glow or try again later.";
+    return 'config';
   }
   if (/network|failed to fetch|load failed/i.test(raw)) {
-    return 'Network problem. Check your connection and try again.';
+    return 'network';
   }
   return null;
+}
+
+const COPY: Record<FailureKind, string> = {
+  // Both deterministic failures share one message: the "Passkey Not
+  // Supported" title carries the diagnosis, so the body is only the two
+  // ways forward, which are the same for either cause.
+  'gpm-loop': 'Please try again with another password provider, or continue with a recovery phrase.',
+  'prf-unsupported': 'Please try again with another password provider, or continue with a recovery phrase.',
+  'auth-failed': "Your device couldn't finish verifying your identity. Lock and unlock your device, then try again.",
+  'timeout': 'The passkey prompt timed out. Please try again.',
+  'prf-eval': "Your password manager couldn't process the passkey. Please try again.",
+  'config': "Passkeys aren't configured correctly for this app. Please update Glow or try again later.",
+  'network': 'Network problem. Check your connection and try again.',
+};
+
+export function friendlyPasskeyError(
+  e: unknown,
+  opts?: { isGrapheneOs?: boolean },
+): string | null {
+  const kind = classify(e, opts);
+  return kind === null ? null : COPY[kind];
+}
+
+// The failures a retry cannot fix: the provider has no PRF at all, or
+// GPM's screen-lock check is broken on this OS. Both already tell the
+// user to switch provider or use the recovery phrase.
+const DETERMINISTIC_COPY: ReadonlySet<string> = new Set([
+  COPY['gpm-loop'],
+  COPY['prf-unsupported'],
+]);
+
+/**
+ * True when retrying the same provider can never succeed, so callers point
+ * the retry action at a different one instead of repeating a ceremony that
+ * always fails. Keyed on the message already held in state rather than a
+ * parallel flag: it cannot go stale, and the set is built from the same
+ * copy the user is reading.
+ */
+export function isDeterministicFailureCopy(message: string | null): boolean {
+  return message !== null && DETERMINISTIC_COPY.has(message);
 }


### PR DESCRIPTION
This PR corrects what the app offers when a passkey sign-in or setup fails.

The recovery phrase button opened a screen to type a phrase that almost no passkey user has. It now starts onboarding for a new wallet, which gives the user a phrase to save. A user who already has a phrase can still restore it from the home screen.

Two failures cannot succeed on a retry. They now share one title, `Passkey Not Supported`, one message, and a `Try Another Provider` action.

Warning and error boxes no longer show an icon beside the title.

**Note:** the two failures need a check on a real device before this leaves draft.