### PR TITLE
chore: install the exact lockfile on production deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "rm -rf node_modules/@breeztech && npm install",
+  "installCommand": "npm ci",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Production deploys now use `npm ci` instead of `npm install`. This command installs exactly the versions that `package-lock.json` records.

The install step no longer does `rm -rf node_modules/@breeztech`. That cleanup is not necessary, because `npm ci` removes `node_modules` before each install.
