### PR TITLE
chore: finish the legacy mnemonic move when the vault is already set

### DIFF
--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -45,6 +45,12 @@ import {
 } from '../services/passkeyService';
 import { LEGACY_RP_ID, SHARED_RP_ID, rpId as defaultRpId } from '../services/passkeyPrfProvider';
 import { secureStorage, deviceOnlyStorage, SecureStorageError, resetSecureStorageInit } from '../services/secureStorage';
+import {
+  saveMnemonic,
+  getSavedMnemonic,
+  clearMnemonic,
+  migrateLegacyMnemonicIfNeeded,
+} from '../services/legacyMnemonicMigration';
 import { isSendSheetOpen } from '../features/send/sendSheetVisibility';
 import { clearPin, isAppLockSupported } from '../services/appLock';
 
@@ -91,41 +97,6 @@ async function initSdkLogging() {
     );
   } catch {
     /* SDK unavailable; skip the log bridge. */
-  }
-}
-
-// ============================================
-// Mnemonic storage (localStorage)
-// ============================================
-
-const MNEMONIC_KEY = 'walletMnemonic';
-const saveMnemonic = (m: string) => localStorage.setItem(MNEMONIC_KEY, m);
-const getSavedMnemonic = () => localStorage.getItem(MNEMONIC_KEY);
-const clearMnemonic = () => localStorage.removeItem(MNEMONIC_KEY);
-
-// ============================================
-// Legacy mnemonic → secure storage migration
-// ============================================
-
-/**
- * On native, copy any plaintext localStorage mnemonic into the
- * device-only secure-storage tier (NOT the biometric-bound tier:
- * these are pre-0.0.3 non-passkey users who never opted into
- * biometrics) and wipe the plaintext copy. Idempotent and non-fatal:
- * retried every startup until done, legacy path keeps working in the
- * meantime.
- */
-async function migrateLegacyMnemonicIfNeeded(): Promise<void> {
-  if (!deviceOnlyStorage.isSupported()) return;
-  const legacy = getSavedMnemonic();
-  if (!legacy) return;
-  try {
-    if (await deviceOnlyStorage.hasStoredSeed()) return;
-    await deviceOnlyStorage.storeSeed({ type: 'mnemonic', mnemonic: legacy });
-    clearMnemonic();
-    logger.info(LogCategory.AUTH, 'Migrated plaintext mnemonic into device-only secure storage');
-  } catch {
-    // deviceOnlyStorage logged the typed error; we'll retry next startup.
   }
 }
 

--- a/src/services/legacyMnemonicMigration.test.ts
+++ b/src/services/legacyMnemonicMigration.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Guard for the drain: a vault that already holds the seed used to make
+ * startup return early and leave the legacy copy behind.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Seed } from '@breeztech/breez-sdk-spark';
+
+const vault = vi.hoisted(() => ({ seed: null as Seed | null }));
+
+vi.mock('./secureStorage', () => ({
+  deviceOnlyStorage: {
+    isSupported: () => true,
+    hasStoredSeed: async () => vault.seed !== null,
+    retrieveSeed: async () => vault.seed!,
+    storeSeed: async (seed: Seed) => { vault.seed = seed; },
+  },
+}));
+
+import { migrateLegacyMnemonicIfNeeded, getSavedMnemonic, saveMnemonic } from './legacyMnemonicMigration';
+
+const MNEMONIC = 'abandon abandon ability';
+const OTHER = 'zoo zoo wrong';
+
+describe('migrateLegacyMnemonicIfNeeded', () => {
+  beforeEach(() => {
+    vault.seed = null;
+    localStorage.clear();
+  });
+
+  it('moves the plaintext mnemonic into an empty vault', async () => {
+    saveMnemonic(MNEMONIC);
+    await migrateLegacyMnemonicIfNeeded();
+    expect(vault.seed).toEqual({ type: 'mnemonic', mnemonic: MNEMONIC });
+    expect(getSavedMnemonic()).toBeNull();
+  });
+
+  it('deletes the plaintext mnemonic when the vault already holds the same seed', async () => {
+    vault.seed = { type: 'mnemonic', mnemonic: MNEMONIC };
+    saveMnemonic(MNEMONIC);
+    await migrateLegacyMnemonicIfNeeded();
+    expect(getSavedMnemonic()).toBeNull();
+  });
+
+  it('keeps a plaintext mnemonic that differs from the vault seed', async () => {
+    vault.seed = { type: 'mnemonic', mnemonic: OTHER };
+    saveMnemonic(MNEMONIC);
+    await migrateLegacyMnemonicIfNeeded();
+    expect(getSavedMnemonic()).toBe(MNEMONIC);
+    expect(vault.seed).toEqual({ type: 'mnemonic', mnemonic: OTHER });
+  });
+
+  it('treats a vault passphrase as a different wallet', async () => {
+    vault.seed = { type: 'mnemonic', mnemonic: MNEMONIC, passphrase: 'x' };
+    saveMnemonic(MNEMONIC);
+    await migrateLegacyMnemonicIfNeeded();
+    expect(getSavedMnemonic()).toBe(MNEMONIC);
+  });
+});

