### PR TITLE
feat: enter invoice amounts in fiat (#356)

### DIFF
--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import type { GetInfoResponse, FiatCurrency } from '@breeztech/breez-sdk-spark';
 import { safeAreaTop } from '../utils/safeAreaInsets';
-import { getFiatSettings } from '../services/settings';
+import { getFiatSettings, getDisplayFiatCurrency, setDisplayFiatCurrency } from '../services/settings';
 import { formatWithSpaces } from '../utils/formatNumber';
 import { SatAmount } from './SatAmount';
 import { useAnimatedNumber } from '../hooks/useAnimatedNumber';
@@ -41,7 +41,9 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
 }) => {
   const { fiatRates, fiatCurrencies } = useFiatData();
   const stableBalance = useStableBalance();
-  const [activeFiatIndex, setActiveFiatIndex] = useState(0);
+  // Persisted rather than a plain index: the receive amount input reads the
+  // same value so it denominates in whatever the balance is showing.
+  const [activeFiatId, setActiveFiatId] = useState<string>(getDisplayFiatCurrency);
   // User-driven open. session is bumped on every tap so the dialog
   // remounts with fresh state via key-based remount (no reset effect).
   const [userToggle, setUserToggle] = useState<{
@@ -138,12 +140,18 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
     return result;
   }, [ratesMap, currenciesMap]);
 
+  // Falls back to the first entry when the stored currency isn't in the list
+  // (rate missing, or the user removed it in Settings).
+  const activeFiatIndex = Math.max(0, fiatCurrencyInfo.findIndex(c => c.currencyId === activeFiatId));
+
   // Cycle through fiat currencies on tap
   const handleFiatTap = useCallback(() => {
     if (fiatCurrencyInfo.length > 1) {
-      setActiveFiatIndex(prev => (prev + 1) % fiatCurrencyInfo.length);
+      const next = fiatCurrencyInfo[(activeFiatIndex + 1) % fiatCurrencyInfo.length];
+      setActiveFiatId(next.currencyId);
+      setDisplayFiatCurrency(next.currencyId);
     }
-  }, [fiatCurrencyInfo.length]);
+  }, [fiatCurrencyInfo, activeFiatIndex]);
 
   // Compute balances
   const btcBalanceSat = walletInfo?.balanceSats || 0;

--- a/src/features/receive/AmountPanel.test.tsx
+++ b/src/features/receive/AmountPanel.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { saveFiatSettings } from '@/services/settings';
+import AmountPanel from './AmountPanel';
+
+// Mock rates put BTC at $100,000 and €92,000, so $1 = 1,000 sats.
+function renderAmountPanel(client?: BreezSdk) {
+  const setAmountSats = vi.fn();
+  const mockClient = client ?? createMockClient();
+  render(
+    <WalletProvider client={mockClient} isConnected>
+      <FiatDataProvider>
+        <StableBalanceProvider>
+          <AmountPanel
+            isOpen
+            amountSats={null}
+            setAmountSats={setAmountSats}
+            description=""
+            setDescription={vi.fn()}
+            isLoading={false}
+            error={null}
+            onCreateInvoice={vi.fn()}
+            onClose={vi.fn()}
+            resetCount={0}
+          />
+        </StableBalanceProvider>
+      </FiatDataProvider>
+    </WalletProvider>
+  );
+  return { setAmountSats, client: mockClient };
+}
+
+describe('AmountPanel fiat entry (no stable balance)', () => {
+  afterEach(() => saveFiatSettings({ selectedCurrencies: ['USD'] }));
+
+  it('converts typed dollars to sats and shows them as an approximation', async () => {
+    const { setAmountSats } = renderAmountPanel();
+
+    // The switcher appears once the USD rate loads.
+    fireEvent.click(await screen.findByRole('button', { name: '₿' }));
+    fireEvent.change(screen.getByTestId('invoice-amount-input'), { target: { value: '5' } });
+
+    await waitFor(() => expect(setAmountSats).toHaveBeenCalledWith(5000n));
+    expect(screen.getByText(/≈/)).toHaveTextContent('5 000');
+  });
+
+  it('denominates in the currency at the top of the user\'s list', async () => {
+    saveFiatSettings({ selectedCurrencies: ['EUR', 'USD'] });
+    const { setAmountSats } = renderAmountPanel();
+
+    fireEvent.click(await screen.findByRole('button', { name: '₿' }));
+    fireEvent.change(screen.getByTestId('invoice-amount-input'), { target: { value: '5' } });
+
+    // €5 at €92,000/BTC = 5,435 sats.
+    await waitFor(() => expect(setAmountSats).toHaveBeenCalledWith(5435n));
+    expect(screen.getByRole('button', { name: '€' })).toBeInTheDocument();
+  });
+
+  it('offers no fiat toggle while the rate has not loaded', async () => {
+    const client = createMockClient({
+      listFiatRates: vi.fn().mockResolvedValue({ rates: [] }),
+    } as unknown as Partial<BreezSdk>);
+    renderAmountPanel(client);
+
+    await waitFor(() => expect(client.listFiatRates).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: '₿' })).toBeNull();
+  });
+});

