### PR TITLE
docs: add security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Disclosures
+
+Security is fundamental to Breez. If you discover a vulnerability, we encourage you to report it responsibly.
+
+Please report security issues privately to **contact@breez.technology**. **Do not file a public issue or pull request.**
+
+When reporting a vulnerability, please include, if available:
+
+- Affected version or commit
+- Where you found it: [glow-app.co](https://glow-app.co), a preview deployment, or a local build
+- Browser and operating system
+- Description of the vulnerability and its potential impact
+- Steps to reproduce or a proof of concept
+
+Glow is built on the [Breez SDK](https://github.com/breez/spark-sdk) and also ships as a native app from [breez/glow-app](https://github.com/breez/glow-app). Report issues in any of them to the same address rather than filing publicly.
+
+We will acknowledge your report and keep you informed as we investigate and address the issue.


### PR DESCRIPTION
Adds a `SECURITY.md` mirroring the one in [breez/spark-sdk](https://github.com/breez/spark-sdk/blob/main/SECURITY.md), so vulnerability reports go privately to contact@breez.technology instead of into a public issue. GitHub also surfaces a "Report a vulnerability" hint on repos that have this file.

The structure is unchanged from the SDK's version. Only the reporting checklist is adapted: "affected SDK or language binding" does not apply here, so it is replaced with the deployment (glow-app.co, a preview, or a local build), the browser, and the OS.

A closing line points at [breez/glow-app](https://github.com/breez/glow-app) and the SDK, so a reporter who lands on the wrong repo still knows to email rather than open a public issue there.

A matching file is going into glow-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBNTJHbNa7uE3j9qorwMKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBNTJHbNa7uE3j9qorwMKk)_