### PR TITLE
fix: stop toasts covering each other, unstick the send sheet flag

### DIFF
--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -477,9 +477,10 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       // Drop the library's decorative styles (white card, grey pills);
       // the surface look comes from our classes below.
       unstyled
-      // Keep sheets in the app's existing z order (confirm dialogs and
-      // toasts render at z-50 in the same stacking context); the
-      // library would otherwise default to 9999.
+      // Keep sheets in the app's existing z order (confirm dialogs render
+      // at z-50 in the same stacking context); the library would otherwise
+      // default to 9999. Toasts deliberately sit above every sheet, in
+      // their own stacking context at 99999.
       //
       // Constrain the library's position:fixed root to the app content
       // column (#content-root is max-w-4xl) and center it, so on wide web

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -41,11 +41,14 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
 
   // Publish sheet visibility so the SDK event handler knows whether this
   // sheet is still around to report the payment outcome (it is dismissible
-  // mid-send). Mount/unmount, because the parent keys a fresh mount per open.
+  // mid-send). Keyed on `isOpen`, not mount: WalletPage pre-mounts this
+  // dialog closed, so a mount-scoped flag would read as open for the whole
+  // session and suppress the outcome report it exists to trigger.
   useEffect(() => {
+    if (!isOpen) return;
     setSendSheetOpen(true);
     return () => setSendSheetOpen(false);
-  }, []);
+  }, [isOpen]);
 
   // Parent (WalletPage) bumps `sendDialogSession` on every open and passes
   // it as `key`, so each open is a fresh mount: hooks re-init, useState

