### PR TITLE
fix: let you select and copy the transaction ID, invoice and preimage

### DIFF
--- a/src/components/PaymentDetailsDialog.tsx
+++ b/src/components/PaymentDetailsDialog.tsx
@@ -159,7 +159,6 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
                 value={dest.recipientAddress}
                 isVisible={visibleFields.recipientAddress}
                 onToggle={() => toggleField('recipientAddress')}
-                copyable
               />
             )}
 
@@ -307,8 +306,6 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
                   isVisible={visibleFields.txId}
                   onToggle={() => toggleField('txId')}
                   href={explorerTxUrl(payment.details.txId)}
-                  copyable
-                  shareable
                 />
               </div>
             )}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -205,74 +205,32 @@ export const CollapsibleCodeField: React.FC<{
   value: string;
   isVisible: boolean;
   onToggle: () => void;
-  /** Tapping the value opens this URL. */
+  /** Adds a button that opens this URL. */
   href?: string;
-  /** Show a copy button next to the value. */
-  copyable?: boolean;
-  /** Show a share button next to the value. */
-  shareable?: boolean;
-}> = ({ label, value, isVisible, onToggle, href, copyable, shareable }) => {
-  const [copied, setCopied] = React.useState(false);
-  const handleCopy = () => {
-    copyToClipboard(value)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      })
-      .catch(err => {
-        logger.error(LogCategory.UI, 'Failed to copy to clipboard', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
-  };
-  const logFailure = (message: string) => (err: unknown) => {
-    logger.error(LogCategory.UI, message, {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  };
-  return (
-    <CollapsibleSection label={label} isVisible={isVisible} onToggle={onToggle}>
-      <div className="flex items-start gap-2">
-        <div className="overflow-x-auto flex-1 min-w-0">
-          {href ? (
-            <button
-              onClick={() => openExternalUrl(href).catch(logFailure('Failed to open link'))}
-              className="font-mono text-xs break-all text-left flex items-start gap-1 group"
-              aria-label={`Open ${label}`}
-            >
-              <span className="text-spark-text-secondary">{value}</span>
-              <ExternalLinkIcon className="w-3.5 h-3.5 shrink-0 text-spark-primary opacity-70 group-hover:opacity-100 transition-opacity" />
-            </button>
-          ) : (
-            <code className="text-spark-text-secondary font-mono text-xs break-all">
-              {value}
-            </code>
-          )}
-        </div>
-        {copyable && (
-          <button
-            onClick={handleCopy}
-            className="shrink-0 p-1 rounded-md hover:bg-white/5 transition-colors"
-            aria-label={`Copy ${label}`}
-          >
-            {copied
-              ? <CheckIcon size="sm" className="text-spark-success" />
-              : <CopyFilledIcon size="sm" className="text-spark-text-secondary" />}
-          </button>
-        )}
-        {shareable && canShare() && (
-          <button
-            onClick={() => shareText(label, value).catch(logFailure('Failed to share'))}
-            className="shrink-0 p-1 rounded-md hover:bg-white/5 transition-colors"
-            aria-label={`Share ${label}`}
-          >
-            <ShareIcon size="sm" className="text-spark-text-secondary" />
-          </button>
-        )}
-      </div>
-    </CollapsibleSection>
-  );
-};
+}> = ({ label, value, isVisible, onToggle, href }) => (
+  <CollapsibleSection label={label} isVisible={isVisible} onToggle={onToggle}>
+    <div className="flex items-start gap-2">
+      {/* Selectable rather than copy/share buttons: the value is the point of
+          the row, and the OS selection menu already copies and shares it. */}
+      <code className="flex-1 min-w-0 text-spark-text-secondary font-mono text-xs break-all select-text">
+        {value}
+      </code>
+      {href && (
+        <button
+          onClick={() => openExternalUrl(href).catch(err => {
+            logger.error(LogCategory.UI, 'Failed to open link', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          })}
+          className="shrink-0 p-1 rounded-md hover:bg-white/5 transition-colors group"
+          aria-label={`Open ${label}`}
+        >
+          <ExternalLinkIcon className="w-3.5 h-3.5 text-spark-primary opacity-70 group-hover:opacity-100 transition-opacity" />
+        </button>
+      )}
+    </div>
+  </CollapsibleSection>
+);
 
 // ============================================
 // TEXT COMPONENTS

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -256,8 +256,6 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                           isVisible={expandedTxIds[txKey] || false}
                           onToggle={() => setExpandedTxIds(prev => ({ ...prev, [txKey]: !prev[txKey] }))}
                           href={explorerTxUrl(dep.txid)}
-                          copyable
-                          shareable
                         />
 
                         {isRefunded && refundedTxId && (
@@ -267,8 +265,6 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                             isVisible={expandedTxIds[refundKey] || false}
                             onToggle={() => setExpandedTxIds(prev => ({ ...prev, [refundKey]: !prev[refundKey] }))}
                             href={explorerTxUrl(refundedTxId)}
-                            copyable
-                            shareable
                           />
                         )}
                       </div>
@@ -485,8 +481,6 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                       isVisible={isTxIdVisible}
                       onToggle={() => setIsTxIdVisible(prev => !prev)}
                       href={explorerTxUrl(refundTxId)}
-                      copyable
-                      shareable
                     />
                   </PaymentInfoCard>
                 )}

--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -146,8 +146,6 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
               isVisible={isTxIdVisible}
               onToggle={() => setIsTxIdVisible(prev => !prev)}
               href={explorerTxUrl(deposit.txid)}
-              copyable
-              shareable
             />
           </PaymentInfoCard>
 


### PR DESCRIPTION
The transaction ID row had a copy button and a share button, and the value itself was a link. You could not select the text.

The value is now plain selectable text, and only the button that opens the block explorer stays next to it. The system selection menu gives you copy and share.

This applies to every code field: the invoice, the payment preimage, the destination public key, the recipient address, and the transaction IDs on the refund and unclaimed deposit pages.

Closes #382
