### PR TITLE
fix: use the auto-lock timeout you chose, and pause it on the screens you read

### DIFF
--- a/src/components/QrScannerDialog.tsx
+++ b/src/components/QrScannerDialog.tsx
@@ -3,6 +3,7 @@ import QrScanner from 'qr-scanner';
 import { BottomSheetContainer, FloatingIconButton } from './ui';
 import { useQrScanner } from '../hooks/useQrScanner';
 import { logger, LogCategory } from '@/services/logger';
+import { holdIdleLock } from '@/services/appLock';
 import { CameraFlipIcon, ImageIcon, AlertTriangleIcon } from './Icons';
 import { useLatest } from '../hooks/useLatest';
 
@@ -53,6 +54,14 @@ const QrScannerDialog: React.FC<QrScannerDialogProps> = ({ isOpen, onClose, onSc
     toggleCamera,
     clearError,
   } = useQrScanner({ onScan: handleScan });
+
+  // Aiming a camera produces no pointer or key events, so the idle
+  // timer would run to completion mid-scan and lock the screen the
+  // user is scanning with.
+  useEffect(() => {
+    if (!isOpen) return;
+    return holdIdleLock();
+  }, [isOpen]);
 
   // Use refs to avoid effect re-running when callbacks change
   const startScanningRef = useLatest(startScanning);

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   BottomSheetContainer,
   BottomSheetCard,
@@ -17,6 +17,7 @@ import { type BuyBitcoinProvider } from '../../services/settings';
 import { useToast } from '../../contexts/ToastContext';
 import { formatQuickAmount } from '../../utils/tokenFormatting';
 import { useBuyBitcoin } from './hooks/useBuyBitcoin';
+import { holdIdleLock } from '@/services/appLock';
 
 const providerMeta: Record<BuyBitcoinProvider, { name: string; icon: React.ReactNode; loadingIcon: React.ReactNode }> = {
   moonpay: {
@@ -75,6 +76,14 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
     onMobileRedirectComplete: onClose,
     onInvoicePaid: onClose,
   });
+
+  // The Cash App code is scanned by another device, so nobody touches
+  // this screen while it is up. Scoped to the QR step: picking a
+  // provider and entering an amount are both tapped through.
+  useEffect(() => {
+    if (!isOpen || buy.step !== 'qr') return;
+    return holdIdleLock();
+  }, [isOpen, buy.step]);
 
   const handleSelect = async (provider: BuyBitcoinProvider) => {
     await buy.selectProvider(provider);

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -24,6 +24,7 @@ import BitcoinAddressDisplay from './BitcoinAddressDisplay';
 import LightningAddressDisplay from './LightningAddressDisplay';
 import AmountPanel from './AmountPanel';
 import { ArrowDownIcon, LightningBoltIcon } from '../../components/Icons';
+import { setIdleLockSuppressed } from '@/services/appLock';
 
 interface ReceivePaymentDialogProps {
   isOpen: boolean;
@@ -90,6 +91,16 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
   // on the next frame while the sheet is already sliding up. Sticky —
   // once true, stays true for the session, so subsequent opens render
   // content immediately (no placeholder flash).
+  // Hold the foreground idle lock off while the sheet is up: a QR
+  // waiting to be scanned is exactly the case where nobody touches the
+  // screen. Keyed to `isOpen`, not to mount, because the sheet stays in
+  // the React tree across opens (see the deferral note below).
+  useEffect(() => {
+    if (!isOpen) return;
+    setIdleLockSuppressed(true);
+    return () => setIdleLockSuppressed(false);
+  }, [isOpen]);
+
   const [isContentReady, setIsContentReady] = useState(false);
   useEffect(() => {
     if (!isOpen || isContentReady) return;

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -24,7 +24,7 @@ import BitcoinAddressDisplay from './BitcoinAddressDisplay';
 import LightningAddressDisplay from './LightningAddressDisplay';
 import AmountPanel from './AmountPanel';
 import { ArrowDownIcon, LightningBoltIcon } from '../../components/Icons';
-import { setIdleLockSuppressed } from '@/services/appLock';
+import { holdIdleLock } from '@/services/appLock';
 
 interface ReceivePaymentDialogProps {
   isOpen: boolean;
@@ -97,8 +97,7 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
   // the React tree across opens (see the deferral note below).
   useEffect(() => {
     if (!isOpen) return;
-    setIdleLockSuppressed(true);
-    return () => setIdleLockSuppressed(false);
+    return holdIdleLock();
   }, [isOpen]);
 
   const [isContentReady, setIsContentReady] = useState(false);

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -17,6 +17,7 @@ import ProcessingStep from './steps/ProcessingStep';
 import ResultStep from './steps/ResultStep';
 import ContactsSubView from './components/ContactsSubView';
 import { setSendSheetOpen } from './sendSheetVisibility';
+import { holdIdleLock } from '@/services/appLock';
 import { PrepareLnurlPayRequest } from '@breeztech/breez-sdk-spark';
 import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
@@ -48,6 +49,14 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
     if (!isOpen) return;
     setSendSheetOpen(true);
     return () => setSendSheetOpen(false);
+  }, [isOpen]);
+
+  // Hold the idle lock while the sheet is up: reading the recipient and
+  // fee before confirming, and waiting out a payment in flight, are both
+  // untouched screens, and locking there strands a send half-finished.
+  useEffect(() => {
+    if (!isOpen) return;
+    return holdIdleLock();
   }, [isOpen]);
 
   // Parent (WalletPage) bumps `sendDialogSession` on every open and passes

--- a/src/hooks/useAppLock.ts
+++ b/src/hooks/useAppLock.ts
@@ -11,6 +11,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   clearPin,
+  getAutoLockSeconds,
   getAutoLockSecondsSync,
   isAppLockSupported,
   isBiometricGateEnabled,
@@ -62,7 +63,13 @@ export function useAppLock(): AppLockState {
     if (!isAppLockSupported()) return;
     let cancelled = false;
     void (async () => {
-      const [pin, gate] = await Promise.all([isPinEnabled(), isBiometricGateEnabled()]);
+      const [pin, gate] = await Promise.all([
+        isPinEnabled(),
+        isBiometricGateEnabled(),
+        // Read through to heal a stale or evicted auto-lock mirror
+        // before the idle timer arms against it.
+        getAutoLockSeconds(),
+      ]);
       if (cancelled) return;
       if (!pin) {
         setLocked(false);

--- a/src/hooks/useAppLock.ts
+++ b/src/hooks/useAppLock.ts
@@ -16,6 +16,7 @@ import {
   isAppLockSupported,
   isBiometricGateEnabled,
   isBiometricGateEnabledSync,
+  isIdleLockSuppressed,
   isPinEnabled,
   isPinEnabledSync,
   verifyPin,
@@ -146,6 +147,14 @@ export function useAppLock(): AppLockState {
       // takes the shortest real option instead.
       const seconds = getAutoLockSecondsSync() || 30;
       timer = setTimeout(() => {
+        // A suppressing screen is up (a receive QR mid-scan). Re-arm
+        // rather than lock, so the lock lands on the first expiry after
+        // it goes away instead of waiting for the user to touch
+        // something.
+        if (isIdleLockSuppressed()) {
+          arm();
+          return;
+        }
         setLocked(true);
         setBiometricGate(isBiometricGateEnabledSync());
       }, seconds * 1000);

--- a/src/services/appLock.test.ts
+++ b/src/services/appLock.test.ts
@@ -137,6 +137,18 @@ describe('appLock auto-lock timeout', () => {
     expect(appLock.getAutoLockSecondsSync()).toBe(600);
   });
 
+  it('heals an evicted mirror on the next async read', async () => {
+    const appLock = await loadAppLock(true);
+    await appLock.setAutoLockSeconds(3600);
+    // WebView storage eviction, or an install that chose a timeout
+    // before the mirror existed. The sync read silently means 2 minutes
+    // until something reads through to Preferences.
+    localStorage.clear();
+    expect(appLock.getAutoLockSecondsSync()).toBe(120);
+    await appLock.getAutoLockSeconds();
+    expect(appLock.getAutoLockSecondsSync()).toBe(3600);
+  });
+
   it('formats every dropdown option', async () => {
     const appLock = await loadAppLock(true);
     const labels = appLock.AUTO_LOCK_OPTIONS_SECONDS.map(appLock.formatAutoLockOption);

--- a/src/services/appLock.test.ts
+++ b/src/services/appLock.test.ts
@@ -159,6 +159,33 @@ describe('appLock auto-lock timeout', () => {
   });
 });
 
+describe('appLock idle-lock suppression', () => {
+  it('stays suppressed until every overlapping holder releases', async () => {
+    const appLock = await loadAppLock(true);
+    expect(appLock.isIdleLockSuppressed()).toBe(false);
+
+    // The scanner opening over the send sheet: the inner release must
+    // not cancel the outer hold.
+    const send = appLock.holdIdleLock();
+    const scanner = appLock.holdIdleLock();
+    scanner();
+    expect(appLock.isIdleLockSuppressed()).toBe(true);
+    send();
+    expect(appLock.isIdleLockSuppressed()).toBe(false);
+  });
+
+  it('ignores a second release from the same holder', async () => {
+    const appLock = await loadAppLock(true);
+    const receive = appLock.holdIdleLock();
+    const scanner = appLock.holdIdleLock();
+    receive();
+    receive();
+    expect(appLock.isIdleLockSuppressed()).toBe(true);
+    scanner();
+    expect(appLock.isIdleLockSuppressed()).toBe(false);
+  });
+});
+
 describe('appLock on web', () => {
   it('reports unsupported and disabled everywhere', async () => {
     const appLock = await loadAppLock(false);

--- a/src/services/appLock.ts
+++ b/src/services/appLock.ts
@@ -260,24 +260,33 @@ export function formatAutoLockOption(seconds: number): string {
 
 /**
  * Held on by screens meant to be looked at rather than touched: a
- * receive QR waiting to be scanned would otherwise lock mid-scan. Only
- * the foreground idle timer honours it, so backgrounding and cold start
- * still lock as usual. Module-level rather than context so the lock hook
- * reads it without a re-render coupling, the same shape as
- * `features/send/sendSheetVisibility.ts`.
+ * receive QR waiting to be scanned, a camera being aimed at someone
+ * else's code. Only the foreground idle timer honours it, so
+ * backgrounding and cold start still lock as usual. Module-level rather
+ * than context so the lock hook reads it without a re-render coupling,
+ * the same shape as `features/send/sendSheetVisibility.ts`.
  *
- * ponytail: a plain flag, with the receive sheet as its only holder. If
- * a second surface ever needs it, make it a counter, so overlapping
- * holders cannot release each other's suppression.
+ * A counter, not a flag: the scanner opens over the send sheet, so
+ * holders overlap, and the inner one's release would otherwise cancel
+ * the outer one's hold.
  */
-let idleLockSuppressed = false;
+let idleLockHolds = 0;
 
-export function setIdleLockSuppressed(suppressed: boolean): void {
-  idleLockSuppressed = suppressed;
+/** Suppress the foreground idle lock until the returned release runs.
+ *  Releasing twice is a no-op, so a double cleanup cannot drop another
+ *  holder's suppression. */
+export function holdIdleLock(): () => void {
+  idleLockHolds += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    idleLockHolds -= 1;
+  };
 }
 
 export function isIdleLockSuppressed(): boolean {
-  return idleLockSuppressed;
+  return idleLockHolds > 0;
 }
 
 // ============================================

--- a/src/services/appLock.ts
+++ b/src/services/appLock.ts
@@ -225,7 +225,12 @@ export function pinAttemptMessage(result: PinVerifyResult): string {
 export async function getAutoLockSeconds(): Promise<number> {
   const { value } = await Preferences.get({ key: AUTO_LOCK_KEY });
   const parsed = value == null ? NaN : parseInt(value, 10);
-  return Number.isFinite(parsed) ? parsed : DEFAULT_AUTO_LOCK_SECONDS;
+  const seconds = Number.isFinite(parsed) ? parsed : DEFAULT_AUTO_LOCK_SECONDS;
+  // Backfill the mirror for installs that chose a timeout before the
+  // mirror existed (and self-heal an evicted one). Every lock decision
+  // reads the mirror, so a missing one silently means 2 minutes.
+  mirrorSet(AUTO_LOCK_MIRROR_KEY, String(seconds));
+  return seconds;
 }
 
 /** Mirror-backed synchronous read for the foreground-return decision. */

--- a/src/services/appLock.ts
+++ b/src/services/appLock.ts
@@ -255,6 +255,32 @@ export function formatAutoLockOption(seconds: number): string {
 }
 
 // ============================================
+// Idle-lock suppression
+// ============================================
+
+/**
+ * Held on by screens meant to be looked at rather than touched: a
+ * receive QR waiting to be scanned would otherwise lock mid-scan. Only
+ * the foreground idle timer honours it, so backgrounding and cold start
+ * still lock as usual. Module-level rather than context so the lock hook
+ * reads it without a re-render coupling, the same shape as
+ * `features/send/sendSheetVisibility.ts`.
+ *
+ * ponytail: a plain flag, with the receive sheet as its only holder. If
+ * a second surface ever needs it, make it a counter, so overlapping
+ * holders cannot release each other's suppression.
+ */
+let idleLockSuppressed = false;
+
+export function setIdleLockSuppressed(suppressed: boolean): void {
+  idleLockSuppressed = suppressed;
+}
+
+export function isIdleLockSuppressed(): boolean {
+  return idleLockSuppressed;
+}
+
+// ============================================
 // Biometric gate flag
 // ============================================
 


### PR DESCRIPTION
Four follow-ups to the app lock in #364.

**Glow now uses the auto-lock time you selected.** Glow keeps a fast copy of your auto-lock setting so it can lock without waiting on a slow read. Some installs never got that copy, and a phone can also delete it when storage runs low. Glow then fell back to 2 minutes. If you selected 1 hour, the lock still came after 2 minutes. Glow now writes that copy again each time it starts.

**The lock waits while you show a QR code.** The idle lock could lock the screen while somebody was still scanning your receive QR code. The Receive sheet now holds the lock off while it is open, and the lock starts again as soon as you close the sheet.

**The lock also waits while you send.** The idle countdown only restarts when you touch the screen, so it ran to the end on any screen you were reading rather than tapping. Aiming the camera at somebody else's code, checking who you are paying and what the fee is before you confirm, and waiting for a payment to finish are all untouched screens, and locking there left a send half done. Sending now pauses the countdown the same way receiving does.

**And while you buy.** The Cash App code is scanned by another device, so that screen goes untouched for as long as the scan takes. Only that step pauses the countdown: picking a provider and entering an amount are both tapped through.

Glow still locks as usual whenever you leave the app or start it fresh, on every one of these screens. The pause only applies while Glow is open in front of you.

## Test plan

Needs a device. Set a PIN in Security, choose **30 seconds** as the auto-lock time, then:

- Pick **1 hour** instead, force-quit Glow, reopen it, and leave it idle for more than 2 minutes. It should not lock.
- Open Receive and leave the QR on screen without touching it. It should not lock.
- Open the scanner and hold it on a code without touching the screen. It should not lock.
- Start a send, stop on the confirmation screen and read it for a minute without touching. It should not lock.
- Open the scanner from inside the send sheet, close just the scanner, and keep waiting on the send screen. It should still not lock.
- Open Buy, pick Cash App, and leave the code on screen. It should not lock. Go back to the amount step and wait there. It **should** lock.
- From any of the above, leave Glow and come back. It should lock every time.

**Note:** all four changes are native only. Buy is stripped from iOS store builds, so that one is testable on Android and TestFlight betas.