--- a/src/features/send/sendSheetVisibility.test.tsx
+++ b/src/features/send/sendSheetVisibility.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import { WalletProvider, WalletInfoProvider, WalletStatusProvider } from '@/contexts/WalletContext';
+import { ContactsProvider } from '@/contexts/ContactsContext';
+import { ToastProvider } from '@/contexts/ToastContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { isSendSheetOpen } from './sendSheetVisibility';
+import SendPaymentDialog from './SendPaymentDialog';
+
+function renderDialog(isOpen: boolean) {
+  const client = createMockClient() as unknown as BreezSdk;
+  client.listContacts = vi.fn().mockResolvedValue([]);
+
+  return render(
+    <ToastProvider>
+      <WalletProvider client={client} isConnected>
+        <WalletInfoProvider walletInfo={{ balanceSats: 500_000 } as never}>
+          <WalletStatusProvider hasPendingConversion={false}>
+            <FiatDataProvider>
+              <StableBalanceProvider>
+                <ContactsProvider>
+                  <SendPaymentDialog isOpen={isOpen} onClose={vi.fn()} />
+                </ContactsProvider>
+              </StableBalanceProvider>
+            </FiatDataProvider>
+          </WalletStatusProvider>
+        </WalletInfoProvider>
+      </WalletProvider>
+    </ToastProvider>,
+  );
+}
+
+// The SDK event handler reports a send's outcome itself only when this
+// reads false. WalletPage pre-mounts the dialog closed, so a flag scoped
+// to mount stays true for the whole session and silences that report.
+describe('isSendSheetOpen', () => {
+  it('reports closed while the pre-mounted dialog is closed', () => {
+    renderDialog(false);
+    expect(isSendSheetOpen()).toBe(false);
+  });
+
+  it('reports open while the dialog is open', () => {
+    renderDialog(true);
+    expect(isSendSheetOpen()).toBe(true);
+  });
+
+  it('reports closed again once the dialog closes', () => {
+    const { rerender } = renderDialog(true);
+    expect(isSendSheetOpen()).toBe(true);
+
+    rerender(
+      <ToastProvider>
+        <WalletProvider client={createMockClient() as unknown as BreezSdk} isConnected>
+          <WalletInfoProvider walletInfo={{ balanceSats: 500_000 } as never}>
+            <WalletStatusProvider hasPendingConversion={false}>
+              <FiatDataProvider>
+                <StableBalanceProvider>
+                  <ContactsProvider>
+                    <SendPaymentDialog isOpen={false} onClose={vi.fn()} />
+                  </ContactsProvider>
+                </StableBalanceProvider>
+              </FiatDataProvider>
+            </WalletStatusProvider>
+          </WalletInfoProvider>
+        </WalletProvider>
+      </ToastProvider>,
+    );
+
+    expect(isSendSheetOpen()).toBe(false);
+  });
+
+  it('reports closed after the dialog unmounts while open', () => {
+    const { unmount } = renderDialog(true);
+    unmount();
+    expect(isSendSheetOpen()).toBe(false);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -797,25 +797,29 @@ video::-webkit-media-controls-panel {
    TOAST NOTIFICATIONS
    ============================================ */
 
+/* The container is what anchors the stack: each toast is an in-flow flex
+   item, so a second toast lands under the first instead of on top of it.
+   Positioning the toasts themselves would take them out of flow and
+   collapse the column to a single point.
+
+   Transparent to pointer events across its whole band, which spans the
+   viewport width; only the toast cards inside take taps. */
 .toast-container {
   position: fixed;
-  left: 16px;
-  right: 16px;
   z-index: 99999;
+  left: env(safe-area-inset-left, 1em);
+  right: env(safe-area-inset-right, 1em);
+  top: calc(1em + env(safe-area-inset-top, 0em));
   display: flex;
   flex-direction: column;
   gap: 12px;
+  pointer-events: none;
 }
 
 .toast-notification {
   pointer-events: none;
-  display:flex;
-  position: fixed;
+  display: flex;
   justify-content: center;
-  z-index: 50;
-  left: env(safe-area-inset-left, 1em);
-  right: env(safe-area-inset-right, 1em);
-  top: calc(1em + env(safe-area-inset-top, 0em));
 }
 
 /* ============================================


### PR DESCRIPTION
Investigating a report that the "Save as contact?" prompt no longer appears after paying a lightning address. That prompt's own path turned out to be intact, and its z-index has not changed since #66, but the investigation surfaced two defects that each silence a toast raised after a payment.

## Toasts covered each other

Every `.toast-notification` was `position: fixed` at the same top offset, so `.toast-container`'s `flex-direction: column` and `gap: 12px` had nothing to lay out and each new toast painted exactly over the previous one. The save-as-contact prompt carries an action, which disables its auto-dismiss, so any toast arriving afterwards hid it for good.

The container now owns the positioning and the toasts are in-flow flex items. It also takes `pointer-events: none`, because it is now a real layout box spanning the viewport width; the cards keep their own `pointer-events-auto`, so a tap beside a card still reaches the UI underneath.

Measured in Chromium at 390x844:

| | before | after |
|---|---|---|
| one toast | top 16 | top 16 (unchanged) |
| three toasts | all at top 16, stacked over each other | tops 16 / 108 / 202, 12px gaps |

## The send sheet reported itself permanently open

`SendPaymentDialog` published its visibility from a mount effect, on the premise that the parent mounts it fresh per open. `WalletPage` pre-mounts it closed ("always mounted for instant response"), so the flag read open from the moment the wallet page appeared and never cleared.

Both guards reading it were therefore dead: a send that completed after the user dismissed the sheet showed no confirmation, and a failed one raised no message, which is the case the flag was added for in #326. Keyed on `isOpen` instead.

## Testing

- New `sendSheetVisibility.test.tsx` covers pre-mounted-closed, open, open to closed, and unmount-while-open.
- Toast stacking was verified by measuring the real CSS in Chromium. No unit test for it: the suite does not load stylesheets, so layout cannot be asserted in jsdom.
- `npx tsc --noEmit` clean, 178 tests across 28 files pass, `npm run lint` reports 0 errors (4 warnings, all pre-existing in files this branch does not touch).

## One caveat

Bug 1 only bites when a second toast co-occurs, and I could not find one that fires during a plain send, so this may not be the exact path the reporter hit. Driving a full lightning-address payment through the real sheet in Chromium showed the prompt appearing correctly. If it still reproduces, the likelier explanation is by design: a scanned `lnurl1...` QR parses as `lnurlPay` rather than `lightningAddress`, and an address already saved as a contact is skipped.