--- a/src/services/legacyMnemonicMigration.ts
+++ b/src/services/legacyMnemonicMigration.ts
@@ -1,0 +1,51 @@
+/**
+ * The legacy `walletMnemonic` localStorage key and its drain into the native
+ * vault. It predates the vault, so on native it is a leftover the vault has
+ * since replaced and startup should not leave behind. Web has no vault and
+ * keeps using it as the only seed store.
+ */
+import { deviceOnlyStorage } from './secureStorage';
+import { logger, LogCategory } from './logger';
+
+const MNEMONIC_KEY = 'walletMnemonic';
+
+export const saveMnemonic = (m: string) => localStorage.setItem(MNEMONIC_KEY, m);
+export const getSavedMnemonic = () => localStorage.getItem(MNEMONIC_KEY);
+export const clearMnemonic = () => localStorage.removeItem(MNEMONIC_KEY);
+
+/**
+ * On native, move any legacy mnemonic into the device-only tier (NOT the
+ * biometric-bound tier: these are pre-0.0.3 non-passkey users who never opted
+ * into biometrics). Idempotent and non-fatal: retried every startup until
+ * done, legacy path keeps working in the meantime.
+ *
+ * A seed already in the vault wins, and the legacy copy is dropped only when
+ * it is that same seed. One that differs is left in place: it can be the
+ * device's only copy of another wallet, and deleting it burns those funds.
+ */
+export async function migrateLegacyMnemonicIfNeeded(): Promise<void> {
+  if (!deviceOnlyStorage.isSupported()) return;
+  const legacy = getSavedMnemonic();
+  if (!legacy) return;
+  try {
+    if (await deviceOnlyStorage.hasStoredSeed()) {
+      const stored = await deviceOnlyStorage.retrieveSeed();
+      // A vault passphrase derives a different wallet, so it counts as a mismatch.
+      const sameSeed = stored.type === 'mnemonic'
+        && stored.mnemonic === legacy
+        && !stored.passphrase;
+      if (!sameSeed) {
+        logger.warn(LogCategory.AUTH, 'Plaintext mnemonic differs from the stored seed; leaving it in place');
+        return;
+      }
+      clearMnemonic();
+      logger.info(LogCategory.AUTH, 'Removed plaintext mnemonic already held in device-only secure storage');
+      return;
+    }
+    await deviceOnlyStorage.storeSeed({ type: 'mnemonic', mnemonic: legacy });
+    clearMnemonic();
+    logger.info(LogCategory.AUTH, 'Migrated plaintext mnemonic into device-only secure storage');
+  } catch {
+    // deviceOnlyStorage logged the typed error; we'll retry next startup.
+  }
+}

--- a/src/services/passkeyService.test.ts
+++ b/src/services/passkeyService.test.ts
@@ -4,7 +4,11 @@ import {
   getMigrationCounterpartCredentialIdBytes,
   clearMigrationCredentialPairs,
   bytesToBase64,
+  getPasskeyRpId,
+  setPasskeyRpId,
+  resetPasskeyMigrationState,
 } from './passkeyService';
+import { LEGACY_RP_ID } from './passkeyPrfProvider';
 
 const LEGACY = 'legacy.example';
 const SHARED = 'shared.example';
@@ -76,5 +80,27 @@ describe('migration credential pairs', () => {
     clearMigrationCredentialPairs();
     setActive(legacyA, LEGACY);
     expect(counterpart(SHARED)).toBeNull();
+  });
+});
+
+describe('passkey RP pin', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('pins the legacy RP on a device that has no pin yet', () => {
+    setPasskeyRpId(LEGACY_RP_ID);
+    expect(getPasskeyRpId()).toBe(LEGACY_RP_ID);
+  });
+
+  // The route back is how stranded funds get recovered. Keep it open.
+  it('lets a migrated device pin the legacy RP again', () => {
+    setPasskeyRpId(SHARED);
+    setPasskeyRpId(LEGACY_RP_ID);
+    expect(getPasskeyRpId()).toBe(LEGACY_RP_ID);
+  });
+
+  it('still rewinds on the dev migration reset', () => {
+    setPasskeyRpId(SHARED);
+    resetPasskeyMigrationState();
+    expect(getPasskeyRpId()).toBe(LEGACY_RP_ID);
   });
 });

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -974,8 +974,16 @@ export function getPasskeyRpId(): string | null {
   return localStorage.getItem(PASSKEY_RP_ID_KEY);
 }
 
-/** Persist the RP ID used for this device's passkey. */
+/**
+ * Persist the RP ID used for this device's passkey. A move back to the legacy
+ * ID is logged, never refused: recovering funds a migration left behind means
+ * signing in on the old passkey, which pins the legacy ID here.
+ */
 export function setPasskeyRpId(rpId: string): void {
+  const current = getPasskeyRpId();
+  if (rpId === LEGACY_RP_ID && current !== null && current !== LEGACY_RP_ID) {
+    logger.warn(LogCategory.AUTH, 'Passkey RP pinned back to the legacy ID', { current });
+  }
   localStorage.setItem(PASSKEY_RP_ID_KEY, rpId);
 }
 


### PR DESCRIPTION
Before the vault existed, the app kept the recovery phrase in a browser storage entry. Startup moves that entry into the vault and then removes it, but when the vault already had a seed it stopped before the removal, so the entry stayed on the device. It now compares the two: same seed and the entry goes, different seed and the entry stays with a warning in the log, because a different phrase can be the only copy of a second wallet. A passphrase on the vault seed counts as different.

Pinning the passkey RP back to the legacy ID now logs a warning. It stays allowed, because recovering funds a move left behind means signing in on the old passkey.
