### PR TITLE
fix: do not celebrate a conversion between USD and BTC

### DIFF
--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -54,6 +54,7 @@ import {
 import { isSendSheetOpen } from '../features/send/sendSheetVisibility';
 import { clearPin, isAppLockSupported } from '../services/appLock';
 import { hasConversionInFlight } from '../contexts/WalletContext';
+import { isConversionPayment } from '../utils/paymentDescription';
 
 
 // ============================================
@@ -359,11 +360,9 @@ export function useBreezSdk(
         setTimeout(() => shownPaymentIdsRef.current.delete(paymentId), 30000);
 
         const isReceived = event.payment.paymentType === 'receive';
-        const hasConversionInfo = event.payment.details &&
-          'conversionInfo' in event.payment.details &&
-          event.payment.details.conversionInfo != null;
+        const isConversion = isConversionPayment(event.payment);
 
-        if (!hasConversionInfo && isReceived && !isMigrationInProgress()) {
+        if (!isConversion && isReceived && !isMigrationInProgress()) {
           setCelebrationPayment(event.payment);
         }
         // A send normally reports itself through the sheet's ResultStep, so
@@ -371,7 +370,7 @@ export function useBreezSdk(
         // the SDK call outlives it, and an unreported SUCCESS is the
         // dangerous direction: the user assumes it failed and sends again.
         // Reuse the same celebration when the sheet is no longer on screen.
-        if (!hasConversionInfo && !isReceived && !isSendSheetOpen() && !isMigrationInProgress()) {
+        if (!isConversion && !isReceived && !isSendSheetOpen() && !isMigrationInProgress()) {
           setCelebrationPayment(event.payment);
         }
       }

--- a/src/utils/paymentDescription.test.ts
+++ b/src/utils/paymentDescription.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import type { Payment } from '@breeztech/breez-sdk-spark';
+import { isConversionPayment } from './paymentDescription';
+
+const payment = (over: Partial<Payment>): Payment => ({
+  id: 'p1',
+  paymentType: 'receive',
+  status: 'completed',
+  amount: 1000n,
+  fees: 0n,
+  timestamp: 0,
+  method: 'lightning',
+  ...over,
+} as Payment);
+
+describe('isConversionPayment', () => {
+  it('is false for a plain receive', () => {
+    expect(isConversionPayment(payment({
+      details: { type: 'lightning', invoice: 'lnbc1', destinationPubkey: 'pk', htlcDetails: {} },
+    } as Partial<Payment>))).toBe(false);
+  });
+
+  it('is true for a cross-chain leg carrying conversionInfo', () => {
+    expect(isConversionPayment(payment({
+      details: { type: 'spark', conversionInfo: { type: 'amm', poolId: 'x', conversionId: 'c', status: 'completed' } },
+    } as Partial<Payment>))).toBe(true);
+  });
+
+  // The stable-balance case: the parent carries only conversionDetails.
+  it('is true for a conversion parent carrying only conversionDetails', () => {
+    expect(isConversionPayment(payment({
+      details: { type: 'spark' },
+      conversionDetails: { status: 'completed' },
+    } as Partial<Payment>))).toBe(true);
+  });
+});

--- a/src/utils/paymentDescription.ts
+++ b/src/utils/paymentDescription.ts
@@ -29,6 +29,15 @@ const isCrossChain = (convInfo: ReturnType<typeof getConversionInfo>) =>
 export const isCrossChainPayment = (payment: Payment): boolean =>
   isCrossChain(getConversionInfo(payment.details));
 
+/**
+ * Whether a payment is part of a conversion rather than money arriving or
+ * leaving. Cross-chain legs carry `conversionInfo`, while an AMM /
+ * stable-balance swap marks only the parent with `conversionDetails` and
+ * leaves the info to its child legs.
+ */
+export const isConversionPayment = (payment: Payment): boolean =>
+  getConversionInfo(payment.details) != null || payment.conversionDetails != null;
+
 /** Truncate text to maxLen characters, appending "..." if shortened */
 const truncate = (text: string, maxLen: number): string =>
   text.length > maxLen ? `${text.slice(0, maxLen)}…` : text;


### PR DESCRIPTION
The celebration screen showed after a conversion from USD to BTC. A conversion moves your own money, so a celebration is not correct.

The check looked only at `conversionInfo`. The SDK puts that field on the child steps of a conversion, while the parent carries `conversionDetails`. A stable balance conversion thus passed the check.

The celebration now skips a payment that carries either field.

**Note:** this does not explain the full report. The tester saw the celebration only on the first conversion after a restart, and nothing found here is specific to a restart. Please test again before you close the issue.

Refs #378