--- a/src/features/receive/AmountPanel.test.tsx
+++ b/src/features/receive/AmountPanel.test.tsx
@@ -5,7 +5,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import { FiatDataProvider } from '@/contexts/FiatDataContext';
 import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
 import { createMockClient } from '@/test/mocks/mockWalletApi';
-import { saveFiatSettings } from '@/services/settings';
+import { saveFiatSettings, setDisplayFiatCurrency } from '@/services/settings';
 import AmountPanel from './AmountPanel';
 
 // Mock rates put BTC at $100,000 and €92,000, so $1 = 1,000 sats.
@@ -36,9 +36,12 @@ function renderAmountPanel(client?: BreezSdk) {
 }
 
 describe('AmountPanel fiat entry (no stable balance)', () => {
-  afterEach(() => saveFiatSettings({ selectedCurrencies: ['USD'] }));
+  afterEach(() => {
+    saveFiatSettings({ selectedCurrencies: ['USD'] });
+    setDisplayFiatCurrency('USD');
+  });
 
-  it('converts typed dollars to sats and shows them as an approximation', async () => {
+  it('converts typed dollars to sats', async () => {
     const { setAmountSats } = renderAmountPanel();
 
     // The switcher appears once the USD rate loads.
@@ -46,11 +49,12 @@ describe('AmountPanel fiat entry (no stable balance)', () => {
     fireEvent.change(screen.getByTestId('invoice-amount-input'), { target: { value: '5' } });
 
     await waitFor(() => expect(setAmountSats).toHaveBeenCalledWith(5000n));
-    expect(screen.getByText(/≈/)).toHaveTextContent('5 000');
   });
 
-  it('denominates in the currency at the top of the user\'s list', async () => {
-    saveFiatSettings({ selectedCurrencies: ['EUR', 'USD'] });
+  it('denominates in the currency the balance header is showing', async () => {
+    saveFiatSettings({ selectedCurrencies: ['USD', 'EUR'] });
+    // What the header writes when the user taps the balance to cycle to EUR.
+    setDisplayFiatCurrency('EUR');
     const { setAmountSats } = renderAmountPanel();
 
     fireEvent.click(await screen.findByRole('button', { name: '₿' }));
@@ -59,6 +63,17 @@ describe('AmountPanel fiat entry (no stable balance)', () => {
     // €5 at €92,000/BTC = 5,435 sats.
     await waitFor(() => expect(setAmountSats).toHaveBeenCalledWith(5435n));
     expect(screen.getByRole('button', { name: '€' })).toBeInTheDocument();
+  });
+
+  it('falls back to the top of the list when that currency is deselected', async () => {
+    setDisplayFiatCurrency('EUR');
+    saveFiatSettings({ selectedCurrencies: ['USD'] });
+    const { setAmountSats } = renderAmountPanel();
+
+    fireEvent.click(await screen.findByRole('button', { name: '₿' }));
+    fireEvent.change(screen.getByTestId('invoice-amount-input'), { target: { value: '5' } });
+
+    await waitFor(() => expect(setAmountSats).toHaveBeenCalledWith(5000n));
   });
 
   it('offers no fiat toggle while the rate has not loaded', async () => {

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -16,7 +16,7 @@ import {
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
 import { SatAmount } from '../../components/SatAmount';
 import { useAmountInput, useFiatOverride } from '../../hooks/useAmountInput';
-import { getFiatSettings } from '../../services/settings';
+import { getDisplayFiatCurrency } from '../../services/settings';
 import type { Sats } from '../../types/sats';
 import { dismissKeyboard } from '../../utils/keyboard';
 import { LIGHTNING_INVOICE_MIN_SATS, LIGHTNING_INVOICE_MAX_SATS } from '../../constants/receive';
@@ -55,11 +55,9 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   resetCount,
 }) => {
   // Fiat entry without a stable-balance token: the typed amount is converted to
-  // sats client-side (#356). Denominated in the currency at the top of the
-  // user's Settings list, the one the balance header opens on.
-  const input = useAmountInput({
-    fiatOverride: useFiatOverride(getFiatSettings().selectedCurrencies[0] ?? 'USD'),
-  });
+  // sats client-side (#356). Denominated in whatever currency the balance
+  // header is showing, including one the user cycled to by tapping it.
+  const input = useAmountInput({ fiatOverride: useFiatOverride(getDisplayFiatCurrency()) });
   const {
     amountInput: displayAmount,
     setAmount,
@@ -193,14 +191,6 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
                 />
               )}
             </div>
-            {/* The invoice is fixed in sats, converted off the last fetched
-                rate, so the fiat value it settles at can differ. The ≈ carries
-                that on its own. */}
-            {isTokenMode && parsedSats !== null && (
-              <p className="mt-2 text-xs text-spark-text-muted">
-                ≈ <SatAmount sats={parsedSats} />
-              </p>
-            )}
           </div>
 
           {/* Quick amount buttons. Hidden while the native keyboard is

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -15,7 +15,8 @@ import {
 } from '../../utils/tokenFormatting';
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
 import { SatAmount } from '../../components/SatAmount';
-import { useAmountInput } from '../../hooks/useAmountInput';
+import { useAmountInput, useFiatOverride } from '../../hooks/useAmountInput';
+import { getFiatSettings } from '../../services/settings';
 import type { Sats } from '../../types/sats';
 import { dismissKeyboard } from '../../utils/keyboard';
 import { LIGHTNING_INVOICE_MIN_SATS, LIGHTNING_INVOICE_MAX_SATS } from '../../constants/receive';
@@ -53,7 +54,12 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   onClose,
   resetCount,
 }) => {
-  const input = useAmountInput();
+  // Fiat entry without a stable-balance token: the typed amount is converted to
+  // sats client-side (#356). Denominated in the currency at the top of the
+  // user's Settings list, the one the balance header opens on.
+  const input = useAmountInput({
+    fiatOverride: useFiatOverride(getFiatSettings().selectedCurrencies[0] ?? 'USD'),
+  });
   const {
     amountInput: displayAmount,
     setAmount,
@@ -61,7 +67,6 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     resetAmount,
     isTokenMode,
     toggleDenomination,
-    isStableBalanceActive,
     tokenSymbol,
     config,
     btcFiatRate,
@@ -179,7 +184,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
                 className="w-full bg-spark-dark border border-spark-border rounded-xl px-4 py-3 pr-16 text-spark-text-primary text-lg font-mono placeholder-spark-text-muted focus-within:border-spark-primary focus:outline-hidden transition-all resize-none"
                 data-testid="invoice-amount-input"
               />
-              {isStableBalanceActive && tokenSymbol && (
+              {tokenSymbol && (
                 <CurrencySwitcher
                   isTokenMode={isTokenMode}
                   tokenSymbol={tokenSymbol}
@@ -188,6 +193,14 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
                 />
               )}
             </div>
+            {/* The invoice is fixed in sats, converted off the last fetched
+                rate, so the fiat value it settles at can differ. The ≈ carries
+                that on its own. */}
+            {isTokenMode && parsedSats !== null && (
+              <p className="mt-2 text-xs text-spark-text-muted">
+                ≈ <SatAmount sats={parsedSats} />
+              </p>
+            )}
           </div>
 
           {/* Quick amount buttons. Hidden while the native keyboard is

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -8,7 +8,7 @@ import {
   formatQuickAmount,
 } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
-import { useAmountInput, useUsdFiatOverride } from '../../../hooks/useAmountInput';
+import { useAmountInput, useFiatOverride } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { useHasPendingConversion } from '../../../contexts/WalletContext';
 import { dismissKeyboard } from '../../../utils/keyboard';
@@ -41,7 +41,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
   // USD entry without a stable-balance token, funded from BTC. Cross-chain
   // ("Send USD", amountFirst) starts in USD; plain BTC sends start in sats
   // with USD as a toggleable secondary option (#253).
-  const fiatOverride = useUsdFiatOverride(amountFirst);
+  const fiatOverride = useFiatOverride('USD', amountFirst);
 
   const input = useAmountInput({ initialAmount: amount, balanceSats, tokenBalance, fiatOverride });
   const {

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -12,7 +12,7 @@ import {
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
 import { SatAmount } from '../../../components/SatAmount';
 import { formatWithSpaces } from '../../../utils/formatNumber';
-import { useAmountInput, useUsdFiatOverride } from '../../../hooks/useAmountInput';
+import { useAmountInput, useFiatOverride } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { useHasPendingConversion } from '../../../contexts/WalletContext';
 
@@ -30,7 +30,7 @@ interface LnurlWorkflowProps {
 const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, balanceSats, tokenBalance, onBack, onRun, onPrepare, onPay }) => {
   // USD as a secondary entry option on BTC sends (#253): starts in sats,
   // toggleable to USD, converted to sats client-side.
-  const fiatOverride = useUsdFiatOverride();
+  const fiatOverride = useFiatOverride();
   const input = useAmountInput({ balanceSats, tokenBalance, fiatOverride });
   const {
     amountInput: amount,

--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -20,21 +20,21 @@ export interface FiatOverride {
 }
 
 /**
- * USD fiat override for amount inputs, built from live fiat data. Lets a
- * BTC-balance user type dollars: the amount is converted to sats client-side.
+ * Fiat override for amount inputs, built from live fiat data. Lets a
+ * BTC-balance user type a fiat amount: it is converted to sats client-side.
  *
- * Returns undefined while the USD rate hasn't loaded, so callers offer no
- * fiat entry that can't parse. Exception: `startInFiat` flows (cross-chain
+ * Returns undefined while that currency's rate hasn't loaded, so callers offer
+ * no fiat entry that can't parse. Exception: `startInFiat` flows (cross-chain
  * "Send USD") are USD-denominated by design and must not fall back to sats
  * entry, so they keep the config even before the rate arrives.
  */
-export function useUsdFiatOverride(startInFiat = false): FiatOverride | undefined {
+export function useFiatOverride(currencyId = 'USD', startInFiat = false): FiatOverride | undefined {
   const { fiatCurrencies, fiatRates } = useFiatData();
   return useMemo(() => {
-    const btcFiatRate = fiatRates.find(r => r.coin === 'USD')?.value ?? 0;
+    const btcFiatRate = fiatRates.find(r => r.coin === currencyId)?.value ?? 0;
     if (!startInFiat && btcFiatRate <= 0) return undefined;
-    return { config: buildFiatDisplayConfig('USD', fiatCurrencies), btcFiatRate, startInFiat };
-  }, [startInFiat, fiatCurrencies, fiatRates]);
+    return { config: buildFiatDisplayConfig(currencyId, fiatCurrencies), btcFiatRate, startInFiat };
+  }, [currencyId, startInFiat, fiatCurrencies, fiatRates]);
 }
 
 export interface UseAmountInputOptions {

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -40,6 +40,7 @@ export const ALL_BUY_PROVIDERS: BuyBitcoinProvider[] = ['moonpay', 'cashApp'];
 
 const SETTINGS_KEY = 'user_settings_v1';
 const FIAT_SETTINGS_KEY = 'fiat_settings_v1';
+const ACTIVE_FIAT_KEY = 'fiat_active_currency';
 const BUY_PROVIDERS_KEY = 'buy_providers_v1';
 
 const defaultSettings: UserSettings = {
@@ -152,6 +153,23 @@ export function getFiatSettings(): FiatSettings {
 
 export function saveFiatSettings(settings: FiatSettings): void {
   setCachedItem(FIAT_SETTINGS_KEY, JSON.stringify(settings));
+}
+
+/**
+ * The fiat currency the balance header is showing: the one the user last
+ * cycled to, else the top of their list. Other fiat surfaces read this so
+ * they denominate in the same currency the balance does.
+ */
+export function getDisplayFiatCurrency(): string {
+  const { selectedCurrencies } = getFiatSettings();
+  const active = getCachedItem(ACTIVE_FIAT_KEY);
+  return active && selectedCurrencies.includes(active)
+    ? active
+    : (selectedCurrencies[0] ?? 'USD');
+}
+
+export function setDisplayFiatCurrency(currencyId: string): void {
+  setCachedItem(ACTIVE_FIAT_KEY, currencyId);
 }
 
 // Stable Balance disclaimer acceptance (one-time)


### PR DESCRIPTION
Closes #356

This PR lets you enter an invoice amount in your own currency. Before, the Create Invoice screen accepted satoshis only. To request $10, you had to calculate the satoshi amount yourself.

Tap the `₿` button in the amount field to change to your currency. Type the amount, and the app converts it to satoshis for the invoice. The currency is the first one in your Settings list, the same one your balance shows.

The app shows the converted amount below the field with an approximation sign, for example `≈ ₿12 500`. The exchange rate can change, so the amount is an estimate.

**Note:** The currency button shows only after the exchange rate loads.