### PR TITLE
fix: name the recipient a scanned LNURL resolves to

### DIFF
--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -23,7 +23,7 @@ import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
 import { ArrowUpIcon, ArrowDownIcon } from '@/components/Icons';
 import { useSendPayment } from './hooks/useSendPayment';
-import { getPaymentMethodName, getLnurlPayRequestDetails, getLnurlAuthRequestDetails, getLnurlWithdrawRequestDetails } from './utils';
+import { getPaymentMethodName, getLnurlPayRequestDetails, getSendLightningAddress, getLnurlAuthRequestDetails, getLnurlWithdrawRequestDetails } from './utils';
 
 interface SendPaymentDialogProps {
   isOpen: boolean;
@@ -79,18 +79,15 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
 
   // A successful send to a lightning address that isn't a contact yet, for
   // the save prompt. Keyed on whatever the destination RESOLVED to, not on
-  // how it was entered: an LNURL that names an address is the same
-  // recipient as the address typed by hand (#366). Hence the address comes
-  // off the parsed input rather than `rawInput`, which for an LNURL is the
-  // lnurl1... blob and for a `lightning:` URI carries a scheme prefix,
-  // neither of which a contact can be keyed on. A bare LNURL exposes only a
-  // domain, so it resolves to nothing saveable and prompts nothing.
+  // how it was entered: a scanned LNURL and the same address typed by hand
+  // are one recipient (#366). Hence the address comes off the parsed input
+  // rather than `rawInput`, which for an LNURL is the lnurl1... blob and for
+  // a `lightning:` URI carries a scheme prefix, neither of which a contact
+  // can be keyed on. Shares one resolver with the confirm step's display, so
+  // the address that was shown is the address that gets saved.
   const lightningAddressForSave = useMemo(() => {
     if (send.paymentResult !== 'success') return undefined;
-    const parsed = send.paymentInput?.parsedInput;
-    const address = parsed?.type === 'lightningAddress' || parsed?.type === 'lnurlPay'
-      ? parsed.address
-      : undefined;
+    const address = getSendLightningAddress(send.paymentInput);
     if (!address) return undefined;
     if (findContactByAddress(address)) return undefined;
     return address;
@@ -114,9 +111,13 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
     ? 'Send BTC or USD'
     : getPaymentMethodName(send.paymentInput);
 
+  // Same resolver as the save prompt, so a scanned LNURL names its recipient
+  // (and matches an existing contact) instead of reading as an opaque blob.
+  // `rawInput` would carry a `lightning:` prefix into both the label and the
+  // contact lookup, which then misses.
   const recipientLabel = useMemo(() => {
-    if (send.paymentInput?.parsedInput.type !== 'lightningAddress') return undefined;
-    const address = send.paymentInput.rawInput;
+    const address = getSendLightningAddress(send.paymentInput);
+    if (!address) return undefined;
     const contact = findContactByAddress(address);
     return contact ? `Pay to ${contact.name}` : `Pay to ${address}`;
   }, [send.paymentInput, findContactByAddress]);

--- a/src/features/send/saveContactPrompt.test.tsx
+++ b/src/features/send/saveContactPrompt.test.tsx
@@ -111,6 +111,76 @@ describe('save-as-contact prompt after a send', () => {
     expect(onSuccessfulSend).not.toHaveBeenCalled();
   });
 
+  // A scanned QR yields a bech32 blob with no `address`, which is the case
+  // QA hit: the confirm step showed the bare domain and nothing was offered.
+  it('offers to save a scanned LNURL whose address is only in metadata', async () => {
+    const { onSuccessfulSend } = renderSend({
+      type: 'lnurlPay',
+      ...payRequest(undefined),
+      metadataStr: '[["text/plain","Tips"],["text/identifier","alice@example.com"]]',
+    });
+
+    await payAndClose(LNURL);
+    expect(onSuccessfulSend).toHaveBeenCalledWith(ADDRESS);
+  });
+
+  it('shows the resolved address on the confirm step, not the domain', async () => {
+    renderSend({
+      type: 'lnurlPay',
+      ...payRequest(undefined),
+      metadataStr: '[["text/identifier","alice@example.com"]]',
+    });
+
+    fireEvent.change(await screen.findByTestId('payment-input'), { target: { value: LNURL } });
+    fireEvent.click(screen.getByTestId('continue-button'));
+    fireEvent.change(await screen.findByPlaceholderText(/Between/i), { target: { value: '1000' } });
+    fireEvent.click(screen.getByText('Continue'));
+
+    const destination = await screen.findByTestId('send-destination');
+    expect(destination.textContent).toBe(ADDRESS);
+  });
+
+  it('falls back to the domain when the LNURL is not an address', async () => {
+    renderSend({ type: 'lnurlPay', ...payRequest(undefined) });
+
+    fireEvent.change(await screen.findByTestId('payment-input'), { target: { value: LNURL } });
+    fireEvent.click(screen.getByTestId('continue-button'));
+    fireEvent.change(await screen.findByPlaceholderText(/Between/i), { target: { value: '1000' } });
+    fireEvent.click(screen.getByText('Continue'));
+
+    const destination = await screen.findByTestId('send-destination');
+    expect(destination.textContent).toBe('example.com');
+  });
+
+  it('names the recipient on the amount step of a scanned LNURL', async () => {
+    renderSend({
+      type: 'lnurlPay',
+      ...payRequest(undefined),
+      metadataStr: '[["text/plain","Tips"],["text/identifier","alice@example.com"]]',
+    });
+
+    fireEvent.change(await screen.findByTestId('payment-input'), { target: { value: LNURL } });
+    fireEvent.click(screen.getByTestId('continue-button'));
+
+    expect(await screen.findByText(`Pay to ${ADDRESS}`)).toBeTruthy();
+  });
+
+  it('names an existing contact when a scanned LNURL resolves to one', async () => {
+    renderSend(
+      {
+        type: 'lnurlPay',
+        ...payRequest(undefined),
+        metadataStr: '[["text/identifier","alice@example.com"]]',
+      },
+      [{ id: 'c1', name: 'Alice', paymentIdentifier: ADDRESS }],
+    );
+
+    fireEvent.change(await screen.findByTestId('payment-input'), { target: { value: LNURL } });
+    fireEvent.click(screen.getByTestId('continue-button'));
+
+    expect(await screen.findByText('Pay to Alice')).toBeTruthy();
+  });
+
   it('stays quiet for a bare LNURL that resolves to no address', async () => {
     const { onSuccessfulSend } = renderSend({ type: 'lnurlPay', ...payRequest(undefined) });
 

--- a/src/features/send/utils.test.ts
+++ b/src/features/send/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { SendPaymentMethod } from '@breeztech/breez-sdk-spark';
-import { getSendDestination } from './utils';
+import { getSendDestination, getLnurlPayAddress } from './utils';
 
 // Only the fields getSendDestination reads; the rest of each variant is noise here.
 const method = (m: unknown) => m as SendPaymentMethod;
@@ -29,6 +29,56 @@ describe('getSendDestination', () => {
         recipientAddress: 'a',
       });
       expect(getSendDestination(m).label).toBeTruthy();
+    }
+  });
+});
+
+// A scanned lnurl1... blob has no `address`, so the lightning address it
+// belongs to has to come from LUD-16 metadata or not at all (#366).
+describe('getLnurlPayAddress', () => {
+  const details = (over: Record<string, unknown>) => ({
+    callback: 'https://breez.tips/cb',
+    minSendable: 1000,
+    maxSendable: 100_000_000,
+    metadataStr: '[["text/plain","Tips"]]',
+    commentAllowed: 0,
+    domain: 'breez.tips',
+    url: 'https://breez.tips/.well-known/lnurlp/alice',
+    ...over,
+  }) as unknown as Parameters<typeof getLnurlPayAddress>[0];
+
+  it('prefers the parsed address when the SDK resolved one', () => {
+    expect(getLnurlPayAddress(details({
+      address: 'alice@breez.tips',
+      metadataStr: '[["text/identifier","bob@breez.tips"]]',
+    }))).toBe('alice@breez.tips');
+  });
+
+  it('recovers the address from a text/identifier entry', () => {
+    expect(getLnurlPayAddress(details({
+      metadataStr: '[["text/plain","Tips"],["text/identifier","alice@breez.tips"]]',
+    }))).toBe('alice@breez.tips');
+  });
+
+  it('recovers the address from a text/email entry', () => {
+    expect(getLnurlPayAddress(details({
+      metadataStr: '[["text/email","alice@breez.tips"]]',
+    }))).toBe('alice@breez.tips');
+  });
+
+  it('returns undefined for an LNURL that is not a lightning address', () => {
+    expect(getLnurlPayAddress(details({}))).toBeUndefined();
+  });
+
+  it('rejects an identifier that contacts would not accept', () => {
+    expect(getLnurlPayAddress(details({
+      metadataStr: '[["text/identifier","not an address"]]',
+    }))).toBeUndefined();
+  });
+
+  it('survives metadata from a hostile host', () => {
+    for (const metadataStr of ['not json', '{}', '[42]', '[["text/identifier"]]', '[["text/identifier",7]]', 'null']) {
+      expect(getLnurlPayAddress(details({ metadataStr }))).toBeUndefined();
     }
   });
 });

