### PR TITLE
Priority deposit claim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5051,9 +5051,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5363,15 +5363,15 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
-      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
-        "pg-protocol": "^1.15.0",
+        "pg-protocol": "^1.16.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -5425,9 +5425,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
-      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
       "license": "MIT",
       "optional": true
     },

--- a/src/components/FeeBreakdownCard.tsx
+++ b/src/components/FeeBreakdownCard.tsx
@@ -11,6 +11,8 @@ export interface FeeBreakdownItem {
   value: number | bigint | string;
   unit?: string;
   highlight?: boolean;
+  /** Marker set before the amount, e.g. "~" for a figure that is estimated. */
+  prefix?: string;
 }
 
 export interface FeeBreakdownCardProps {
@@ -48,6 +50,7 @@ export const FeeBreakdownCard: React.FC<FeeBreakdownCardProps> = ({
               {item.label}
             </span>
             <span className={`font-mono text-sm ${item.highlight ? 'font-bold text-spark-primary' : 'text-spark-text-primary'}`}>
+              {item.prefix}
               {useRawStrings || typeof item.value === 'string'
                 ? String(item.value)
                 : Number(item.value) === 0 ? '0' : <SatAmount sats={item.value} />

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -21,7 +21,7 @@ import { buildConnectConfig } from './buildConnectConfig';
 import { logger, LogCategory, logSdkMessage } from '../services/logger';
 import { formatError } from '../utils/formatError';
 import { isStandalonePwa, openExternalUrl } from '../utils/externalLink';
-import { INSTANT_CLAIM_SUBMITTED_TOAST, splitClaimedDeposits } from '../utils/depositClaimQuote';
+import { INSTANT_CLAIM_SUBMITTED_TOAST, forgetAnnouncedClaims, splitClaimedDeposits, takeUnannouncedClaims } from '../utils/depositClaimQuote';
 import { isDepositRejected, clearRejectedDeposits } from '../services/depositState';
 import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, ensureSparkPrivateMode, isDevMode, type BuyBitcoinProvider } from '../services/settings';
 import { wipeAllLocalData } from '../services/accountDeletion';
@@ -396,11 +396,16 @@ export function useBreezSdk(
       // An instant (0-conf) claim fires this event on submission, before the
       // funds are credited, so it can't share the settled copy.
       const { submitted, settled } = splitClaimedDeposits(event.claimedDeposits);
-      logger.info(LogCategory.PAYMENT, 'Deposits claimed', { settled, submitted });
+      const announcing = takeUnannouncedClaims(submitted);
+      logger.info(LogCategory.PAYMENT, 'Deposits claimed', {
+        settled,
+        submitted: submitted.length,
+        announcing: announcing.length,
+      });
       if (settled > 0) {
         showToastRef.current('success', 'Deposits Claimed Successfully', `${settled} deposits were claimed`);
       }
-      if (submitted > 0) {
+      if (announcing.length > 0) {
         showToastRef.current('success', INSTANT_CLAIM_SUBMITTED_TOAST.title, INSTANT_CLAIM_SUBMITTED_TOAST.detail);
       }
       refreshWalletData(false);
@@ -640,6 +645,7 @@ export function useBreezSdk(
     clearStableRestorePrompted();
     clearRejectedDeposits();
     shownPaymentIdsRef.current.clear();
+    forgetAnnouncedClaims();
     setIsConnected(false);
     setIsSyncing(false);
     setWalletInfo(null);
@@ -682,6 +688,7 @@ export function useBreezSdk(
     setPasskeyMode(label, SHARED_RP_ID ?? defaultRpId);
     markLabelUsed(label);
     shownPaymentIdsRef.current.clear();
+    forgetAnnouncedClaims();
     setCelebrationPayment(null);
 
     try {
@@ -758,6 +765,7 @@ export function useBreezSdk(
     setCachedStableTicker(null);
     clearStableRestorePrompted();
     shownPaymentIdsRef.current.clear();
+    forgetAnnouncedClaims();
 
     if (secureStorage.isSupported()) {
       try {
@@ -909,6 +917,7 @@ export function useBreezSdk(
     setCachedStableTicker(null);
     clearStableRestorePrompted();
     shownPaymentIdsRef.current.clear();
+    forgetAnnouncedClaims();
     setIsLoading(false);
   }, [sdk]);
 

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -21,6 +21,7 @@ import { buildConnectConfig } from './buildConnectConfig';
 import { logger, LogCategory, logSdkMessage } from '../services/logger';
 import { formatError } from '../utils/formatError';
 import { isStandalonePwa, openExternalUrl } from '../utils/externalLink';
+import { INSTANT_CLAIM_SUBMITTED_TOAST, splitClaimedDeposits } from '../utils/depositClaimQuote';
 import { isDepositRejected, clearRejectedDeposits } from '../services/depositState';
 import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, ensureSparkPrivateMode, isDevMode, type BuyBitcoinProvider } from '../services/settings';
 import { wipeAllLocalData } from '../services/accountDeletion';
@@ -55,7 +56,6 @@ import { isSendSheetOpen } from '../features/send/sendSheetVisibility';
 import { clearPin, isAppLockSupported } from '../services/appLock';
 import { hasConversionInFlight } from '../contexts/WalletContext';
 import { isConversionPayment } from '../utils/paymentDescription';
-
 
 // ============================================
 // Payment filtering
@@ -393,8 +393,16 @@ export function useBreezSdk(
         showToastRef.current('error', 'Payment Failed', 'The payment did not go through. Your funds were not sent.');
       }
     } else if (event.type === 'claimedDeposits') {
-      logger.info(LogCategory.PAYMENT, 'Deposits claimed', { count: event.claimedDeposits.length });
-      showToastRef.current('success', 'Deposits Claimed Successfully', `${event.claimedDeposits.length} deposits were claimed`);
+      // An instant (0-conf) claim fires this event on submission, before the
+      // funds are credited, so it can't share the settled copy.
+      const { submitted, settled } = splitClaimedDeposits(event.claimedDeposits);
+      logger.info(LogCategory.PAYMENT, 'Deposits claimed', { settled, submitted });
+      if (settled > 0) {
+        showToastRef.current('success', 'Deposits Claimed Successfully', `${settled} deposits were claimed`);
+      }
+      if (submitted > 0) {
+        showToastRef.current('success', INSTANT_CLAIM_SUBMITTED_TOAST.title, INSTANT_CLAIM_SUBMITTED_TOAST.detail);
+      }
       refreshWalletData(false);
       fetchUnclaimedDeposits();
     } else if (event.type === 'unclaimedDeposits') {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -410,7 +410,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
             </div>
           )}
 
-          {/* Priority Deposit Claim (temporary, while the feature is tested) */}
+          {/* TEMPORARY: the dev gate for the priority deposit claim, removed at launch. */}
           {isDevMode && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
               <div className="flex items-center justify-between gap-3">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -75,6 +75,9 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     if (typeof cfg.lnurlDomain === 'string') return cfg.lnurlDomain;
     return '';
   });
+  const [priorityDepositClaim, setPriorityDepositClaim] = useState<boolean>(
+    () => getSettings().priorityDepositClaimEnabled === true,
+  );
   const [preferSparkOverLightning, setPreferSparkOverLightning] = useState<boolean>(() => {
     const s = getSettings();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK config type doesn't expose all fields
@@ -132,6 +135,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
             syncIntervalSecs: syncIntervalSecs !== '' ? Math.max(0, Math.floor(Number(syncIntervalSecs))) : undefined,
             lnurlDomain: lnurlDomain !== '' ? lnurlDomain : undefined,
             preferSparkOverLightning,
+            priorityDepositClaimEnabled: priorityDepositClaim,
           }
         : {}),
     };
@@ -401,6 +405,22 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                 <Switch
                   checked={preferSparkOverLightning}
                   onChange={() => setPreferSparkOverLightning(!preferSparkOverLightning)}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Priority Deposit Claim (temporary, while the feature is tested) */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <span className="font-display font-medium text-spark-text-primary block">Priority deposit claim</span>
+                  <span className="text-sm text-spark-text-muted">Offer to claim a transfer before it confirms, for a fee</span>
+                </div>
+                <Switch
+                  checked={priorityDepositClaim}
+                  onChange={() => setPriorityDepositClaim(!priorityDepositClaim)}
                 />
               </div>
             </div>

--- a/src/pages/UnclaimedDepositDetailsPage.test.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.test.tsx
@@ -1,12 +1,29 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ComponentProps } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { BreezSdk, DepositInfo, FetchClaimDepositQuoteResponse } from '@breeztech/breez-sdk-spark';
 import { WalletProvider } from '@/contexts/WalletContext';
 import { ToastProvider } from '@/contexts/ToastContext';
 import { createMockClient } from '@/test/mocks/mockWalletApi';
 import { saveSettings } from '@/services/settings';
-import { CLAIM_SUBMITTED_LINE } from '@/utils/depositClaimQuote';
+import { CLAIM_SUBMITTED_LINE, forgetAnnouncedClaims, takeUnannouncedClaims } from '@/utils/depositClaimQuote';
 import UnclaimedDepositDetailsPage from './UnclaimedDepositDetailsPage';
+
+type SubscribeToSdkEvents = NonNullable<ComponentProps<typeof WalletProvider>['subscribeToSdkEvents']>;
+type SdkEventHandler = Parameters<SubscribeToSdkEvents>[0];
+
+/** Captures the sheet's event handler so a test can drive a sync itself. */
+function eventStream() {
+  const handlers = new Set<SdkEventHandler>();
+  const subscribe: SubscribeToSdkEvents = h => {
+    handlers.add(h);
+    return () => handlers.delete(h);
+  };
+  return {
+    subscribe,
+    emitSynced: () => handlers.forEach(h => h({ type: 'synced' } as Parameters<SdkEventHandler>[0])),
+  };
+}
 
 function depositWithFee(requiredFeeSats: number): DepositInfo {
   return {
@@ -95,16 +112,12 @@ function quote(overrides: Partial<FetchClaimDepositQuoteResponse> = {}): FetchCl
   };
 }
 
-function renderSheet(deposit: DepositInfo, client?: BreezSdk) {
+function renderSheet(deposit: DepositInfo, client?: BreezSdk, subscribeToSdkEvents?: SubscribeToSdkEvents) {
   const onChanged = vi.fn();
   const mockClient = client ?? createMockClient();
-  if (!vi.mocked(mockClient.fetchClaimDepositQuote)?.mock) {
-    (mockClient as unknown as { fetchClaimDepositQuote: unknown }).fetchClaimDepositQuote =
-      vi.fn().mockResolvedValue(quote());
-  }
   render(
     <ToastProvider>
-      <WalletProvider client={mockClient} isConnected>
+      <WalletProvider client={mockClient} isConnected subscribeToSdkEvents={subscribeToSdkEvents}>
         <UnclaimedDepositDetailsPage deposit={deposit} onBack={vi.fn()} onChanged={onChanged} />
       </WalletProvider>
     </ToastProvider>
@@ -143,8 +156,9 @@ function setPriorityClaim(enabled: boolean) {
 
 function withQuote(q: FetchClaimDepositQuoteResponse | Error) {
   const client = createMockClient();
-  (client as unknown as { fetchClaimDepositQuote: unknown }).fetchClaimDepositQuote =
-    q instanceof Error ? vi.fn().mockRejectedValue(q) : vi.fn().mockResolvedValue(q);
+  const quoting = vi.mocked(client.fetchClaimDepositQuote);
+  if (q instanceof Error) quoting.mockRejectedValue(q);
+  else quoting.mockResolvedValue(q);
   // The deposit stays listed: an empty list means it was claimed elsewhere, and
   // the sheet rightly stands down on that rather than reporting a failure.
   vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({ deposits: [makeDeposit()] });
@@ -153,6 +167,7 @@ function withQuote(q: FetchClaimDepositQuoteResponse | Error) {
 
 beforeEach(() => {
   localStorage.clear();
+  forgetAnnouncedClaims();
   // The choice sits behind a dev setting while it is being tested, so the suite
   // below opts in. The gate itself is covered separately.
   setPriorityClaim(true);
@@ -206,6 +221,168 @@ describe('a confirming deposit with both routes on offer', () => {
     expect(feeRow('Network fee')).toContain('~');
   });
 
+  it('re-prices when a block lands, so the route unlocks without reopening', async () => {
+    const client = withQuote(quote({ confirmations: 0 }));
+    const stream = eventStream();
+    renderSheet(makeDeposit(), client, stream.subscribe);
+
+    // Early unlocks at depth 1, and the deposit is at 0: nothing to claim yet.
+    await screen.findByText('Priority');
+    expect(screen.getByText('Waiting for 1 confirmation.')).toBeInTheDocument();
+
+    vi.mocked(client.fetchClaimDepositQuote).mockResolvedValue(quote({ confirmations: 1 }));
+    stream.emitSynced();
+
+    await waitFor(() => expect(screen.queryByText('Waiting for 1 confirmation.')).toBeNull());
+    expect(button('Claim now')).toBeEnabled();
+  });
+
+  it('does not re-price under a claim already sent', async () => {
+    const client = withQuote(quote());
+    const stream = eventStream();
+    // Never settles: the claim stays in flight for the whole test.
+    vi.mocked(client.claimDeposit).mockReturnValue(new Promise(() => {}));
+    renderSheet(makeDeposit(), client, stream.subscribe);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+    await screen.findByText('Processing...');
+    const quotesBefore = vi.mocked(client.fetchClaimDepositQuote).mock.calls.length;
+
+    stream.emitSynced();
+    await waitFor(() => expect(screen.getByText('Processing...')).toBeInTheDocument());
+    expect(vi.mocked(client.fetchClaimDepositQuote).mock.calls).toHaveLength(quotesBefore);
+  });
+
+  it('stands down when background sync claims the deposit under the sheet', async () => {
+    const client = withQuote(quote());
+    const stream = eventStream();
+    const { onChanged } = renderSheet(makeDeposit(), client, stream.subscribe);
+    await screen.findByText('Priority');
+
+    // Claimed elsewhere: it has left the unclaimed set entirely.
+    vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({ deposits: [] });
+    stream.emitSynced();
+
+    // Closing is the honest move: the routes on screen no longer apply.
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('surfaces a refused automatic claim when the deposit matures under the sheet', async () => {
+    const client = withQuote(quote());
+    const stream = eventStream();
+    renderSheet(makeDeposit(), client, stream.subscribe);
+    await screen.findByText('Priority');
+
+    // It matures with the sheet open and the automatic claim trips the ceiling.
+    vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
+      deposits: [makeDeposit({
+        isMature: true,
+        claimError: {
+          type: 'maxDepositClaimFeeExceeded',
+          tx: 'a'.repeat(64), vout: 0,
+          requiredFeeSats: 512, requiredFeeRateSatPerVbyte: 4,
+        },
+      })],
+    });
+    stream.emitSynced();
+
+    await waitFor(() => expect(button('Approve')).toBeInTheDocument());
+    expect(screen.getByText('Network fee').parentElement).toHaveTextContent('512');
+    // The approve panel owns the sheet: no route button still offering a claim.
+    expect(queryButton('Claim now')).toBeNull();
+  });
+
+  it('does not let a sync re-announce a claim the sheet already toasted', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockResolvedValue({});
+    const { onChanged } = renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+
+    // Sync reports the same outpoint as submitted; it is no longer news.
+    expect(takeUnannouncedClaims([makeDeposit()])).toEqual([]);
+  });
+
+  it('does not re-read under an approval already sent', async () => {
+    const client = withQuote(quote());
+    const stream = eventStream();
+    renderSheet(makeDeposit(), client, stream.subscribe);
+    await screen.findByText('Priority');
+
+    vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
+      deposits: [makeDeposit({
+        isMature: true,
+        claimError: {
+          type: 'maxDepositClaimFeeExceeded',
+          tx: 'a'.repeat(64), vout: 0,
+          requiredFeeSats: 512, requiredFeeRateSatPerVbyte: 4,
+        },
+      })],
+    });
+    stream.emitSynced();
+    await waitFor(() => expect(button('Approve')).toBeInTheDocument());
+
+    vi.mocked(client.claimDeposit).mockReturnValue(new Promise(() => {}));
+    fireEvent.click(button('Approve'));
+    await screen.findByText('Processing...');
+    const readsBefore = vi.mocked(client.listUnclaimedDeposits).mock.calls.length;
+
+    stream.emitSynced();
+    await waitFor(() => expect(screen.getByText('Processing...')).toBeInTheDocument());
+    expect(vi.mocked(client.listUnclaimedDeposits).mock.calls).toHaveLength(readsBefore);
+  });
+
+  it('keeps the last good quote when a re-price fails', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('network unreachable'));
+    // Prices once on open, then the re-quote behind the failed claim fails too.
+    vi.mocked(client.fetchClaimDepositQuote)
+      .mockResolvedValueOnce(quote())
+      .mockRejectedValue(new Error('quote unavailable'));
+    renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+    await screen.findByText('network unreachable');
+    // The options came from the first quote and still describe the deposit.
+    expect(queryButton(/^Priority/)).not.toBeNull();
+    expect(queryButton(/^Standard/)).not.toBeNull();
+  });
+
+  it('leaves a deposit at maturity depth to the automatic claim', async () => {
+    // Deep enough for Standard, which is not the user's to commit: the SDK
+    // claims it at maturity, so offering a button would only race that.
+    renderSheet(makeDeposit(), withQuote(quote({ confirmations: 3 })));
+
+    await screen.findByText('Standard');
+    fireEvent.click(button(/^Standard/));
+    expect(screen.getByText('This transfer will be claimed automatically.')).toBeInTheDocument();
+    expect(queryButton(/^Claim/)).toBeNull();
+  });
+
+  it('still commits the early route itself', async () => {
+    renderSheet(makeDeposit(), withQuote(quote({ confirmations: 3 })));
+
+    await screen.findByText('Priority');
+    expect(button('Claim now')).toBeEnabled();
+    expect(screen.queryByText('This transfer will be claimed automatically.')).toBeNull();
+  });
+
+  it('reports a claim already in flight as submitted, not as a failure', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(
+      new Error('deposit claim in progress for a...a:0'),
+    );
+    vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
+      deposits: [makeDeposit({ instantClaimStatus: { type: 'submitted', claimId: 'c' } })],
+    });
+    renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+    await screen.findByText(CLAIM_SUBMITTED_LINE);
+    expect(screen.queryByText(/in progress/)).toBeNull();
+  });
+
   it('drops the previous route failure when the other is chosen', async () => {
     const client = withQuote(quote());
     vi.mocked(client.claimDeposit).mockRejectedValue(new Error('network unreachable'));
@@ -217,6 +394,24 @@ describe('a confirming deposit with both routes on offer', () => {
     fireEvent.click(screen.getByText('Standard'));
     // It priced the route that is no longer selected.
     expect(screen.queryByText('network unreachable')).not.toBeInTheDocument();
+  });
+
+  it('drops the previous route re-price when the other is chosen', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('Max deposit claim fee exceeded'));
+    vi.mocked(client.fetchClaimDepositQuote)
+      .mockResolvedValueOnce(quote())
+      .mockResolvedValue(quote({
+        instant: { confirmationsRequired: 1, creditAmountSats: 91_000, feeSats: 9_000,
+          feeRateSatPerVbyte: 9, isEstimate: false },
+      }));
+    renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+    await screen.findByText('Fee changed');
+
+    fireEvent.click(button(/^Standard/));
+    expect(screen.queryByText('Fee changed')).not.toBeInTheDocument();
   });
 
   it('defaults to the early route and prices the breakdown against it', async () => {
@@ -325,8 +520,14 @@ describe('a deposit the provider will not front', () => {
     renderSheet(makeDeposit(), withQuote(noEarly));
 
     await screen.findByText('Priority');
-    expect(button(/^Priority/)).toBeDisabled();
+    // aria-disabled rather than disabled, so it still reads as a route that
+    // exists and is unavailable instead of vanishing from the group.
+    expect(button(/^Priority/)).toHaveAttribute('aria-disabled', 'true');
     expect(button(/^Priority/)).toHaveTextContent('Not available');
+    // Still inert: tapping it must not steal the selection from Standard.
+    fireEvent.click(button(/^Priority/));
+    expect(button(/^Priority/)).toHaveAttribute('aria-checked', 'false');
+    expect(button(/^Standard/)).toHaveAttribute('aria-checked', 'true');
     // Waiting is still priced, so the screen says what the claim will cost.
     expect(button(/^Standard/)).toHaveTextContent('198');
     expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198');
@@ -369,6 +570,23 @@ describe('a claim already in flight', () => {
     expect(screen.queryByText('Priority')).not.toBeInTheDocument();
     // No point pricing a deposit whose claim is already settling.
     expect(client.fetchClaimDepositQuote).not.toHaveBeenCalled();
+  });
+
+  it('withdraws the options when a sync reports the claim as submitted', async () => {
+    const client = withQuote(quote());
+    const stream = eventStream();
+    renderSheet(makeDeposit(), client, stream.subscribe);
+    await screen.findByText('Priority');
+
+    vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
+      deposits: [makeDeposit({ instantClaimStatus: { type: 'submitted', claimId: 'c' } })],
+    });
+    stream.emitSynced();
+
+    // The quote is still loaded: only the in-flight status hides the choice.
+    await screen.findByText(CLAIM_SUBMITTED_LINE);
+    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+    expect(queryButton(/^Claim/)).toBeNull();
   });
 
   it('still reports it once the deposit confirms, the SDK skipping it either way', () => {

--- a/src/pages/UnclaimedDepositDetailsPage.test.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.test.tsx
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import type { BreezSdk, DepositInfo } from '@breeztech/breez-sdk-spark';
+import type { BreezSdk, DepositInfo, FetchClaimDepositQuoteResponse } from '@breeztech/breez-sdk-spark';
 import { WalletProvider } from '@/contexts/WalletContext';
+import { ToastProvider } from '@/contexts/ToastContext';
 import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { saveSettings } from '@/services/settings';
+import { CLAIM_SUBMITTED_LINE } from '@/utils/depositClaimQuote';
 import UnclaimedDepositDetailsPage from './UnclaimedDepositDetailsPage';
 
 function depositWithFee(requiredFeeSats: number): DepositInfo {
@@ -64,5 +67,367 @@ describe('when the failure is not a fee change', () => {
     fireEvent.click(screen.getByText('Approve'));
     await waitFor(() => expect(screen.getByText('Network error: timed out')).toBeInTheDocument());
     expect(screen.queryByText('Approve')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Early claiming, against the unified claim API.
+// ---------------------------------------------------------------------------
+
+function makeDeposit(overrides: Partial<DepositInfo> = {}): DepositInfo {
+  return { txid: 'a'.repeat(64), vout: 0, amountSats: 100_000, isMature: false, ...overrides } as DepositInfo;
+}
+
+/** A quote offering both routes, early claimable at `confirmations`. */
+function quote(overrides: Partial<FetchClaimDepositQuoteResponse> = {}): FetchClaimDepositQuoteResponse {
+  return {
+    amountSats: 100_000,
+    confirmations: 1,
+    instant: {
+      confirmationsRequired: 1, creditAmountSats: 96_800, feeSats: 3_200,
+      feeRateSatPerVbyte: 4, isEstimate: false,
+    },
+    mature: {
+      confirmationsRequired: 3, creditAmountSats: 99_802, feeSats: 198,
+      feeRateSatPerVbyte: 2, isEstimate: true,
+    },
+    ...overrides,
+  };
+}
+
+function renderSheet(deposit: DepositInfo, client?: BreezSdk) {
+  const onChanged = vi.fn();
+  const mockClient = client ?? createMockClient();
+  if (!vi.mocked(mockClient.fetchClaimDepositQuote)?.mock) {
+    (mockClient as unknown as { fetchClaimDepositQuote: unknown }).fetchClaimDepositQuote =
+      vi.fn().mockResolvedValue(quote());
+  }
+  render(
+    <ToastProvider>
+      <WalletProvider client={mockClient} isConnected>
+        <UnclaimedDepositDetailsPage deposit={deposit} onBack={vi.fn()} onChanged={onChanged} />
+      </WalletProvider>
+    </ToastProvider>
+  );
+  return { onChanged, client: mockClient };
+}
+
+// react-modal-sheet's container leaves the whole sheet out of happy-dom's
+// accessibility tree, which empties every accessible name, so `getByRole` with
+// a name matches nothing here even with `hidden: true`. Match on button text
+// instead: a role query that always returns null would pass the negative
+// assertions below for the wrong reason.
+function matchingButtons(name: string | RegExp): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll('button')).filter(b => {
+    const text = (b.textContent ?? '').replace(/\s+/g, ' ').trim();
+    return typeof name === 'string' ? text === name : name.test(text);
+  });
+}
+const queryButton = (name: string | RegExp) => matchingButtons(name)[0] ?? null;
+function button(name: string | RegExp): HTMLButtonElement {
+  const found = queryButton(name);
+  if (!found) {
+    const present = Array.from(document.querySelectorAll('button')).map(b => b.textContent);
+    throw new Error(`No button matching ${name}. Present: ${JSON.stringify(present)}`);
+  }
+  return found;
+}
+
+/** The temporary dev setting that gates the priority claim. */
+function setPriorityClaim(enabled: boolean) {
+  saveSettings({
+    depositMaxFee: { type: 'rate', satPerVbyte: 1 },
+    priorityDepositClaimEnabled: enabled,
+  });
+}
+
+function withQuote(q: FetchClaimDepositQuoteResponse | Error) {
+  const client = createMockClient();
+  (client as unknown as { fetchClaimDepositQuote: unknown }).fetchClaimDepositQuote =
+    q instanceof Error ? vi.fn().mockRejectedValue(q) : vi.fn().mockResolvedValue(q);
+  // The deposit stays listed: an empty list means it was claimed elsewhere, and
+  // the sheet rightly stands down on that rather than reporting a failure.
+  vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({ deposits: [makeDeposit()] });
+  return client;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // The choice sits behind a dev setting while it is being tested, so the suite
+  // below opts in. The gate itself is covered separately.
+  setPriorityClaim(true);
+});
+
+describe('a confirming deposit with both routes on offer', () => {
+  it('prices both without being asked, the quote being a pure read', async () => {
+    const client = withQuote(quote());
+    renderSheet(makeDeposit(), client);
+
+    await waitFor(() => expect(client.fetchClaimDepositQuote).toHaveBeenCalledWith({
+      txid: 'a'.repeat(64), vout: 0,
+    }));
+    expect(await screen.findByText('Priority')).toBeInTheDocument();
+    expect(screen.getByText('Standard')).toBeInTheDocument();
+  });
+
+  it('shows what each route costs and how long it takes', async () => {
+    renderSheet(makeDeposit(), withQuote(quote()));
+
+    await screen.findByText('Priority');
+    // Early is claimable at the current depth; maturity is 2 blocks out.
+    expect(button(/^Priority/)).toHaveTextContent('Now');
+    expect(button(/^Standard/)).toHaveTextContent('~20 min');
+    expect(button(/^Standard/)).toHaveTextContent('198');
+  });
+
+  it('says nothing about waiting, the options and button speaking for it', async () => {
+    renderSheet(makeDeposit(), withQuote(quote()));
+
+    await screen.findByText('Priority');
+    expect(screen.queryByText(/Waiting for/)).not.toBeInTheDocument();
+  });
+
+  it('marks the estimated fee and leaves the quoted one bare', async () => {
+    renderSheet(makeDeposit(), withQuote(quote()));
+
+    await screen.findByText('Priority');
+    // The provider will not quote maturity before a deposit matures.
+    expect(button(/^Standard/).textContent).toContain('~');
+    expect(button(/^Priority/).textContent).not.toContain('~');
+  });
+
+  it('carries the estimate marker into the breakdown, which reprices too', async () => {
+    renderSheet(makeDeposit(), withQuote(quote()));
+
+    await screen.findByText('Priority');
+    const feeRow = (label: string) => screen.getByText(label).parentElement?.textContent ?? '';
+    expect(feeRow('Priority fee')).not.toContain('~');
+    fireEvent.click(button(/^Standard/));
+    expect(feeRow('Network fee')).toContain('~');
+  });
+
+  it('drops the previous route failure when the other is chosen', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('network unreachable'));
+    renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+    await screen.findByText('network unreachable');
+
+    fireEvent.click(screen.getByText('Standard'));
+    // It priced the route that is no longer selected.
+    expect(screen.queryByText('network unreachable')).not.toBeInTheDocument();
+  });
+
+  it('defaults to the early route and prices the breakdown against it', async () => {
+    renderSheet(makeDeposit(), withQuote(quote()));
+
+    await screen.findByText('Priority');
+    expect(screen.getByText('Priority fee').parentElement).toHaveTextContent('3 200');
+    expect(screen.getByText('You receive').parentElement).toHaveTextContent('96 800');
+  });
+
+  it('reprices the breakdown when the other route is chosen', async () => {
+    renderSheet(makeDeposit(), withQuote(quote()));
+
+    fireEvent.click(await screen.findByText('Standard'));
+
+    expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198');
+    expect(screen.getByText('You receive').parentElement).toHaveTextContent('99 802');
+  });
+
+  it('claims at a ceiling that covers the chosen route', async () => {
+    const client = withQuote(quote());
+    renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+
+    await waitFor(() => expect(client.claimDeposit).toHaveBeenCalled());
+    // Below the quoted fee the SDK declines the route and waits for maturity.
+    expect(vi.mocked(client.claimDeposit).mock.calls[0][0]).toEqual({
+      txid: 'a'.repeat(64), vout: 0, maxFee: { type: 'fixed', amount: 3_200 },
+    });
+  });
+
+  it('announces an early claim, which settles asynchronously', async () => {
+    const client = withQuote(quote());
+    // No payment: claimed early, so nothing else reports it.
+    vi.mocked(client.claimDeposit).mockResolvedValue({});
+    const { onChanged } = renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+
+    expect(await screen.findByText('Claim Submitted')).toBeInTheDocument();
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+});
+
+describe('a fee that rises between quoting and claiming', () => {
+  const risen = () => quote({
+    instant: {
+      confirmationsRequired: 1, creditAmountSats: 95_400, feeSats: 4_600,
+      feeRateSatPerVbyte: 6, isEstimate: false,
+    },
+  });
+
+  it('explains the rise instead of the raw decline, and reprices', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('early claim was declined'));
+    vi.mocked(client.fetchClaimDepositQuote)
+      .mockResolvedValueOnce(quote())
+      .mockResolvedValue(risen());
+    renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+
+    expect(await screen.findByText('Fee changed')).toBeInTheDocument();
+    expect(screen.getByText('Claim again to accept the new fee.')).toBeInTheDocument();
+    // The card says it better than the SDK's message, so that stays off screen.
+    expect(screen.queryByText(/early claim was declined/)).not.toBeInTheDocument();
+    // The new figure lives in the breakdown, which has repriced.
+    expect(screen.getByText('Priority fee').parentElement).toHaveTextContent('4 600');
+  });
+
+  it('keeps the raw error when the fee is not what failed', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('network unreachable'));
+    renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+
+    expect(await screen.findByText('network unreachable')).toBeInTheDocument();
+    expect(screen.queryByText('Fee changed')).not.toBeInTheDocument();
+  });
+});
+
+describe('an early route that has not unlocked yet', () => {
+  const notYet = () => quote({
+    confirmations: 0,
+    instant: {
+      confirmationsRequired: 1, creditAmountSats: 96_800, feeSats: 3_200,
+      feeRateSatPerVbyte: 4, isEstimate: false,
+    },
+  });
+
+  it('says how much longer rather than offering a dead button', async () => {
+    renderSheet(makeDeposit(), withQuote(notYet()));
+
+    expect(await screen.findByText('Waiting for 1 confirmation.')).toBeInTheDocument();
+    // Calling claimDeposit before the floor throws, so nothing is pressable.
+    expect(queryButton('Claim now')).not.toBeInTheDocument();
+  });
+});
+
+describe('a deposit the provider will not front', () => {
+  it('keeps the layout but fades the route that is not on offer', async () => {
+    const noEarly = quote();
+    delete noEarly.instant;
+    renderSheet(makeDeposit(), withQuote(noEarly));
+
+    await screen.findByText('Priority');
+    expect(button(/^Priority/)).toBeDisabled();
+    expect(button(/^Priority/)).toHaveTextContent('Not available');
+    // Waiting is still priced, so the screen says what the claim will cost.
+    expect(button(/^Standard/)).toHaveTextContent('198');
+    expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198');
+  });
+
+  it('leaves nothing to press, the claim happening at maturity', async () => {
+    const noEarly = quote();
+    delete noEarly.instant;
+    renderSheet(makeDeposit(), withQuote(noEarly));
+
+    await screen.findByText('Priority');
+    expect(queryButton('Claim now')).not.toBeInTheDocument();
+    expect(queryButton('Claim')).not.toBeInTheDocument();
+  });
+
+  it('offers nothing when the early route unlocks no sooner than waiting', async () => {
+    // Same depth as maturity: an "early" route that saves nothing.
+    const pointless = quote({
+      instant: {
+        confirmationsRequired: 3, creditAmountSats: 96_800, feeSats: 3_200,
+        feeRateSatPerVbyte: 4, isEstimate: false,
+      },
+    });
+    renderSheet(makeDeposit(), withQuote(pointless));
+
+    await waitFor(() => expect(screen.queryByText('Priority')).not.toBeInTheDocument());
+  });
+});
+
+describe('a claim already in flight', () => {
+  const inFlight = (isMature = false) =>
+    makeDeposit({ isMature, instantClaimStatus: { type: 'submitted', claimId: 'c' } });
+
+  it('reports the claim in the same words as the toast, and offers nothing', async () => {
+    const client = withQuote(quote());
+    renderSheet(inFlight(), client);
+
+    expect(screen.getByText(CLAIM_SUBMITTED_LINE)).toBeInTheDocument();
+    expect(queryButton('Claim now')).not.toBeInTheDocument();
+    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+    // No point pricing a deposit whose claim is already settling.
+    expect(client.fetchClaimDepositQuote).not.toHaveBeenCalled();
+  });
+
+  it('still reports it once the deposit confirms, the SDK skipping it either way', () => {
+    renderSheet(inFlight(true), withQuote(quote()));
+    expect(screen.getByText(CLAIM_SUBMITTED_LINE)).toBeInTheDocument();
+    expect(screen.queryByText(/claimed automatically/)).not.toBeInTheDocument();
+  });
+});
+
+describe('a route the background sync passed over', () => {
+  it('offers it anyway, the quote being priced regardless of the ceiling', async () => {
+    // A manual claim authorises the quoted fee itself, so a past decline against
+    // the configured ceiling has no bearing on what is offered here.
+    renderSheet(
+      makeDeposit({ instantClaimStatus: { type: 'declined', maxFeeSats: 400, confirmations: 1 } }),
+      withQuote(quote()),
+    );
+
+    expect(await screen.findByText('Priority')).toBeInTheDocument();
+    expect(button('Claim now')).toBeInTheDocument();
+    expect(screen.queryByText(/above your limit/)).not.toBeInTheDocument();
+  });
+});
+
+describe('a deposit claimed while the sheet was working', () => {
+  it('stands down rather than reporting a failure over it', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('already claimed'));
+    // Gone from the unclaimed set: something else got to it first.
+    vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({ deposits: [] });
+    const { onChanged } = renderSheet(makeDeposit(), client);
+
+    fireEvent.click(await screen.findByText('Claim now'));
+
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(screen.queryByText('already claimed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Fee changed')).not.toBeInTheDocument();
+  });
+});
+
+describe('the dev setting that gates it', () => {
+  it('offers nothing and asks for no quote while it is off', async () => {
+    setPriorityClaim(false);
+    const client = withQuote(quote());
+    renderSheet(makeDeposit(), client);
+
+    // Falls back to what the sheet was before the feature.
+    await waitFor(() => expect(screen.getByText(/Waiting for 3 confirmations/)).toBeInTheDocument());
+    expect(client.fetchClaimDepositQuote).not.toHaveBeenCalled();
+    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+    expect(queryButton('Claim now')).not.toBeInTheDocument();
+  });
+});
+
+describe('when the quote cannot be fetched', () => {
+  it('falls back to plain waiting rather than a broken offer', async () => {
+    renderSheet(makeDeposit(), withQuote(new Error('offline')));
+
+    await waitFor(() => expect(screen.getByText(/Waiting for 3 confirmations/)).toBeInTheDocument());
+    expect(queryButton('Claim now')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState, type ReactNode } from 'react';
-import { useWallet } from '../contexts/WalletContext';
+import React, { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useWallet, useSdkEvents } from '../contexts/WalletContext';
 import { useToast } from '../contexts/ToastContext';
 import type {
   BreezSdk,
@@ -24,10 +24,12 @@ import {
   earlyOption,
   formatWait,
   isClaimInFlight as isClaimInFlightStatus,
+  markClaimAnnounced,
   isClaimable,
   selectOption,
 } from '../utils/depositClaimQuote';
 import { useSheetFullSnap } from '../components/ui/sheets/BottomSheetCardContext';
+import { useLatest } from '../hooks/useLatest';
 import { logger, LogCategory } from '@/services/logger';
 
 interface UnclaimedDepositDetailsPageProps {
@@ -42,7 +44,9 @@ interface ClaimState {
 }
 
 // Derive the claim/fee state from a deposit record's last claim outcome,
-// whether that came from an automatic claim or from a manual retry.
+// whether that came from an automatic claim or from a manual retry. A
+// confirming deposit has an automatic claim still ahead of it, so a stored
+// error there is not yet the user's to answer.
 function deriveClaimState(deposit: DepositInfo | null): ClaimState {
   if (!deposit || !deposit.isMature) {
     return { claimError: null, requiredFeeSats: null };
@@ -66,16 +70,26 @@ function deriveClaimState(deposit: DepositInfo | null): ClaimState {
 // record already carries the fee the operator just quoted. Re-reading it is
 // the only way back to that number: the thrown error crosses the WASM
 // boundary as a plain string.
-async function refetchClaimState(
-  wallet: BreezSdk,
-  deposit: DepositInfo,
-): Promise<ClaimState | null> {
+//
+// The three outcomes are kept apart because they call for opposite handling:
+// `gone` means the deposit has left the unclaimed set, so it was claimed
+// elsewhere and nothing here still applies to it, whereas `unknown` means the
+// read itself failed and the panel must keep whatever it already had.
+type FreshDeposit =
+  | { kind: 'found'; deposit: DepositInfo }
+  | { kind: 'gone' }
+  | { kind: 'unknown' };
+
+async function findFreshDeposit(wallet: BreezSdk, deposit: DepositInfo): Promise<FreshDeposit> {
   try {
     const { deposits } = await wallet.listUnclaimedDeposits({});
     const fresh = deposits.find(d => d.txid === deposit.txid && d.vout === deposit.vout);
-    return fresh ? deriveClaimState(fresh) : null;
-  } catch {
-    return null;
+    return fresh ? { kind: 'found', deposit: fresh } : { kind: 'gone' };
+  } catch (e) {
+    logger.warn(LogCategory.SDK, 'Failed to re-read deposit after a failed claim', {
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return { kind: 'unknown' };
   }
 }
 
@@ -107,8 +121,12 @@ const DeliveryOption: React.FC<{
   wait: string | null;
 }> = ({ label, active, onSelect, option, wait }) => (
   <button
+    role="radio"
+    aria-checked={active}
     onClick={option ? onSelect : undefined}
-    disabled={!option}
+    // aria-disabled, not disabled: the route being unavailable is the point, and
+    // a disabled control drops out of the group rather than announcing that.
+    aria-disabled={!option}
     className={`flex-1 p-3 rounded-2xl border text-left transition-all ${
       !option
         ? 'bg-spark-dark border-spark-border opacity-40 cursor-not-allowed'
@@ -123,8 +141,8 @@ const DeliveryOption: React.FC<{
     </div>
     {option && (
       <div className="text-sm text-spark-text-secondary mt-1">
-        {/* The provider will not quote maturity before a deposit matures, so
-            that figure is derived from current onchain rates, not priced. */}
+        {/* Until a deposit is deep enough to claim at maturity there is nothing
+            for the provider to price, so that figure comes off onchain rates. */}
         {option.isEstimate && '~'}<SatAmount sats={option.feeSats} />
       </div>
     )}
@@ -137,11 +155,12 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
   onChanged,
 }) => {
   const wallet = useWallet();
+  const subscribeToSdkEvents = useSdkEvents();
   const { showToast } = useToast();
 
-  // Parent keys this component on deposit identity, so the prop is stable
-  // per mount and never picks up a later claim outcome; handleClaim owns
-  // the state from the first retry on.
+  // Parent keys this component on deposit identity, so the prop is stable per
+  // mount and never picks up a later claim outcome. Everything after the first
+  // read comes from handleClaim's retries or from the sync listener below.
   const [{ claimError, requiredFeeSats }, setClaim] = useState<ClaimState>(() => deriveClaimState(deposit));
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const [feeRaised, setFeeRaised] = useState<boolean>(false);
@@ -157,6 +176,10 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
   const [quote, setQuote] = useState<FetchClaimDepositQuoteResponse | null>(null);
   const [preferEarly, setPreferEarly] = useState<boolean>(true);
   const [feeRequoted, setFeeRequoted] = useState(false);
+  // Read by the sync listener, which must not re-price under a claim already
+  // sent: the sheet would restate the fee, and could drop the button, while the
+  // user is looking at "Processing...".
+  const claimInFlightRef = useRef(false);
 
   const isConfirming = deposit ? !deposit.isMature : false;
   const isClaimInFlight = isClaimInFlightStatus(instantStatus);
@@ -180,9 +203,9 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
   // current depth is an offer for N blocks' time, and claiming against it throws.
   const chosenReady = chosen ? isClaimable(chosen, confirmations) : false;
   const blocksLeft = chosen ? blocksToWait(chosen, confirmations) : 0;
-  // What the deposit is doing, when nothing else on screen already says it.
-  // A claimable choice speaks through its own options and button, so it needs
-  // no line, and a line about waiting would contradict the one being offered.
+  // What the deposit is doing, when nothing else on screen already says it. A
+  // ready early route speaks through its own button, so it needs no line, and a
+  // line about waiting would contradict the one being offered.
   const statusLine = isClaimInFlight
     // Says what the toast said, so reopening the sheet mid-settlement reports
     // the claim rather than showing an amount and nothing else.
@@ -190,13 +213,22 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
     : !isConfirming
       ? 'This transfer will be claimed automatically.'
       : chosen
-        ? (chosenReady ? null : `Waiting for ${blocksLeft} confirmation${blocksLeft === 1 ? '' : 's'}.`)
+        ? (blocksLeft > 0
+            ? `Waiting for ${blocksLeft} confirmation${blocksLeft === 1 ? '' : 's'}.`
+            // Nothing left to wait for, and no button on this route: the only
+            // thing left to say is who does the claiming.
+            : chosenIsEarly ? null : 'This transfer will be claimed automatically.')
         : 'Waiting for 3 confirmations.';
+
+  const handleClose = () => {
+    onBack();
+  };
 
   const handleClaim = async () => {
     if (!deposit || requiredFeeSats === null) return;
     setFeeRaised(false);
     setIsProcessing(true);
+    claimInFlightRef.current = true;
     try {
       const maxFee: MaxFee = { type: 'fixed', amount: requiredFeeSats };
       await wallet.claimDeposit({ txid: deposit.txid, vout: deposit.vout, maxFee });
@@ -211,7 +243,8 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
       // The operator re-quotes on every attempt, so the fee we just sent can
       // already be stale. Retrying at it fails the same way with the same
       // number, so adopt the quote behind the failure when there is one.
-      const fresh = await refetchClaimState(wallet, deposit);
+      const found = await findFreshDeposit(wallet, deposit);
+      const fresh = found.kind === 'found' ? deriveClaimState(found.deposit) : null;
       if (fresh?.requiredFeeSats != null && fresh.requiredFeeSats !== requiredFeeSats) {
         setClaim(fresh);
         setFeeRaised(true);
@@ -220,31 +253,8 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
         setClaim({ claimError: errorMessage, requiredFeeSats: null });
       }
     } finally {
+      claimInFlightRef.current = false;
       setIsProcessing(false);
-    }
-  };
-
-  /**
-   * Re-reads the outcome the SDK persisted before throwing. The three cases are
-   * kept apart because they call for opposite handling: `gone` means the deposit
-   * has left the unclaimed set, so it was claimed elsewhere and no action here
-   * can still apply to it, whereas `unknown` means the read itself failed and
-   * the panel must keep whatever it already had.
-   */
-  const refreshInstantStatus = async (
-    target: DepositInfo,
-  ): Promise<{ kind: 'found' | 'gone' | 'unknown' }> => {
-    try {
-      const { deposits } = await wallet.listUnclaimedDeposits({});
-      const fresh = deposits.find(d => d.txid === target.txid && d.vout === target.vout);
-      if (!fresh) return { kind: 'gone' };
-      setInstantStatus(fresh.instantClaimStatus);
-      return { kind: 'found' };
-    } catch (e) {
-      logger.warn(LogCategory.SDK, 'Failed to refresh instant claim status', {
-        error: e instanceof Error ? e.message : String(e),
-      });
-      return { kind: 'unknown' };
     }
   };
 
@@ -253,12 +263,13 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
     onChanged?.();
     handleClose();
   };
+  const dismissAsSettledRef = useLatest(dismissAsSettled);
 
   /**
    * Prices both ways of claiming. A pure read, so it runs on open rather than
-   * behind a tap. Fetched once per mount and again after a failed claim: the
-   * provider's spread falls as the deposit gets deeper, so the figure behind a
-   * rejection is already out of date.
+   * behind a tap, and again on every sync and after a failed claim: the
+   * provider's spread falls as the deposit gets deeper, so a figure held from
+   * one depth is already out of date at the next.
    */
   const loadQuote = useCallback(async (target: DepositInfo) => {
     try {
@@ -266,12 +277,12 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
       setQuote(fresh);
       return fresh;
     } catch (e) {
-      // Leaves the sheet on its plain waiting state, which is what the deposit
-      // does anyway. Nothing here is actionable without a quote.
+      // Keeps the last good quote. Clearing it would strip the options, the
+      // breakdown and the button mid-flow, turning a failed re-price into a
+      // sheet that looks like it never had a choice to offer.
       logger.warn(LogCategory.PAYMENT, 'Failed to quote deposit claim', {
         error: e instanceof Error ? e.message : String(e),
       });
-      setQuote(null);
       return null;
     }
   }, [wallet]);
@@ -288,22 +299,59 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
     void loadQuote(deposit);
   }, [deposit, loadQuote]);
 
+  // A quote is a snapshot at one depth. Left alone it goes stale in place: the
+  // block that unlocks the early route lands, and the sheet still shows the
+  // wait and no button until it is reopened.
+  useEffect(() => {
+    if (!deposit || deposit.isMature) return;
+    // TEMPORARY: the same dev gate as the quote above, and it goes with it.
+    if (!isPriorityDepositClaimEnabled()) return;
+    let cancelled = false;
+    const unsubscribe = subscribeToSdkEvents(event => {
+      if (event.type !== 'synced' || claimInFlightRef.current) return;
+      void (async () => {
+        const found = await findFreshDeposit(wallet, deposit);
+        if (cancelled || claimInFlightRef.current) return;
+        if (found.kind === 'gone') {
+          // Claimed by background sync. Leaving the sheet up would keep offering
+          // routes for a deposit that no longer exists, and the funds announce
+          // themselves as a receive either way.
+          dismissAsSettledRef.current();
+          return;
+        }
+        if (found.kind !== 'found') return;
+        setInstantStatus(found.deposit.instantClaimStatus);
+        // A deposit that matures with the sheet open gets claimed automatically,
+        // and that claim can trip the fee ceiling. Without this the outcome sits
+        // unread on the record and the approve panel never appears.
+        setClaim(deriveClaimState(found.deposit));
+        if (isClaimInFlightStatus(found.deposit.instantClaimStatus)) return;
+        await loadQuote(deposit);
+      })();
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [deposit, dismissAsSettledRef, loadQuote, subscribeToSdkEvents, wallet]);
+
   const handleQuotedClaim = async () => {
     if (!deposit || !chosen) return;
     setInstantError(null);
     setFeeRequoted(false);
     setIsProcessing(true);
+    claimInFlightRef.current = true;
     try {
       // At least the quoted fee, or the SDK declines this route and falls back
-      // to waiting for maturity. An estimated maturity fee doubles as a ceiling
-      // here, but it comes off the fastest mempool tier, so it overshoots the
-      // operator's price rather than undercutting it.
+      // to waiting for maturity.
       const maxFee: MaxFee = { type: 'fixed', amount: chosen.feeSats };
       const { payment } = await wallet.claimDeposit({ txid: deposit.txid, vout: deposit.vout, maxFee });
       removeRejectedDeposit(deposit.txid, deposit.vout);
       // No payment means it was claimed early and settles asynchronously, so
       // nothing else will announce it: the sheet is about to close over it.
+      // Marked first, or the next sync reports the same claim as news.
       if (!payment) {
+        markClaimAnnounced(deposit);
         showToast('success', INSTANT_CLAIM_SUBMITTED_TOAST.title, INSTANT_CLAIM_SUBMITTED_TOAST.detail);
       }
       onChanged?.();
@@ -312,12 +360,18 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
       logger.error(LogCategory.PAYMENT, 'Failed to claim transfer', {
         error: e instanceof Error ? e.message : String(e),
       });
-      const refreshed = await refreshInstantStatus(deposit);
-      if (refreshed.kind === 'gone') {
+      const found = await findFreshDeposit(wallet, deposit);
+      if (found.kind === 'gone') {
         // Claimed while we were working. Reporting a failure over a deposit
         // that is no longer pending would be false.
         dismissAsSettled();
         return;
+      }
+      if (found.kind === 'found') {
+        setInstantStatus(found.deposit.instantClaimStatus);
+        // A claim already in flight is not a failure to report: the SDK refuses
+        // the second attempt, and the status line now says the first was taken.
+        if (isClaimInFlightStatus(found.deposit.instantClaimStatus)) return;
       }
       // The price moves with depth, so a failure is a reason to re-price rather
       // than to retry against the figure that just failed.
@@ -326,10 +380,11 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
         // A fee that outran the ceiling explains itself: the sheet has already
         // repriced, so the raw SDK message would only repeat it worse.
         setFeeRequoted(true);
-      } else {
-        setInstantError(e instanceof Error ? e.message : 'Failed to claim transfer');
+        return;
       }
+      setInstantError(e instanceof Error ? e.message : 'Failed to claim transfer');
     } finally {
+      claimInFlightRef.current = false;
       setIsProcessing(false);
     }
   };
@@ -340,10 +395,6 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
     rejectDeposit(deposit.txid, deposit.vout);
     onChanged?.();
     handleClose();
-  };
-
-  const handleClose = () => {
-    onBack();
   };
 
   if (!deposit) {
@@ -417,11 +468,11 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
                   : [{ label: 'Amount', value: depositAmount, highlight: true }]}
               />
 
-              {/* Both ways of claiming, priced. Offered only when the early
-                  route is genuinely on the table: absent, the provider declined
-                  to front this deposit and only waiting is possible. */}
+              {/* Both ways of claiming, priced. The pair always renders: with no
+                  early route the provider declined to front this deposit, and
+                  fading that card says so more plainly than dropping it. */}
               {quote && !isClaimInFlight && (
-                <div className="flex gap-2">
+                <div className="flex gap-2" role="radiogroup" aria-label="How to claim">
                   <DeliveryOption
                     label="Priority"
                     active={Boolean(early) && preferEarly}
@@ -466,9 +517,12 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
           </div>
 
           <div className="shrink-0 space-y-4 pt-4">
-            {/* One button for whichever option is selected: the choice is made
-                above, so this only commits it. */}
-            {isConfirming && !isClaimInFlight && chosen && chosenReady && (
+            {/* Only the early route is the user's to commit. Waiting is claimed
+                automatically at maturity, so a button for it would race the
+                SDK's own claim to do the same thing a moment sooner. A recorded
+                fee means that automatic claim has already run and been refused,
+                so the approve panel below owns the sheet. */}
+            {isConfirming && !isClaimInFlight && chosenIsEarly && chosenReady && requiredFeeSats === null && (
               <PrimaryButton onClick={handleQuotedClaim} disabled={isProcessing} className="w-full">
                 {isProcessing ? (
                   <span className="flex items-center justify-center gap-2">
@@ -476,7 +530,7 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
                     Processing...
                   </span>
                 ) : (
-                  chosenIsEarly ? 'Claim now' : 'Claim'
+                  'Claim now'
                 )}
               </PrimaryButton>
             )}

--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -1,13 +1,33 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useWallet } from '../contexts/WalletContext';
-import type { BreezSdk, DepositInfo, MaxFee } from '@breeztech/breez-sdk-spark';
-import { BottomSheetContainer, BottomSheetCard, DialogHeader, PrimaryButton, SecondaryButton, PaymentInfoCard, CollapsibleCodeField } from '../components/ui';
+import { useToast } from '../contexts/ToastContext';
+import type {
+  BreezSdk,
+  ClaimDepositQuote,
+  DepositInfo,
+  FetchClaimDepositQuoteResponse,
+  InstantClaimStatus,
+  MaxFee,
+} from '@breeztech/breez-sdk-spark';
+import { BottomSheetContainer, BottomSheetCard, DialogHeader, FormError, PrimaryButton, SecondaryButton, PaymentInfoCard, CollapsibleCodeField } from '../components/ui';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
 import { SpinnerIcon } from '../components/Icons';
 import { AlertCard } from '../components/AlertCard';
 import { SatAmount } from '../components/SatAmount';
 import { rejectDeposit, removeRejectedDeposit } from '../services/depositState';
 import { explorerTxUrl } from '../utils/explorer';
+import { isPriorityDepositClaimEnabled } from '../services/settings';
+import {
+  CLAIM_SUBMITTED_LINE,
+  INSTANT_CLAIM_SUBMITTED_TOAST,
+  blocksToWait,
+  earlyOption,
+  formatWait,
+  isClaimInFlight as isClaimInFlightStatus,
+  isClaimable,
+  selectOption,
+} from '../utils/depositClaimQuote';
+import { useSheetFullSnap } from '../components/ui/sheets/BottomSheetCardContext';
 import { logger, LogCategory } from '@/services/logger';
 
 interface UnclaimedDepositDetailsPageProps {
@@ -59,12 +79,65 @@ async function refetchClaimState(
   }
 }
 
+/**
+ * The sheet body, capped in dvh so the card stays fully on screen: unbounded,
+ * the content snap is measured against the URL-bar-hidden viewport, so the card
+ * runs past the visible one while its scroller still believes it fits.
+ *
+ * Its own component because the cap reads the sheet's snap, and that context is
+ * provided by BottomSheetContainer. Read in the component that renders the
+ * container it would only ever see the default, leaving the cap stuck at 65dvh.
+ */
+const SheetBody: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const isSheetFull = useSheetFullSnap();
+  return (
+    <div className="flex flex-col" style={{ maxHeight: isSheetFull ? '85dvh' : '65dvh' }}>
+      {children}
+    </div>
+  );
+};
+
+/** One of the two ways to claim, or a faded placeholder when it is not on offer. */
+const DeliveryOption: React.FC<{
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+  /** The quote, or null when this route is not on offer for this deposit. */
+  option: ClaimDepositQuote | null;
+  wait: string | null;
+}> = ({ label, active, onSelect, option, wait }) => (
+  <button
+    onClick={option ? onSelect : undefined}
+    disabled={!option}
+    className={`flex-1 p-3 rounded-2xl border text-left transition-all ${
+      !option
+        ? 'bg-spark-dark border-spark-border opacity-40 cursor-not-allowed'
+        : active
+          ? 'bg-spark-primary/10 border-spark-primary'
+          : 'bg-spark-dark border-spark-border hover:border-spark-border-light'
+    }`}
+  >
+    <div className="font-display font-medium text-spark-text-primary">{label}</div>
+    <div className="text-xs text-spark-text-muted mt-0.5">
+      {option ? (wait ?? 'Now') : 'Not available'}
+    </div>
+    {option && (
+      <div className="text-sm text-spark-text-secondary mt-1">
+        {/* The provider will not quote maturity before a deposit matures, so
+            that figure is derived from current onchain rates, not priced. */}
+        {option.isEstimate && '~'}<SatAmount sats={option.feeSats} />
+      </div>
+    )}
+  </button>
+);
+
 const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = ({
   deposit,
   onBack,
   onChanged,
 }) => {
   const wallet = useWallet();
+  const { showToast } = useToast();
 
   // Parent keys this component on deposit identity, so the prop is stable
   // per mount and never picks up a later claim outcome; handleClaim owns
@@ -74,8 +147,51 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
   const [feeRaised, setFeeRaised] = useState<boolean>(false);
   const [isTxIdVisible, setIsTxIdVisible] = useState<boolean>(false);
 
-  const isConfirming = deposit ? !deposit.isMature : false;
+  // Refreshed from the SDK after a declined instant claim, which persists the
+  // outcome before it throws. The `deposit` prop is a snapshot taken when the
+  // row was tapped, so it never picks that up on its own.
+  const [instantStatus, setInstantStatus] = useState<InstantClaimStatus | undefined>(
+    () => deposit?.instantClaimStatus,
+  );
+  const [instantError, setInstantError] = useState<string | null>(null);
+  const [quote, setQuote] = useState<FetchClaimDepositQuoteResponse | null>(null);
+  const [preferEarly, setPreferEarly] = useState<boolean>(true);
+  const [feeRequoted, setFeeRequoted] = useState(false);
 
+  const isConfirming = deposit ? !deposit.isMature : false;
+  const isClaimInFlight = isClaimInFlightStatus(instantStatus);
+
+  const early = earlyOption(quote);
+  const confirmations = quote?.confirmations ?? 0;
+  // Without an early route there is nothing to pick, but waiting is still worth
+  // pricing: the breakdown shows what the automatic claim will cost.
+  const chosen: ClaimDepositQuote | null = selectOption(quote, preferEarly);
+  // Which fee is being priced: the provider's spread, or the onchain claim fee
+  // that the matured path above already calls "Network fee".
+  const chosenIsEarly = Boolean(early) && preferEarly;
+
+  /** Switching route drops the last attempt's failure, which priced a different one. */
+  const chooseRoute = (early_: boolean) => {
+    setPreferEarly(early_);
+    setInstantError(null);
+    setFeeRequoted(false);
+  };
+  // Quoted is not claimable: an option whose floor is above the deposit's
+  // current depth is an offer for N blocks' time, and claiming against it throws.
+  const chosenReady = chosen ? isClaimable(chosen, confirmations) : false;
+  const blocksLeft = chosen ? blocksToWait(chosen, confirmations) : 0;
+  // What the deposit is doing, when nothing else on screen already says it.
+  // A claimable choice speaks through its own options and button, so it needs
+  // no line, and a line about waiting would contradict the one being offered.
+  const statusLine = isClaimInFlight
+    // Says what the toast said, so reopening the sheet mid-settlement reports
+    // the claim rather than showing an amount and nothing else.
+    ? CLAIM_SUBMITTED_LINE
+    : !isConfirming
+      ? 'This transfer will be claimed automatically.'
+      : chosen
+        ? (chosenReady ? null : `Waiting for ${blocksLeft} confirmation${blocksLeft === 1 ? '' : 's'}.`)
+        : 'Waiting for 3 confirmations.';
 
   const handleClaim = async () => {
     if (!deposit || requiredFeeSats === null) return;
@@ -102,6 +218,116 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
       } else {
         const errorMessage = e instanceof Error ? e.message : 'Failed to claim transfer';
         setClaim({ claimError: errorMessage, requiredFeeSats: null });
+      }
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  /**
+   * Re-reads the outcome the SDK persisted before throwing. The three cases are
+   * kept apart because they call for opposite handling: `gone` means the deposit
+   * has left the unclaimed set, so it was claimed elsewhere and no action here
+   * can still apply to it, whereas `unknown` means the read itself failed and
+   * the panel must keep whatever it already had.
+   */
+  const refreshInstantStatus = async (
+    target: DepositInfo,
+  ): Promise<{ kind: 'found' | 'gone' | 'unknown' }> => {
+    try {
+      const { deposits } = await wallet.listUnclaimedDeposits({});
+      const fresh = deposits.find(d => d.txid === target.txid && d.vout === target.vout);
+      if (!fresh) return { kind: 'gone' };
+      setInstantStatus(fresh.instantClaimStatus);
+      return { kind: 'found' };
+    } catch (e) {
+      logger.warn(LogCategory.SDK, 'Failed to refresh instant claim status', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return { kind: 'unknown' };
+    }
+  };
+
+  /** Stands the sheet down: the deposit is settled or gone, so it has no actions left. */
+  const dismissAsSettled = () => {
+    onChanged?.();
+    handleClose();
+  };
+
+  /**
+   * Prices both ways of claiming. A pure read, so it runs on open rather than
+   * behind a tap. Fetched once per mount and again after a failed claim: the
+   * provider's spread falls as the deposit gets deeper, so the figure behind a
+   * rejection is already out of date.
+   */
+  const loadQuote = useCallback(async (target: DepositInfo) => {
+    try {
+      const fresh = await wallet.fetchClaimDepositQuote({ txid: target.txid, vout: target.vout });
+      setQuote(fresh);
+      return fresh;
+    } catch (e) {
+      // Leaves the sheet on its plain waiting state, which is what the deposit
+      // does anyway. Nothing here is actionable without a quote.
+      logger.warn(LogCategory.PAYMENT, 'Failed to quote deposit claim', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      setQuote(null);
+      return null;
+    }
+  }, [wallet]);
+
+  useEffect(() => {
+    if (!deposit || deposit.isMature || isClaimInFlightStatus(deposit.instantClaimStatus)) return;
+    // TEMPORARY: gated on the dev setting while the feature is being tested.
+    // Skipping the quote is the whole gate, since the options, the breakdown and
+    // the claim button all render off it: without one the sheet is what it was
+    // before this feature. Remove this line to ship the choice to everyone.
+    if (!isPriorityDepositClaimEnabled()) return;
+    // loadQuote awaits the SDK before it sets anything, so nothing is written during this render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadQuote(deposit);
+  }, [deposit, loadQuote]);
+
+  const handleQuotedClaim = async () => {
+    if (!deposit || !chosen) return;
+    setInstantError(null);
+    setFeeRequoted(false);
+    setIsProcessing(true);
+    try {
+      // At least the quoted fee, or the SDK declines this route and falls back
+      // to waiting for maturity. An estimated maturity fee doubles as a ceiling
+      // here, but it comes off the fastest mempool tier, so it overshoots the
+      // operator's price rather than undercutting it.
+      const maxFee: MaxFee = { type: 'fixed', amount: chosen.feeSats };
+      const { payment } = await wallet.claimDeposit({ txid: deposit.txid, vout: deposit.vout, maxFee });
+      removeRejectedDeposit(deposit.txid, deposit.vout);
+      // No payment means it was claimed early and settles asynchronously, so
+      // nothing else will announce it: the sheet is about to close over it.
+      if (!payment) {
+        showToast('success', INSTANT_CLAIM_SUBMITTED_TOAST.title, INSTANT_CLAIM_SUBMITTED_TOAST.detail);
+      }
+      onChanged?.();
+      handleClose();
+    } catch (e) {
+      logger.error(LogCategory.PAYMENT, 'Failed to claim transfer', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      const refreshed = await refreshInstantStatus(deposit);
+      if (refreshed.kind === 'gone') {
+        // Claimed while we were working. Reporting a failure over a deposit
+        // that is no longer pending would be false.
+        dismissAsSettled();
+        return;
+      }
+      // The price moves with depth, so a failure is a reason to re-price rather
+      // than to retry against the figure that just failed.
+      const fresh = selectOption(await loadQuote(deposit), preferEarly);
+      if (fresh && fresh.feeSats > chosen.feeSats) {
+        // A fee that outran the ceiling explains itself: the sheet has already
+        // repriced, so the raw SDK message would only repeat it worse.
+        setFeeRequoted(true);
+      } else {
+        setInstantError(e instanceof Error ? e.message : 'Failed to claim transfer');
       }
     } finally {
       setIsProcessing(false);
@@ -137,7 +363,8 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
     <BottomSheetContainer isOpen={deposit != null} onClose={handleClose}>
       <BottomSheetCard>
         <DialogHeader title="BTC Transfer" onClose={handleClose} />
-        <div className="space-y-4 overflow-y-auto">
+        <SheetBody>
+          <div className="space-y-4 flex-1 min-h-0 overflow-y-auto overscroll-y-none touch-pan-y">
           {/* Transaction ID */}
           <PaymentInfoCard>
             <CollapsibleCodeField
@@ -175,20 +402,56 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
             </>
           )}
 
-          {/* Confirming or pending automatic claim - no action needed */}
+          {/* Confirming or pending automatic claim */}
           {!claimError && requiredFeeSats === null && (
             <>
               <FeeBreakdownCard
-                items={[
-                  { label: 'Amount', value: depositAmount, highlight: true },
-                ]}
+                items={chosen
+                  ? [
+                      { label: 'Amount', value: depositAmount },
+                      // Same estimate caveat as the option cards above: an
+                      // unpriced maturity fee is marked, not presented as firm.
+                      { label: chosenIsEarly ? 'Priority fee' : 'Network fee', value: chosen.feeSats, prefix: chosen.isEstimate ? '~' : undefined },
+                      { label: 'You receive', value: chosen.creditAmountSats, highlight: true },
+                    ]
+                  : [{ label: 'Amount', value: depositAmount, highlight: true }]}
               />
 
-              <p className="text-spark-text-muted text-sm text-center">
-                {isConfirming
-                  ? 'Waiting for 3 confirmations.'
-                  : 'This transfer will be claimed automatically.'}
-              </p>
+              {/* Both ways of claiming, priced. Offered only when the early
+                  route is genuinely on the table: absent, the provider declined
+                  to front this deposit and only waiting is possible. */}
+              {quote && !isClaimInFlight && (
+                <div className="flex gap-2">
+                  <DeliveryOption
+                    label="Priority"
+                    active={Boolean(early) && preferEarly}
+                    onSelect={() => chooseRoute(true)}
+                    option={early}
+                    wait={early ? formatWait(blocksToWait(early, confirmations)) : null}
+                  />
+                  <DeliveryOption
+                    label="Standard"
+                    active={!early || !preferEarly}
+                    onSelect={() => chooseRoute(false)}
+                    option={quote.mature}
+                    wait={formatWait(blocksToWait(quote.mature, confirmations))}
+                  />
+                </div>
+              )}
+
+              {statusLine && (
+                <p className="text-spark-text-muted text-sm text-center">{statusLine}</p>
+              )}
+
+              {feeRequoted && (
+                /* The figure is in the breakdown and on the cards above, both
+                   already repriced, so this only needs to say what to do. */
+                <AlertCard variant="warning" title="Fee changed">
+                  <p className="text-sm">Claim again to accept the new fee.</p>
+                </AlertCard>
+              )}
+
+              <FormError error={instantError} />
             </>
           )}
 
@@ -200,32 +463,51 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
             </AlertCard>
           )}
 
-          {/* Action Buttons - Approve/Reject for fee exceeded, hide when claim error shown */}
-          {requiredFeeSats !== null && !claimError && (
-            <div className="flex gap-3">
-              <SecondaryButton onClick={handleReject} disabled={isProcessing} className="flex-1">
-                Reject
-              </SecondaryButton>
-              <PrimaryButton onClick={handleClaim} disabled={isProcessing} className="flex-1">
+          </div>
+
+          <div className="shrink-0 space-y-4 pt-4">
+            {/* One button for whichever option is selected: the choice is made
+                above, so this only commits it. */}
+            {isConfirming && !isClaimInFlight && chosen && chosenReady && (
+              <PrimaryButton onClick={handleQuotedClaim} disabled={isProcessing} className="w-full">
                 {isProcessing ? (
                   <span className="flex items-center justify-center gap-2">
                     <SpinnerIcon size="md" />
                     Processing...
                   </span>
                 ) : (
-                  'Approve'
+                  chosenIsEarly ? 'Claim now' : 'Claim'
                 )}
               </PrimaryButton>
-            </div>
-          )}
+            )}
 
-          {/* Only Reject button when claim error is shown */}
-          {claimError && (
-            <SecondaryButton onClick={handleReject} disabled={isProcessing} className="w-full">
-              Reject
-            </SecondaryButton>
-          )}
-        </div>
+            {/* Action Buttons - Approve/Reject for fee exceeded, hide when claim error shown */}
+            {requiredFeeSats !== null && !claimError && (
+              <div className="flex gap-3">
+                <SecondaryButton onClick={handleReject} disabled={isProcessing} className="flex-1">
+                  Reject
+                </SecondaryButton>
+                <PrimaryButton onClick={handleClaim} disabled={isProcessing} className="flex-1">
+                  {isProcessing ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <SpinnerIcon size="md" />
+                      Processing...
+                    </span>
+                  ) : (
+                    'Approve'
+                  )}
+                </PrimaryButton>
+              </div>
+            )}
+
+            {/* Only Reject button when claim error is shown */}
+            {claimError && (
+              <SecondaryButton onClick={handleReject} disabled={isProcessing} className="w-full">
+                Reject
+              </SecondaryButton>
+            )}
+          </div>
+        </SheetBody>
       </BottomSheetCard>
     </BottomSheetContainer>
   );

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -67,6 +67,11 @@ export interface UserSettings {
   lnurlDomain?: string;
   preferSparkOverLightning?: boolean;
   crossChainEnabled?: boolean;
+  /**
+   * TEMPORARY: gates the priority deposit claim while it is being tested.
+   * Absent means off, so the deposit sheet behaves as it did before it.
+   */
+  priorityDepositClaimEnabled?: boolean;
 }
 
 export interface FiatSettings {
@@ -198,6 +203,8 @@ export function getSettings(): UserSettings {
       lnurlDomain: typeof parsed.lnurlDomain === 'string' ? parsed.lnurlDomain : undefined,
       preferSparkOverLightning: typeof parsed.preferSparkOverLightning === 'boolean' ? parsed.preferSparkOverLightning : undefined,
       crossChainEnabled: typeof parsed.crossChainEnabled === 'boolean' ? parsed.crossChainEnabled : undefined,
+      priorityDepositClaimEnabled:
+        typeof parsed.priorityDepositClaimEnabled === 'boolean' ? parsed.priorityDepositClaimEnabled : undefined,
     };
     return out;
   } catch {
@@ -207,6 +214,11 @@ export function getSettings(): UserSettings {
 
 export function saveSettings(settings: UserSettings): void {
   setCachedItem(SETTINGS_KEY, JSON.stringify(settings));
+}
+
+/** TEMPORARY: whether the priority deposit claim is offered. Off by default. */
+export function isPriorityDepositClaimEnabled(): boolean {
+  return getSettings().priorityDepositClaimEnabled === true;
 }
 
 /**

--- a/src/test/mocks/mockWalletApi.ts
+++ b/src/test/mocks/mockWalletApi.ts
@@ -185,6 +185,9 @@ export function createMockClient(overrides?: Partial<BreezSdk>): BreezSdk {
     // Unclaimed deposits
     listUnclaimedDeposits: vi.fn().mockResolvedValue({ deposits: [] as DepositInfo[] }),
     claimDeposit: vi.fn().mockResolvedValue({ payment: createMockPayment('receive') }),
+    // Rejects by default: a deposit the operator will not front has no early
+    // route, which is the shape most callers want.
+    fetchClaimDepositQuote: vi.fn().mockRejectedValue(new Error('no quote')),
     refundDeposit: vi.fn().mockResolvedValue(undefined),
 
     // Info & data

--- a/src/utils/depositClaimQuote.test.ts
+++ b/src/utils/depositClaimQuote.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { DepositInfo } from '@breeztech/breez-sdk-spark';
+import { CLAIM_SUBMITTED_LINE, INSTANT_CLAIM_SUBMITTED_TOAST, splitClaimedDeposits } from './depositClaimQuote';
+
+const deposit = (submitted: boolean): DepositInfo => ({
+  txid: 'a'.repeat(64),
+  vout: 0,
+  amountSats: 1_000,
+  isMature: !submitted,
+  ...(submitted ? { instantClaimStatus: { type: 'submitted' as const, claimId: 'c' } } : {}),
+}) as DepositInfo;
+
+describe('the claimedDeposits split', () => {
+  it('counts an early claim as submitted, not credited', () => {
+    expect(splitClaimedDeposits([deposit(true)])).toEqual({ submitted: 1, settled: 0 });
+  });
+
+  it('counts a claim at maturity as settled', () => {
+    expect(splitClaimedDeposits([deposit(false)])).toEqual({ submitted: 0, settled: 1 });
+  });
+
+  it('separates a mixed batch, so neither is reported as the other', () => {
+    expect(splitClaimedDeposits([deposit(true), deposit(false), deposit(true)]))
+      .toEqual({ submitted: 2, settled: 1 });
+  });
+});
+
+describe('submitted-claim copy', () => {
+  it('says the same thing in the sheet as in the toast', () => {
+    // Composed from the toast so the two cannot drift apart.
+    expect(CLAIM_SUBMITTED_LINE).toContain(INSTANT_CLAIM_SUBMITTED_TOAST.detail);
+  });
+});

--- a/src/utils/depositClaimQuote.test.ts
+++ b/src/utils/depositClaimQuote.test.ts
@@ -1,6 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { DepositInfo } from '@breeztech/breez-sdk-spark';
-import { CLAIM_SUBMITTED_LINE, INSTANT_CLAIM_SUBMITTED_TOAST, splitClaimedDeposits } from './depositClaimQuote';
+import type { ClaimDepositQuote, FetchClaimDepositQuoteResponse } from '@breeztech/breez-sdk-spark';
+import {
+  CLAIM_SUBMITTED_LINE,
+  forgetAnnouncedClaims,
+  markClaimAnnounced,
+  takeUnannouncedClaims,
+  INSTANT_CLAIM_SUBMITTED_TOAST,
+  blocksToWait,
+  earlyOption,
+  formatWait,
+  isClaimable,
+  isClaimInFlight,
+  selectOption,
+  splitClaimedDeposits,
+} from './depositClaimQuote';
+
+beforeEach(() => forgetAnnouncedClaims());
+
+const option = (confirmationsRequired: number, feeSats = 100): ClaimDepositQuote =>
+  ({ confirmationsRequired, feeSats, creditAmountSats: 1_000 - feeSats, isEstimate: false }) as ClaimDepositQuote;
+
+const quoteOf = (instant: ClaimDepositQuote | null, mature: ClaimDepositQuote) =>
+  ({ instant: instant ?? undefined, mature, confirmations: 0 }) as FetchClaimDepositQuoteResponse;
 
 const deposit = (submitted: boolean): DepositInfo => ({
   txid: 'a'.repeat(64),
@@ -12,16 +34,19 @@ const deposit = (submitted: boolean): DepositInfo => ({
 
 describe('the claimedDeposits split', () => {
   it('counts an early claim as submitted, not credited', () => {
-    expect(splitClaimedDeposits([deposit(true)])).toEqual({ submitted: 1, settled: 0 });
+    expect(splitClaimedDeposits([deposit(true)])).toMatchObject({ settled: 0 });
+    expect(splitClaimedDeposits([deposit(true)]).submitted).toHaveLength(1);
   });
 
   it('counts a claim at maturity as settled', () => {
-    expect(splitClaimedDeposits([deposit(false)])).toEqual({ submitted: 0, settled: 1 });
+    expect(splitClaimedDeposits([deposit(false)])).toMatchObject({ settled: 1 });
+    expect(splitClaimedDeposits([deposit(false)]).submitted).toEqual([]);
   });
 
   it('separates a mixed batch, so neither is reported as the other', () => {
-    expect(splitClaimedDeposits([deposit(true), deposit(false), deposit(true)]))
-      .toEqual({ submitted: 2, settled: 1 });
+    const split = splitClaimedDeposits([deposit(true), deposit(false), deposit(true)]);
+    expect(split.submitted).toHaveLength(2);
+    expect(split.settled).toBe(1);
   });
 });
 
@@ -29,5 +54,117 @@ describe('submitted-claim copy', () => {
   it('says the same thing in the sheet as in the toast', () => {
     // Composed from the toast so the two cannot drift apart.
     expect(CLAIM_SUBMITTED_LINE).toContain(INSTANT_CLAIM_SUBMITTED_TOAST.detail);
+  });
+});
+
+describe('waiting on confirmations', () => {
+  it('counts the gap to the unlock depth, not the depth itself', () => {
+    expect(blocksToWait(option(3), 1)).toBe(2);
+  });
+
+  it('never goes negative once the deposit is deeper than the option needs', () => {
+    expect(blocksToWait(option(3), 9)).toBe(0);
+    expect(isClaimable(option(3), 9)).toBe(true);
+  });
+
+  it('is not claimable while any gap remains', () => {
+    expect(isClaimable(option(3), 2)).toBe(false);
+  });
+});
+
+describe('formatWait', () => {
+  it('says nothing when there is nothing left to wait for', () => {
+    expect(formatWait(0)).toBeNull();
+    expect(formatWait(-1)).toBeNull();
+  });
+
+  it('stays in minutes below the hour', () => {
+    expect(formatWait(1)).toBe('~10 min');
+    expect(formatWait(5)).toBe('~50 min');
+  });
+
+  it('switches to hours at the hour, dropping the decimal when it is whole', () => {
+    expect(formatWait(6)).toBe('~1 hr');
+    expect(formatWait(12)).toBe('~2 hr');
+  });
+
+  it('keeps one decimal for a part hour', () => {
+    expect(formatWait(7)).toBe('~1.2 hr');
+  });
+});
+
+describe('earlyOption', () => {
+  it('is absent without a quote at all', () => {
+    expect(earlyOption(null)).toBeNull();
+  });
+
+  it('is absent when the provider declined to front the deposit', () => {
+    expect(earlyOption(quoteOf(null, option(3)))).toBeNull();
+  });
+
+  it('is absent when it unlocks no sooner than simply waiting', () => {
+    expect(earlyOption(quoteOf(option(3), option(3)))).toBeNull();
+  });
+
+  it('is offered when it genuinely arrives first', () => {
+    expect(earlyOption(quoteOf(option(0), option(3)))).toMatchObject({ confirmationsRequired: 0 });
+  });
+});
+
+describe('selectOption', () => {
+  it('resolves to nothing without a quote', () => {
+    expect(selectOption(null, true)).toBeNull();
+  });
+
+  it('follows the preference when both routes are real', () => {
+    const q = quoteOf(option(0, 500), option(3, 100));
+    expect(selectOption(q, true)).toMatchObject({ feeSats: 500 });
+    expect(selectOption(q, false)).toMatchObject({ feeSats: 100 });
+  });
+
+  it('falls back to waiting when early is preferred but not on offer', () => {
+    expect(selectOption(quoteOf(null, option(3, 100)), true)).toMatchObject({ feeSats: 100 });
+  });
+});
+
+describe('isClaimInFlight', () => {
+  it('is true only for a submitted claim', () => {
+    expect(isClaimInFlight({ type: 'submitted', claimId: 'c' })).toBe(true);
+    expect(isClaimInFlight({ type: 'declined' })).toBe(false);
+    expect(isClaimInFlight(undefined)).toBe(false);
+  });
+});
+
+describe('announced claims', () => {
+  it('hands a claim over exactly once, however often sync repeats it', () => {
+    const d = deposit(true);
+    expect(takeUnannouncedClaims([d])).toEqual([d]);
+    expect(takeUnannouncedClaims([d])).toEqual([]);
+  });
+
+  it('keys on the outpoint, so a second vout is its own claim', () => {
+    const d = deposit(true);
+    takeUnannouncedClaims([d]);
+    expect(takeUnannouncedClaims([{ ...d, vout: 1 }])).toHaveLength(1);
+  });
+
+  it('passes over one the sheet announced itself', () => {
+    const d = deposit(true);
+    markClaimAnnounced(d);
+    expect(takeUnannouncedClaims([d])).toEqual([]);
+  });
+
+  it('separates the new from the repeated within one batch', () => {
+    const first = deposit(true);
+    const second = { ...first, vout: 1 };
+    takeUnannouncedClaims([first]);
+    expect(takeUnannouncedClaims([first, second])).toEqual([second]);
+  });
+
+  it('forgets everything when the wallet changes', () => {
+    const d = deposit(true);
+    takeUnannouncedClaims([d]);
+    forgetAnnouncedClaims();
+    expect(takeUnannouncedClaims([d])).toEqual([d]);
   });
 });

--- a/src/utils/depositClaimQuote.ts
+++ b/src/utils/depositClaimQuote.ts
@@ -72,12 +72,50 @@ export function isClaimInFlight(status: InstantClaimStatus | undefined): boolean
   return status?.type === 'submitted';
 }
 
+/** Identifies a deposit across events, which carry records rather than ids. */
+function depositOutpoint(deposit: DepositInfo): string {
+  return `${deposit.txid}:${deposit.vout}`;
+}
+
 /**
- * How many of a `claimedDeposits` batch are credited and how many are only
- * submitted. Background sync reports both through the one event, and an early
- * claim in it has not credited anything yet, so the two need different copy.
+ * Outpoints whose submitted claim has already been announced. Sync keeps
+ * reporting a claim until it settles, and the sheet announces its own manual
+ * claim, so without a marker both doors lead to the same repeated toast. Lives
+ * for the session; `forgetAnnouncedClaims` clears it when the wallet changes.
  */
-export function splitClaimedDeposits(claimed: DepositInfo[]): { submitted: number; settled: number } {
-  const submitted = claimed.filter(d => isClaimInFlight(d.instantClaimStatus)).length;
-  return { submitted, settled: claimed.length - submitted };
+const announcedClaims = new Set<string>();
+
+function claimAlreadyAnnounced(deposit: DepositInfo): boolean {
+  return announcedClaims.has(depositOutpoint(deposit));
+}
+
+/**
+ * The submitted claims worth announcing, marked as they are taken. Reading and
+ * marking are one step because sync repeats a claim until it settles, so a
+ * caller that read first and marked later would announce the same claim twice.
+ */
+export function takeUnannouncedClaims(submitted: DepositInfo[]): DepositInfo[] {
+  const fresh = submitted.filter(d => !claimAlreadyAnnounced(d));
+  fresh.forEach(markClaimAnnounced);
+  return fresh;
+}
+
+export function markClaimAnnounced(deposit: DepositInfo): void {
+  announcedClaims.add(depositOutpoint(deposit));
+}
+
+export function forgetAnnouncedClaims(): void {
+  announcedClaims.clear();
+}
+
+/**
+ * Splits a `claimedDeposits` batch into the credited and the merely submitted.
+ * Background sync reports both through the one event, and an early claim in it
+ * has not credited anything yet, so the two need different copy. The submitted
+ * come back whole because sync repeats them while they settle, and telling one
+ * apart from the same one again needs the outpoint.
+ */
+export function splitClaimedDeposits(claimed: DepositInfo[]): { submitted: DepositInfo[]; settled: number } {
+  const submitted = claimed.filter(d => isClaimInFlight(d.instantClaimStatus));
+  return { submitted, settled: claimed.length - submitted.length };
 }

--- a/src/utils/depositClaimQuote.ts
+++ b/src/utils/depositClaimQuote.ts
@@ -1,0 +1,83 @@
+import type { ClaimDepositQuote, DepositInfo, FetchClaimDepositQuoteResponse, InstantClaimStatus } from '@breeztech/breez-sdk-spark';
+
+/** Rough block interval, for turning a confirmation depth into a wait. */
+const MINUTES_PER_BLOCK = 10;
+
+/**
+ * Copy for a submitted early claim. Shared because the SDK raises no event for a
+ * manual claim, so the sheet announces that one itself while background sync
+ * announces its own: one wording, two callers.
+ */
+export const INSTANT_CLAIM_SUBMITTED_TOAST = {
+  title: 'Claim Submitted',
+  detail: 'Funds will arrive shortly',
+} as const;
+
+/**
+ * The same confirmation for the sheet, which stays open behind the toast and can
+ * be reopened later. Composed from the toast so the two cannot drift apart.
+ */
+export const CLAIM_SUBMITTED_LINE = `Claim submitted. ${INSTANT_CLAIM_SUBMITTED_TOAST.detail}.`;
+
+/**
+ * Blocks still to wait before an option can be claimed. `confirmationsRequired`
+ * is the depth at which the option unlocks, not a countdown, so the deposit's
+ * current depth has to come off it.
+ */
+export function blocksToWait(option: ClaimDepositQuote, confirmations: number): number {
+  return Math.max(0, option.confirmationsRequired - confirmations);
+}
+
+/** True once the deposit is deep enough for this option; claiming earlier throws. */
+export function isClaimable(option: ClaimDepositQuote, confirmations: number): boolean {
+  return blocksToWait(option, confirmations) === 0;
+}
+
+/** Approximate wait for `blocks`, or null when there is nothing left to wait for. */
+export function formatWait(blocks: number): string | null {
+  if (blocks <= 0) return null;
+  const minutes = blocks * MINUTES_PER_BLOCK;
+  if (minutes < 60) return `~${minutes} min`;
+  const hours = minutes / 60;
+  return `~${Number.isInteger(hours) ? hours : hours.toFixed(1)} hr`;
+}
+
+/**
+ * The early option worth offering, or null. Absent means the provider declined
+ * to front this deposit or would only credit at maturity's own depth, and
+ * claiming against it would be refused.
+ */
+export function earlyOption(quote: FetchClaimDepositQuoteResponse | null): ClaimDepositQuote | null {
+  if (!quote?.instant) return null;
+  // No point offering a route that unlocks no sooner than simply waiting.
+  if (quote.instant.confirmationsRequired >= quote.mature.confirmationsRequired) return null;
+  return quote.instant;
+}
+
+/**
+ * The option a preference resolves to. Shared so a re-quote can be compared
+ * against the same selection the user made, not just against `instant`.
+ */
+export function selectOption(
+  quote: FetchClaimDepositQuoteResponse | null,
+  preferEarly: boolean,
+): ClaimDepositQuote | null {
+  if (!quote) return null;
+  const early = earlyOption(quote);
+  return early && preferEarly ? early : quote.mature;
+}
+
+/** True while a claim is in flight, during which the SDK refuses a second one. */
+export function isClaimInFlight(status: InstantClaimStatus | undefined): boolean {
+  return status?.type === 'submitted';
+}
+
+/**
+ * How many of a `claimedDeposits` batch are credited and how many are only
+ * submitted. Background sync reports both through the one event, and an early
+ * claim in it has not credited anything yet, so the two need different copy.
+ */
+export function splitClaimedDeposits(claimed: DepositInfo[]): { submitted: number; settled: number } {
+  const submitted = claimed.filter(d => isClaimInFlight(d.instantClaimStatus)).length;
+  return { submitted, settled: claimed.length - submitted };
+}


### PR DESCRIPTION
The SDK now prices both ways of claiming a static deposit, so Glow shows the trade off and lets the user decide: pay the provider a spread to be credited early, or wait for maturity and pay the onchain fee.

SDK dependency is also updated to 0.24.1

Behind a temporary dev setting while it is tested: Settings, dev section, "Priority deposit claim", off by default. With it off the deposit sheet is unchanged, because the quote is what the options, the breakdown and the claim button all render from, so skipping it turns the whole feature off at once. The setting and its gate come out at launch, marked TEMPORARY in the three places they touch.

<img width="453" height="340" alt="Screenshot 2026-09-03 at 08 23 31" src="https://github.com/user-attachments/assets/0d49187e-4c85-4893-bcae-0e846af08d39" />

