### PR TITLE
Remove the icon from the claim and refund failure cards

### DIFF
--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -13,11 +13,11 @@ import {
   WarningIcon,
   CheckCircleIcon,
   ErrorIcon,
-  AlertTriangleIcon,
   CheckIcon,
   ExternalLinkIcon,
   BackIcon,
 } from '../Icons';
+import { AlertCard } from '../AlertCard';
 import { useBackButton } from '../../hooks/useBackButton';
 import { useStatusBarColor } from '../../hooks/useStatusBarColor';
 import { STATUS_BAR_DIALOG_SCRIM } from '../../utils/statusBarManager';
@@ -446,24 +446,16 @@ export const ErrorMessageBox: React.FC<{
   }
 
   return (
-    <div className={`bg-spark-warn-surface border border-spark-warn-border rounded-2xl p-4 ${className}`}>
-      <div className="flex items-center gap-3 mb-2">
-        <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center shrink-0">
-          <AlertTriangleIcon className="text-spark-primary" />
+    <AlertCard variant="error" title={title} className={className}>
+      <p className="text-sm">{mainMessage}</p>
+      {stackTrace && (
+        <div className="mt-3 bg-spark-dark/50 border border-spark-border rounded-xl p-3 max-h-32 overflow-auto">
+          <code className="text-xs text-spark-text-muted font-mono whitespace-pre-wrap break-all">
+            {stackTrace}
+          </code>
         </div>
-        <h3 className="font-display font-bold text-spark-warn-title">{title}</h3>
-      </div>
-      <div className="pl-[52px]">
-        <p className="text-spark-warn-text text-sm">{mainMessage}</p>
-        {stackTrace && (
-          <div className="mt-3 bg-spark-dark/50 border border-spark-border rounded-xl p-3 max-h-32 overflow-auto">
-            <code className="text-xs text-spark-text-muted font-mono whitespace-pre-wrap break-all">
-              {stackTrace}
-            </code>
-          </div>
-        )}
-      </div>
-    </div>
+      )}
+    </AlertCard>
   );
 };
 

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useWallet } from '../contexts/WalletContext';
 import type { DepositInfo, Fee, SdkEvent } from '@breeztech/breez-sdk-spark';
 import { LoadingSpinner, PrimaryButton, SecondaryButton, FormInput, BottomSheetContainer, BottomSheetCard, DialogHeader, CollapsibleCodeField, PaymentInfoCard } from '../components/ui';
-import { SimpleAlert } from '../components/AlertCard';
+import { AlertCard, SimpleAlert } from '../components/AlertCard';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
-import { CloseIcon, CheckIcon, WarningIcon, RadioCheckIcon } from '../components/Icons';
+import { CloseIcon, CheckIcon, RadioCheckIcon } from '../components/Icons';
 import { isDepositRejected, removeRejectedDeposit } from '../services/depositState';
 import { SatAmount } from '../components/SatAmount';
 import { explorerTxUrl } from '../utils/explorer';
@@ -419,17 +419,9 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                 />
 
                 {refundError && (
-                  <div className="bg-spark-warn-surface border border-spark-warn-border rounded-2xl p-4">
-                    <div className="flex items-center gap-3 mb-2">
-                      <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center shrink-0">
-                        <WarningIcon size="md" className="text-spark-primary" />
-                      </div>
-                      <h3 className="font-display font-bold text-spark-warn-title">Refund Failed</h3>
-                    </div>
-                    <div className="pl-[52px]">
-                      <p className="text-spark-warn-text text-sm">{refundError}</p>
-                    </div>
-                  </div>
+                  <AlertCard variant="warning" title="Refund Failed">
+                    <p className="text-sm">{refundError}</p>
+                  </AlertCard>
                 )}
 
                 <div className="flex gap-3">

--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -3,7 +3,8 @@ import { useWallet } from '../contexts/WalletContext';
 import type { DepositInfo, MaxFee } from '@breeztech/breez-sdk-spark';
 import { BottomSheetContainer, BottomSheetCard, DialogHeader, PrimaryButton, SecondaryButton, PaymentInfoCard, CollapsibleCodeField } from '../components/ui';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
-import { SpinnerIcon, WarningIcon } from '../components/Icons';
+import { SpinnerIcon } from '../components/Icons';
+import { AlertCard } from '../components/AlertCard';
 import { rejectDeposit, removeRejectedDeposit } from '../services/depositState';
 import { explorerTxUrl } from '../utils/explorer';
 import { logger, LogCategory } from '@/services/logger';
@@ -157,18 +158,10 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
 
           {/* Error message for failed automatic claim (non-fee error) */}
           {claimError && (
-            <div className="bg-spark-warn-surface border border-spark-warn-border rounded-2xl p-4">
-              <div className="flex items-center gap-3 mb-2">
-                <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center shrink-0">
-                  <WarningIcon size="md" className="text-spark-primary" />
-                </div>
-                <h3 className="font-display font-bold text-spark-warn-title">Claim Failed</h3>
-              </div>
-              <div className="pl-[52px]">
-                <p className="text-spark-warn-text text-sm">{claimError}</p>
-                <p className="text-spark-primary text-sm mt-2">You can reject to process a refund instead.</p>
-              </div>
-            </div>
+            <AlertCard variant="warning" title="Claim Failed">
+              <p className="text-sm">{claimError}</p>
+              <p className="text-spark-primary text-sm mt-2">You can reject to process a refund instead.</p>
+            </AlertCard>
           )}
 
           {/* Action Buttons - Approve/Reject for fee exceeded, hide when claim error shown */}


### PR DESCRIPTION
Three cards still showed an icon in a colored box beside their title: the claim failure card, the refund failure card, and the card that reports an error with its details. Every other alert card in the app had already lost it.

These three did not use the shared alert card. Each one carried its own copy of the same layout, so the earlier change did not reach them. They now use the shared card, and the icon is gone.
