### PR TITLE
fix: let you select the code fields in the native app

### DIFF
--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -211,8 +211,11 @@ export const CollapsibleCodeField: React.FC<{
   <CollapsibleSection label={label} isVisible={isVisible} onToggle={onToggle}>
     <div className="flex items-start gap-2">
       {/* Selectable rather than copy/share buttons: the value is the point of
-          the row, and the OS selection menu already copies and shares it. */}
-      <code className="flex-1 min-w-0 text-spark-text-secondary font-mono text-xs break-all select-text">
+          the row, and the OS selection menu already copies and shares it.
+          The WebKit properties are not redundant with `select-text`: Tailwind
+          emits `user-select` unprefixed only, which the WKWebView ignores, and
+          a WebView withholds long-press selection until the page asks. */}
+      <code className="flex-1 min-w-0 text-spark-text-secondary font-mono text-xs break-all select-text [-webkit-touch-callout:default] [-webkit-user-select:text]">
         {value}
       </code>
       {href && (


### PR DESCRIPTION
The code fields became selectable text in #383, but the change worked only on the web. In the native app you still could not select them.

Tailwind writes `user-select` without the WebKit prefix. The WebView of the native app ignores the unprefixed property, and it also holds back long-press selection on read-only text until the page asks for it. A browser selects the text anyway, which is why the web test passed.

The code fields now set `-webkit-user-select: text` and `-webkit-touch-callout: default` as well. The built CSS carries all three properties:

```
user-select:text
-webkit-user-select:text
-webkit-touch-callout:default
```

## Test

In a native build, long-press a transaction ID and use the system copy. Check the invoice, the preimage, the destination public key, the recipient address, and the IDs on the refund and unclaimed deposit pages.

Refs #382
