### PR TITLE
fix: offer to save any destination that resolves to a lightning address

### DIFF
--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -68,11 +68,21 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialRawInput]);
 
-  // Detect successful send to non-contact lightning address for save prompt
+  // A successful send to a lightning address that isn't a contact yet, for
+  // the save prompt. Keyed on whatever the destination RESOLVED to, not on
+  // how it was entered: an LNURL that names an address is the same
+  // recipient as the address typed by hand (#366). Hence the address comes
+  // off the parsed input rather than `rawInput`, which for an LNURL is the
+  // lnurl1... blob and for a `lightning:` URI carries a scheme prefix,
+  // neither of which a contact can be keyed on. A bare LNURL exposes only a
+  // domain, so it resolves to nothing saveable and prompts nothing.
   const lightningAddressForSave = useMemo(() => {
     if (send.paymentResult !== 'success') return undefined;
-    if (send.paymentInput?.parsedInput.type !== 'lightningAddress') return undefined;
-    const address = send.paymentInput.rawInput;
+    const parsed = send.paymentInput?.parsedInput;
+    const address = parsed?.type === 'lightningAddress' || parsed?.type === 'lnurlPay'
+      ? parsed.address
+      : undefined;
+    if (!address) return undefined;
     if (findContactByAddress(address)) return undefined;
     return address;
   }, [send.paymentResult, send.paymentInput, findContactByAddress]);

