### PR TITLE
fix: pay a scanned invoice that carries a "lightning:" prefix

### DIFF
--- a/src/features/send/hooks/useSendPayment.test.tsx
+++ b/src/features/send/hooks/useSendPayment.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { InputType } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { useSendPayment } from './useSendPayment';
+
+const BOLT11 = 'lnbc100n1test';
+
+/** Stands in for the SDK parser, which strips a `lightning:` prefix and reports
+ *  the bare invoice in the details it returns. */
+const bolt11Details = (input: string) =>
+  ({
+    type: 'bolt11Invoice',
+    invoice: { bolt11: input.replace(/^lightning:/i, '') },
+    amountMsat: 10000,
+  }) as unknown as InputType;
+
+function renderSendPayment(parse: (input: string) => Promise<InputType>) {
+  const client = createMockClient({ parse: vi.fn().mockImplementation(parse) } as never);
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WalletProvider client={client} isConnected>
+      <FiatDataProvider>
+        <StableBalanceProvider>{children}</StableBalanceProvider>
+      </FiatDataProvider>
+    </WalletProvider>
+  );
+  return { client, ...renderHook(() => useSendPayment(), { wrapper }) };
+}
+
+describe('processInput destinations', () => {
+  it('prepares a scanned `lightning:` invoice with the bare bolt11 (breez/glow-app#168)', async () => {
+    const { client, result } = renderSendPayment(async (input) => bolt11Details(input));
+
+    await act(() => result.current.processInput(`lightning:${BOLT11}`));
+
+    await waitFor(() =>
+      expect(client.prepareSendPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentRequest: { type: 'input', input: BOLT11 } }),
+      ),
+    );
+    // The field still shows what was scanned, so back-navigation is not surprising.
+    expect(result.current.paymentInput?.rawInput).toBe(`lightning:${BOLT11}`);
+  });
+
+  it('prepares a BIP21 URI with the address it wraps', async () => {
+    const address = 'bc1qtest';
+    const { client, result } = renderSendPayment(
+      async (uri) =>
+        ({
+          type: 'bip21',
+          uri,
+          amountSat: 1000,
+          paymentMethods: [{ type: 'bitcoinAddress', address }],
+        }) as unknown as InputType,
+    );
+
+    await act(() => result.current.processInput(`bitcoin:${address}?amount=0.00001`));
+
+    await waitFor(() =>
+      expect(client.prepareSendPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentRequest: { type: 'input', input: address } }),
+      ),
+    );
+  });
+});

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -1,11 +1,25 @@
 import { useState, useCallback, useMemo } from 'react';
-import type { PrepareSendPaymentResponse, FeePolicy, SendPaymentOptions, SdkEvent, ConversionOptions } from '@breeztech/breez-sdk-spark';
+import type { PrepareSendPaymentResponse, FeePolicy, SendPaymentOptions, SdkEvent, ConversionOptions, InputType } from '@breeztech/breez-sdk-spark';
 import type { SendInput } from '@/types/domain';
 import { useWallet, useWalletInfo } from '../../../contexts/WalletContext';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { getTokenBalance } from '../../../utils/tokenFormatting';
 import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
+
+/** The destination string inside a parsed input, or null for the types that
+ *  are paid through their own workflow rather than a prepared destination. */
+function bareDestination(parsed: InputType): string | null {
+  switch (parsed.type) {
+    case 'bolt11Invoice':
+      return parsed.invoice.bolt11;
+    case 'bitcoinAddress':
+    case 'sparkAddress':
+      return parsed.address;
+    default:
+      return null;
+  }
+}
 
 export type SendStep = 'input' | 'amount' | 'workflow' | 'processing' | 'result';
 export type ProcessingPhase = 'sending' | 'converting';
@@ -137,12 +151,8 @@ export function useSendPayment(): UseSendPaymentReturn {
       const parseResult = await wallet.parse(currentInput);
 
       // Unwrap a BIP21 URI (bitcoin:<addr>?amount=&label=) to its underlying
-      // payment method. `paymentRequest` becomes the bare address/invoice sent to
-      // prepareSendPayment (the URI itself isn't a valid send request), while
-      // `rawInput` keeps the original text so the input field still shows it on
-      // back-navigation. The URI amount (sats) is used as the exact send amount.
+      // payment method. The URI amount (sats) is used as the exact send amount.
       let effective = parseResult;
-      let paymentRequest = currentInput;
       let prefillAmountSat: number | undefined;
       if (parseResult.type === 'bip21') {
         const method = parseResult.paymentMethods.find(
@@ -154,13 +164,16 @@ export function useSendPayment(): UseSendPaymentReturn {
           return;
         }
         effective = method;
-        if (method.type === 'bolt11Invoice') {
-          paymentRequest = method.invoice.bolt11;
-        } else if (method.type === 'bitcoinAddress' || method.type === 'sparkAddress') {
-          paymentRequest = method.address;
-        }
         prefillAmountSat = parseResult.amountSat;
       }
+
+      // prepareSendPayment gets the bare destination the parser resolved, never
+      // the text it came in. The SDK parses what it is handed but then decodes
+      // the invoice from that same string, so a wrapper the parser accepts (a
+      // BIP21 URI, or the `lightning:` prefix a QR code carries) reaches the
+      // decoder and fails there (breez/glow-app#168). `rawInput` keeps the original text so
+      // the input field still shows it on back-navigation.
+      const paymentRequest = bareDestination(effective) ?? currentInput;
 
       const parsed: SendInput = { rawInput: currentInput, paymentRequest, parsedInput: effective };
       setPaymentInput(parsed);


### PR DESCRIPTION
Scanning a Lightning QR code that encodes `lightning:lnbc...` failed with a decoding error. The only way through was to go back, delete the prefix by hand, and submit again.

Glow was reading the destination straight out of the scanned text. The SDK accepts that prefix when it identifies what the input is, but it decodes the invoice from the same string it was handed, so the prefix reached the decoder and the payment never got started. Glow now passes on the destination the SDK resolved, the way it already did for Bitcoin URIs.

Pasted text and payment links opened from another app took the same path, so they are covered too.

Fixes breez/glow-app#168

## Test plan

- [ ] Scan a Lightning QR code that encodes the `lightning:` prefix and pay it. Needs a real device, since it is the camera path.
- [ ] Scan or paste a plain invoice, a Bitcoin URI with an amount, and a Lightning address, and confirm they still pay as before.