### PR TITLE
fix: stop a stuck conversion status from disabling Send All (#367)

### DIFF
--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1,6 +1,27 @@
 import React, { createContext, useContext, useMemo } from 'react';
-import type { BreezSdk, GetInfoResponse } from '@breeztech/breez-sdk-spark';
+import type { BreezSdk, GetInfoResponse, Payment } from '@breeztech/breez-sdk-spark';
 import type { SdkEventHandler, SdkEventUnsubscribe } from '../hooks/useBreezSdk';
+
+/**
+ * How long a `pending` conversion status is trusted to mean "in flight".
+ * Matches the SDK's own deferred-conversion timeout.
+ */
+const PENDING_CONVERSION_MAX_AGE_SECS = 120;
+
+/**
+ * Whether a conversion is in flight right now, so balance-dependent actions
+ * (Send All) should wait for it to settle.
+ *
+ * Age-bounded because the status can be stranded: the SDK marks a payment
+ * `pending` when it queues a conversion, but skips the `completed` write when
+ * the conversion turns out to be a no-op (below the minimum, stable balance
+ * deactivated, already converted elsewhere). An unbounded check leaves Send All
+ * disabled for the life of that wallet's local storage (#367).
+ */
+export function hasConversionInFlight(payments: Payment[], nowSecs = Date.now() / 1000): boolean {
+  const cutoff = nowSecs - PENDING_CONVERSION_MAX_AGE_SECS;
+  return payments.some(p => p.conversionDetails?.status === 'pending' && p.timestamp >= cutoff);
+}
 
 type SubscribeToSdkEvents = (handler: SdkEventHandler) => SdkEventUnsubscribe;
 
@@ -104,8 +125,9 @@ export const useWalletInfo = (): GetInfoResponse | null => {
 
 /**
  * Returns true while an auto-conversion (or any payment-linked conversion) is
- * still pending. While true, the balance snapshot in `walletInfo` may be mid
- * flight: Send All flows should treat it as unsettled and gate the action.
+ * still in flight. While true, the balance snapshot in `walletInfo` may be mid
+ * flight: Send All flows should treat it as unsettled and gate the action. See
+ * `hasConversionInFlight` for why this is age-bounded.
  */
 export const useHasPendingConversion = (): boolean => {
   return useContext(WalletStatusContext).hasPendingConversion;

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -4,9 +4,10 @@ import type { SdkEventHandler, SdkEventUnsubscribe } from '../hooks/useBreezSdk'
 
 /**
  * How long a `pending` conversion status is trusted to mean "in flight".
- * Matches the SDK's own deferred-conversion timeout.
+ * Matches the SDK's `DEFAULT_CONVERSION_TIMEOUT_SECS`, the longest one
+ * conversion attempt may take. Observed attempts settle in under 10s.
  */
-const PENDING_CONVERSION_MAX_AGE_SECS = 120;
+const PENDING_CONVERSION_MAX_AGE_SECS = 30;
 
 /**
  * Whether a conversion is in flight right now, so balance-dependent actions

--- a/src/contexts/walletConversionStatus.test.ts
+++ b/src/contexts/walletConversionStatus.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import type { Payment } from '@breeztech/breez-sdk-spark';
+import { hasConversionInFlight } from './WalletContext';
+
+const NOW = 1_786_544_000;
+
+const payment = (timestamp: number, status?: 'pending' | 'completed'): Payment => ({
+  id: `p-${timestamp}`,
+  paymentType: 'receive',
+  status: 'completed',
+  amount: 1000n,
+  fees: 0n,
+  timestamp,
+  method: 'spark',
+  conversionDetails: status ? { status } : undefined,
+});
+
+describe('hasConversionInFlight', () => {
+  it('gates on a conversion that just started', () => {
+    expect(hasConversionInFlight([payment(NOW - 5, 'pending')], NOW)).toBe(true);
+  });
+
+  it('ignores a pending status the SDK stranded (#367)', () => {
+    expect(hasConversionInFlight([payment(NOW - 3600, 'pending')], NOW)).toBe(false);
+  });
+
+  it('ignores completed conversions and payments without one', () => {
+    expect(hasConversionInFlight([payment(NOW, 'completed'), payment(NOW)], NOW)).toBe(false);
+  });
+});

--- a/src/contexts/walletConversionStatus.test.ts
+++ b/src/contexts/walletConversionStatus.test.ts
@@ -20,6 +20,11 @@ describe('hasConversionInFlight', () => {
     expect(hasConversionInFlight([payment(NOW - 5, 'pending')], NOW)).toBe(true);
   });
 
+  it('still gates at the edge of the window', () => {
+    expect(hasConversionInFlight([payment(NOW - 29, 'pending')], NOW)).toBe(true);
+    expect(hasConversionInFlight([payment(NOW - 31, 'pending')], NOW)).toBe(false);
+  });
+
   it('ignores a pending status the SDK stranded (#367)', () => {
     expect(hasConversionInFlight([payment(NOW - 3600, 'pending')], NOW)).toBe(false);
   });

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -53,6 +53,7 @@ import {
 } from '../services/legacyMnemonicMigration';
 import { isSendSheetOpen } from '../features/send/sendSheetVisibility';
 import { clearPin, isAppLockSupported } from '../services/appLock';
+import { hasConversionInFlight } from '../contexts/WalletContext';
 
 
 // ============================================
@@ -242,9 +243,10 @@ export function useBreezSdk(
   const [transactions, setTransactions] = useState<Payment[]>([]);
   // Any payment in the latest snapshot that's still mid-conversion (e.g.
   // auto-conversion in flight after a receive). While true, balances are in
-  // motion and Send All flows shouldn't trust the snapshot.
+  // motion and Send All flows shouldn't trust the snapshot. Recomputed per
+  // snapshot, so the age bound clears on the next refresh rather than on a timer.
   const hasPendingConversion = useMemo(
-    () => transactions.some(p => p.conversionDetails?.status === 'pending'),
+    () => hasConversionInFlight(transactions),
     [transactions],
   );
   const [unclaimedDeposits, setUnclaimedDeposits] = useState<DepositInfo[]>([]);


### PR DESCRIPTION
Closes #367

The `Send All` button can become permanently unusable. It shows a spinner and does not react to taps. The user cannot send the full balance, and only a manually typed amount works. This affects the Lightning address send panel and the standard send panel.

`Send All` waits while the wallet converts your balance, because the balance is not final during a conversion. But the wallet can keep a conversion marked as unfinished after that conversion stops. `Send All` then waits forever. The mark is stored on one device, so the same wallet still works on another device.

This PR makes `Send All` wait for at most 30 seconds. A conversion normally completes in less than 10 seconds. After 30 seconds, `Send All` becomes usable again.

**Note:** The stuck mark comes from the SDK. See breez/spark-sdk#1052. This change stops the app from waiting on it.