--- a/src/features/send/saveContactPrompt.test.tsx
+++ b/src/features/send/saveContactPrompt.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { BreezSdk, InputType } from '@breeztech/breez-sdk-spark';
+import { WalletProvider, WalletInfoProvider, WalletStatusProvider } from '@/contexts/WalletContext';
+import { ContactsProvider } from '@/contexts/ContactsContext';
+import { ToastProvider } from '@/contexts/ToastContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import SendPaymentDialog from './SendPaymentDialog';
+
+const ADDRESS = 'alice@example.com';
+const LNURL = 'lnurl1dp68gurn8ghj7ampd3kx2ar0veekzar0wd5xjtnrdakj7';
+
+function payRequest(address?: string) {
+  return {
+    callback: 'https://example.com/lnurl',
+    minSendable: 1000,
+    maxSendable: 100_000_000,
+    metadataStr: '[["text/plain","pay alice"]]',
+    commentAllowed: 0,
+    domain: 'example.com',
+    url: 'https://example.com/lnurl',
+    address,
+  };
+}
+
+/** Renders the sheet with `parse` pinned to one destination shape. */
+function renderSend(parsed: unknown, contacts: unknown[] = []) {
+  const client = createMockClient() as unknown as BreezSdk;
+  client.parse = vi.fn().mockResolvedValue(parsed as InputType);
+  client.listContacts = vi.fn().mockResolvedValue(contacts);
+  const onSuccessfulSend = vi.fn();
+
+  render(
+    <ToastProvider>
+      <WalletProvider client={client} isConnected>
+        <WalletInfoProvider walletInfo={{ balanceSats: 500_000 } as never}>
+          <WalletStatusProvider hasPendingConversion={false}>
+            <FiatDataProvider>
+              <StableBalanceProvider>
+                <ContactsProvider>
+                  <SendPaymentDialog isOpen onClose={vi.fn()} onSuccessfulSend={onSuccessfulSend} />
+                </ContactsProvider>
+              </StableBalanceProvider>
+            </FiatDataProvider>
+          </WalletStatusProvider>
+        </WalletInfoProvider>
+      </WalletProvider>
+    </ToastProvider>,
+  );
+
+  return { onSuccessfulSend };
+}
+
+/** Drives input -> amount -> confirm -> pay -> Done, the close that prompts. */
+async function payAndClose(input: string) {
+  fireEvent.change(await screen.findByTestId('payment-input'), { target: { value: input } });
+  fireEvent.click(screen.getByTestId('continue-button'));
+
+  fireEvent.change(await screen.findByPlaceholderText(/Between/i), { target: { value: '1000' } });
+  fireEvent.click(screen.getByText('Continue'));
+
+  fireEvent.click(await screen.findByTestId('send-confirm-button'));
+  await waitFor(() => expect(screen.getByTestId('payment-success')).toBeTruthy());
+
+  fireEvent.click(screen.getByText('Done'));
+}
+
+// The prompt keys on what the destination resolved to, so an LNURL naming an
+// address offers the save that the same address typed by hand does (#366).
+describe('save-as-contact prompt after a send', () => {
+  it('offers to save a lightning address', async () => {
+    const { onSuccessfulSend } = renderSend({
+      type: 'lightningAddress',
+      address: ADDRESS,
+      payRequest: payRequest(ADDRESS),
+    });
+
+    await payAndClose(ADDRESS);
+    expect(onSuccessfulSend).toHaveBeenCalledWith(ADDRESS);
+  });
+
+  it('offers to save an LNURL that resolves to a lightning address', async () => {
+    const { onSuccessfulSend } = renderSend({ type: 'lnurlPay', ...payRequest(ADDRESS) });
+
+    await payAndClose(LNURL);
+    expect(onSuccessfulSend).toHaveBeenCalledWith(ADDRESS);
+  });
+
+  it('saves the resolved address, not the raw input', async () => {
+    const { onSuccessfulSend } = renderSend({
+      type: 'lightningAddress',
+      address: ADDRESS,
+      payRequest: payRequest(ADDRESS),
+    });
+
+    // A `lightning:` URI resolves to the same recipient; the scheme prefix
+    // must not reach contacts, which are keyed on the bare address.
+    await payAndClose(`lightning:${ADDRESS}`);
+    expect(onSuccessfulSend).toHaveBeenCalledWith(ADDRESS);
+  });
+
+  it('stays quiet when the address is already a contact', async () => {
+    const { onSuccessfulSend } = renderSend(
+      { type: 'lnurlPay', ...payRequest(ADDRESS) },
+      [{ id: 'c1', name: 'Alice', paymentIdentifier: ADDRESS.toUpperCase() }],
+    );
+
+    await payAndClose(LNURL);
+    expect(onSuccessfulSend).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for a bare LNURL that resolves to no address', async () => {
+    const { onSuccessfulSend } = renderSend({ type: 'lnurlPay', ...payRequest(undefined) });
+
+    await payAndClose(LNURL);
+    expect(onSuccessfulSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #366.

The save-as-contact prompt keyed on how a destination was entered, so it only appeared for input the SDK parsed as `lightningAddress`. Paying the same recipient through an LNURL that names an address parsed as `lnurlPay` and offered nothing, even though the resulting contact would have been identical.

It now keys on what the destination resolved to:

```tsx
const address = parsed?.type === 'lightningAddress' || parsed?.type === 'lnurlPay'
  ? parsed.address
  : undefined;
```

Both variants carry `address`, so an LNURL naming `alice@example.com` offers the same save as that address typed by hand.

Reading the address off the parsed input rather than `rawInput` also closes a latent trap. `rawInput` is the `lnurl1...` blob for an LNURL, and keeps the scheme prefix for `lightning:alice@example.com`. Either would have been stored as a contact identifier that `findContactByAddress` could never match again, so the prompt would return on every subsequent payment to that recipient.

A bare LNURL exposes only a domain, resolves to no address, and still prompts nothing. Per discussion on the issue, that case is out of scope: contacts are keyed on a lightning address, and `ContactsSubView` rejects anything failing `isValidLightningAddress`.

## Testing

New `saveContactPrompt.test.tsx` drives the sheet through input, amount, confirm, pay, and the close that raises the prompt:

- lightning address offers the save
- LNURL resolving to a lightning address offers the save
- a `lightning:` URI saves the bare address, not the prefixed input
- an address already in contacts stays quiet (matched case-insensitively)
- a bare LNURL with no address stays quiet

`npx tsc --noEmit` clean, 199 tests across 32 files pass, `npm run lint` reports 0 errors (4 warnings, all pre-existing in files this branch does not touch).

## Not covered here

Bolt12 offers cannot be paid at all today, so there is no post-payment moment at which to offer saving one: entering one fails with "Invalid payment destination", and there are no `bolt12` references in `src/`. `Bolt12OfferDetails` also has no `address` field, so an offer does not resolve to a lightning address.

Spark address is the one destination type that is payable, reusable, and still unprompted. Extending the prompt to it needs the same contacts-model decisions as bolt12 (identifier validation, name defaulting, display), so it is left for a follow-up rather than folded in here.