--- a/src/features/send/utils.ts
+++ b/src/features/send/utils.ts
@@ -1,4 +1,5 @@
 import type { SendInput } from '@/types/domain';
+import { isValidLightningAddress } from '@/hooks/useContacts';
 import type { LnurlPayRequestDetails, LnurlAuthRequestDetails, LnurlWithdrawRequestDetails, SendPaymentMethod } from '@breeztech/breez-sdk-spark';
 
 /** Who a prepared payment pays, for the confirm step. Read from the prepare
@@ -51,6 +52,44 @@ export function getLnurlPayRequestDetails(input: SendInput | null): LnurlPayRequ
     return input.parsedInput.payRequest;
   }
   return null;
+}
+
+/** The lightning address an LNURL-pay endpoint belongs to, when there is one.
+ *
+ *  `address` is populated only when the SDK parsed a `user@domain` input, so a
+ *  scanned lnurl1... blob arrives without it and the address has to come from
+ *  the LUD-16 `text/identifier` / `text/email` metadata entry the host
+ *  publishes. `undefined` means this endpoint is not a lightning address (a
+ *  plain tipping LNURL), so callers show the domain and offer no contact. */
+export function getLnurlPayAddress(details: LnurlPayRequestDetails): string | undefined {
+  if (details.address) return details.address;
+  // metadataStr comes from a third-party host, so an unguarded parse here
+  // throws during render and takes the whole tree down with it.
+  try {
+    const entries: unknown = JSON.parse(details.metadataStr);
+    if (!Array.isArray(entries)) return undefined;
+    for (const entry of entries) {
+      if (!Array.isArray(entry)) continue;
+      if (entry[0] !== 'text/identifier' && entry[0] !== 'text/email') continue;
+      // Validated against the same predicate the contacts form uses, so a
+      // recovered identifier is never one contacts would then reject.
+      if (typeof entry[1] === 'string' && isValidLightningAddress(entry[1])) return entry[1];
+    }
+  } catch {
+    // Malformed metadata: nothing to recover.
+  }
+  return undefined;
+}
+
+/** The lightning address a destination resolves to, whichever form it was
+ *  entered in: typed, `lightning:` prefixed, or a scanned LNURL. One rule for
+ *  every caller, so the address the confirm step shows is the one offered as a
+ *  contact. `undefined` for destinations that are not lightning addresses. */
+export function getSendLightningAddress(input: SendInput | null): string | undefined {
+  const parsed = input?.parsedInput;
+  if (parsed?.type === 'lightningAddress') return parsed.address;
+  if (parsed?.type === 'lnurlPay') return getLnurlPayAddress(parsed);
+  return undefined;
 }
 
 export function getLnurlAuthRequestDetails(input: SendInput | null): LnurlAuthRequestDetails | null {

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -15,6 +15,7 @@ import { formatWithSpaces } from '../../../utils/formatNumber';
 import { useAmountInput, useFiatOverride } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { useHasPendingConversion } from '../../../contexts/WalletContext';
+import { getLnurlPayAddress } from '../utils';
 
 interface LnurlWorkflowProps {
   parsed: LnurlPayRequestDetails;
@@ -242,7 +243,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
       ? BigInt(prepareResponse.amountSats)
       : BigInt(balance.parseInputToSats(amount) || 0);
     return (
-      <ConfirmStep amountSats={confirmAmountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} destination={{ label: 'To', value: parsed.address ?? parsed.domain }} error={error} isLoading={isLoading} onBack={() => { setPrepareResponse(null); setError(null); setStep('amount'); }} onConfirm={onConfirm} />
+      <ConfirmStep amountSats={confirmAmountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} destination={{ label: 'To', value: getLnurlPayAddress(parsed) ?? parsed.domain }} error={error} isLoading={isLoading} onBack={() => { setPrepareResponse(null); setError(null); setStep('amount'); }} onConfirm={onConfirm} />
     );
   }
 


### PR DESCRIPTION
Follow-up to #374: scanning a destination still offered no save-as-contact prompt, and the confirm step showed a bare domain (`breez.tips`) instead of the address.

One cause. A scanned QR is a bech32 `lnurl1...` blob, and the SDK sets `address` only when it parsed a `user@domain` input. With no address, the confirm step fell back to the domain and the prompt had nothing to offer. Typing the address worked, which is why #374 looked complete.

LUD-16 has the host publish the identifier in its metadata, so recover the address from the `text/identifier` / `text/email` entry when the parse has none. Validated with `isValidLightningAddress`, so a recovered address is never one the contacts form would reject.

`getSendLightningAddress` now backs all three call sites (save prompt, confirm-step destination, recipient label), so the address shown is the address saved. The recipient label was not in the report but had the same defect: it read `rawInput`, so a `lightning:` prefix broke the contact lookup and a known recipient did not show by name.

An LNURL that is not a lightning address has no identifier to find. It still shows its domain and offers no contact.

## Testing

`getLnurlPayAddress`: parse `address` wins over metadata, recovery from both entry types, `undefined` for a non-address LNURL, rejected invalid identifier, and six malformed `metadataStr` inputs (that string is third-party, and an unguarded parse during render takes down the tree).

Sheet-level, scanned path: prompt fires with the recovered address, confirm step shows address not domain, amount step names the recipient, existing contact named, non-address LNURL unchanged. The two confirm-step assertions fail on `main`.

`tsc` clean, 215 tests across 33 files pass, lint 0 errors.

## Note for QA

This only works when the host publishes an identifier. If that `breez.tips` QR has no `text/identifier` in its metadata, it will still show `breez.tips` and offer no contact, because there is no lightning address in the payload. Worth checking the scanned payload to tell the two apart.