### PR TITLE
feat: let anyone set the automatic claim limit

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -290,11 +290,10 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                     min={0}
                     value={feeValue}
                     onChange={(e) => setFeeDrafts({ ...feeDrafts, [feeType]: e.target.value })}
-                    placeholder={feeUnit}
                   />
                 </div>
-                {/* The placeholder carries the unit too, but it is gone as
-                    soon as the field holds a value. */}
+                {/* Pinned next to the field: a placeholder would carry the
+                    unit only while the field is empty. */}
                 <span className="text-sm text-spark-text-muted shrink-0">{feeUnit}</span>
               </div>
               {!enteredFee && (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -55,6 +55,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   const feeValue = feeDrafts[feeType];
   const feeUnit = feeType === 'fixed' ? 'sats' : 'sat/vB';
   const enteredFee = buildDepositMaxFee(feeType, feeValue);
+  const feeError = feeType === 'fixed' ? 'Please enter a valid amount' : 'Please enter a valid fee rate';
 
   // SettingsPage only mounts after wallet connect, so `config` is
   // effectively stable for this lifetime; capture once via lazy init.
@@ -297,7 +298,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                 <span className="text-sm text-spark-text-muted shrink-0">{feeUnit}</span>
               </div>
               {!enteredFee && (
-                <p className="text-xs text-spark-warning">Enter a positive number to save.</p>
+                <p className="text-xs text-spark-warning">{feeError}</p>
               )}
             </FormGroup>
           </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ConfirmDialog, FormGroup, FormInput, LoadingSpinner, PrimaryButton, Switch } from '../components/ui';
 import { PinGate } from '../components/PinEntry';
-import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable, isDevMode as isDevModeEnabled, setDevMode, buildDepositMaxFee, depositMaxFeeDrafts, DepositMaxFeeType } from '../services/settings';
+import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable, isDevMode as isDevModeEnabled, setDevMode, buildDepositMaxFee, depositMaxFeeDrafts, depositMaxFeeValue, DepositMaxFeeType } from '../services/settings';
 import type { Config, Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '@/contexts/WalletContext';
 import { CurrencyIcon, ChevronRightIcon, DownloadIcon, KeyIcon, LockIcon, ShieldCheckIcon, TrashIcon, ExternalLinkIcon } from '../components/Icons';
@@ -54,6 +54,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   );
   const feeValue = feeDrafts[feeType];
   const feeUnit = feeType === 'fixed' ? 'sats' : 'sat/vB';
+  const enteredFee = buildDepositMaxFee(feeType, feeValue);
 
   // SettingsPage only mounts after wallet connect, so `config` is
   // effectively stable for this lifetime; capture once via lazy init.
@@ -108,13 +109,15 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   };
 
   const handleSave = async () => {
+    // Save is disabled while the limit field cannot be read, so there is
+    // nothing here that would quietly discard what the user typed.
+    if (!enteredFee) return;
     const current = getSettings();
-    const entered = buildDepositMaxFee(feeType, feeValue);
-    const depositMaxFee = entered ?? current.depositMaxFee;
+    const depositMaxFee = enteredFee;
     const depositMaxFeeByType = { ...current.depositMaxFeeByType };
     for (const [type, value] of Object.entries(feeDrafts)) {
       const parsed = buildDepositMaxFee(type as DepositMaxFeeType, value);
-      if (parsed) depositMaxFeeByType[type as DepositMaxFeeType] = Number(value);
+      if (parsed) depositMaxFeeByType[type as DepositMaxFeeType] = depositMaxFeeValue(parsed);
     }
     const updated: UserSettings = isDevMode
       ? {
@@ -167,7 +170,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   };
 
   const footer = (
-    <PrimaryButton className="w-full" onClick={handleSave}>
+    <PrimaryButton className="w-full" onClick={handleSave} disabled={!enteredFee}>
       Save Changes
     </PrimaryButton>
   );
@@ -294,6 +297,9 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                     soon as the field holds a value. */}
                 <span className="text-sm text-spark-text-muted shrink-0">{feeUnit}</span>
               </div>
+              {!enteredFee && (
+                <p className="text-xs text-spark-warning">Enter a positive number to save.</p>
+              )}
             </FormGroup>
           </div>
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ConfirmDialog, FormGroup, FormInput, LoadingSpinner, PrimaryButton, Switch } from '../components/ui';
 import { PinGate } from '../components/PinEntry';
 import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable, isDevMode as isDevModeEnabled, setDevMode } from '../services/settings';
-import type { Config, Network } from '@breeztech/breez-sdk-spark';
+import type { Config, MaxFee, Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '@/contexts/WalletContext';
 import { CurrencyIcon, ChevronRightIcon, DownloadIcon, KeyIcon, LockIcon, ShieldCheckIcon, TrashIcon, ExternalLinkIcon } from '../components/Icons';
 import { ACCOUNT_DELETION_GUIDE_URL } from '@/services/accountDeletion';
@@ -50,6 +50,9 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     const s = getSettings();
     return s.depositMaxFee.type;
   });
+  // A stored rate / leeway value shows its raw number in the sats field
+  // outside developer mode. Only an ex-developer-mode install can be in that
+  // state, and the next save rewrites it as a flat sat amount.
   const [feeValue, setFeeValue] = useState<string>(() => {
     const s = getSettings();
     if (s.depositMaxFee.type === 'fixed') return String(s.depositMaxFee.amount);
@@ -110,21 +113,28 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   };
 
   const handleSave = async () => {
+    const current = getSettings();
     const n = Number(feeValue);
-    if (isDevMode) {
-      const updated: UserSettings = {
-        ...(feeType === 'fixed'
-          ? { depositMaxFee: { type: 'fixed', amount: Math.floor(n) } }
-          : feeType === 'rate'
-            ? { depositMaxFee: { type: 'rate', satPerVbyte: n } }
-            : { depositMaxFee: { type: 'networkRecommended', leewaySatPerVbyte: Math.max(0, Math.floor(n)) } }
-        ),
-        syncIntervalSecs: syncIntervalSecs !== '' ? Math.max(0, Math.floor(Number(syncIntervalSecs))) : undefined,
-        lnurlDomain: lnurlDomain !== '' ? lnurlDomain : undefined,
-        preferSparkOverLightning,
-      };
-      saveSettings(updated);
-    }
+    // The field is free text, and a bad value persisted here would fail
+    // validation on the next read and reset every setting to its default.
+    const validFee = feeValue.trim() !== '' && Number.isFinite(n) && n >= 0;
+    // Outside developer mode the only shape on offer is a flat sat amount.
+    const depositMaxFee: MaxFee = !validFee
+      ? current.depositMaxFee
+      : !isDevMode || feeType === 'fixed'
+        ? { type: 'fixed', amount: Math.floor(n) }
+        : feeType === 'rate'
+          ? { type: 'rate', satPerVbyte: n }
+          : { type: 'networkRecommended', leewaySatPerVbyte: Math.floor(n) };
+    const updated: UserSettings = isDevMode
+      ? {
+          depositMaxFee,
+          syncIntervalSecs: syncIntervalSecs !== '' ? Math.max(0, Math.floor(Number(syncIntervalSecs))) : undefined,
+          lnurlDomain: lnurlDomain !== '' ? lnurlDomain : undefined,
+          preferSparkOverLightning,
+        }
+      : { ...current, depositMaxFee };
+    saveSettings(updated);
     window.location.reload();
   };
 
@@ -165,11 +175,11 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     }
   };
 
-  const footer = isDevMode ? (
+  const footer = (
     <PrimaryButton className="w-full" onClick={handleSave}>
       Save Changes
     </PrimaryButton>
-  ) : undefined;
+  );
 
   // Same shape as BackupPage: the gate replaces the page body, and the
   // header's close button is the way out.
@@ -373,11 +383,14 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
           )}
 
           {/* Deposit Claim Fee */}
-          {isDevMode && (
-            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Deposit Claim Fee</h3>
-              <FormGroup>
-                <div className="flex gap-2 items-center">
+          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+            <h3 className="font-display font-semibold text-spark-text-primary mb-1">Automatic Claims</h3>
+            <p className="text-sm text-spark-text-muted mb-3">
+              Incoming Bitcoin is claimed for you while the network fee stays under this amount.
+            </p>
+            <FormGroup>
+              <div className="flex gap-2 items-center">
+                {isDevMode && (
                   <select
                     value={feeType}
                     onChange={(e) => setFeeType(e.currentTarget.value as 'fixed' | 'rate' | 'networkRecommended')}
@@ -388,20 +401,21 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                     <option className="bg-spark-surface" value="rate">Rate (sat/vB)</option>
                     <option className="bg-spark-surface" value="networkRecommended">Network + leeway</option>
                   </select>
-                  <div className="flex-1">
-                    <FormInput
-                      id="deposit-fee-default"
-                      type="number"
-                      min={0}
-                      value={feeValue}
-                      onChange={(e) => setFeeValue(e.target.value)}
-                      placeholder={feeType === 'fixed' ? 'sats' : 'sat/vB'}
-                    />
-                  </div>
+                )}
+                <div className="flex-1">
+                  <FormInput
+                    id="deposit-fee-default"
+                    type="number"
+                    min={0}
+                    value={feeValue}
+                    onChange={(e) => setFeeValue(e.target.value)}
+                    placeholder={isDevMode && feeType !== 'fixed' ? 'sat/vB' : 'sats'}
+                    aria-label="Maximum claim fee"
+                  />
                 </div>
-              </FormGroup>
-            </div>
-          )}
+              </div>
+            </FormGroup>
+          </div>
 
           {/* Sync Settings */}
           {isDevMode && (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ConfirmDialog, FormGroup, FormInput, LoadingSpinner, PrimaryButton, Switch } from '../components/ui';
 import { PinGate } from '../components/PinEntry';
-import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable, isDevMode as isDevModeEnabled, setDevMode } from '../services/settings';
-import type { Config, MaxFee, Network } from '@breeztech/breez-sdk-spark';
+import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable, isDevMode as isDevModeEnabled, setDevMode, buildDepositMaxFee, depositMaxFeeDrafts, DepositMaxFeeType } from '../services/settings';
+import type { Config, Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '@/contexts/WalletContext';
 import { CurrencyIcon, ChevronRightIcon, DownloadIcon, KeyIcon, LockIcon, ShieldCheckIcon, TrashIcon, ExternalLinkIcon } from '../components/Icons';
 import { ACCOUNT_DELETION_GUIDE_URL } from '@/services/accountDeletion';
@@ -46,19 +46,14 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     () => (new URLSearchParams(window.location.search).get('network') || 'mainnet') as Network,
   );
 
-  const [feeType, setFeeType] = useState<'fixed' | 'rate' | 'networkRecommended'>(() => {
-    const s = getSettings();
-    return s.depositMaxFee.type;
-  });
-  // A stored rate / leeway value shows its raw number in the sats field
-  // outside developer mode. Only an ex-developer-mode install can be in that
-  // state, and the next save rewrites it as a flat sat amount.
-  const [feeValue, setFeeValue] = useState<string>(() => {
-    const s = getSettings();
-    if (s.depositMaxFee.type === 'fixed') return String(s.depositMaxFee.amount);
-    if (s.depositMaxFee.type === 'rate') return String(s.depositMaxFee.satPerVbyte);
-    return String(s.depositMaxFee.leewaySatPerVbyte);
-  });
+  const [feeType, setFeeType] = useState<DepositMaxFeeType>(() => getSettings().depositMaxFee.type);
+  // One draft per type: the units differ, so carrying a single number across
+  // a type change would turn 500 sats into 500 sat/vB.
+  const [feeDrafts, setFeeDrafts] = useState<Record<DepositMaxFeeType, string>>(() =>
+    depositMaxFeeDrafts(getSettings()),
+  );
+  const feeValue = feeDrafts[feeType];
+  const feeUnit = feeType === 'fixed' ? 'sats' : 'sat/vB';
 
   // SettingsPage only mounts after wallet connect, so `config` is
   // effectively stable for this lifetime; capture once via lazy init.
@@ -114,26 +109,22 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
 
   const handleSave = async () => {
     const current = getSettings();
-    const n = Number(feeValue);
-    // The field is free text, and a bad value persisted here would fail
-    // validation on the next read and reset every setting to its default.
-    const validFee = feeValue.trim() !== '' && Number.isFinite(n) && n >= 0;
-    // Outside developer mode the only shape on offer is a flat sat amount.
-    const depositMaxFee: MaxFee = !validFee
-      ? current.depositMaxFee
-      : !isDevMode || feeType === 'fixed'
-        ? { type: 'fixed', amount: Math.floor(n) }
-        : feeType === 'rate'
-          ? { type: 'rate', satPerVbyte: n }
-          : { type: 'networkRecommended', leewaySatPerVbyte: Math.floor(n) };
+    const entered = buildDepositMaxFee(feeType, feeValue);
+    const depositMaxFee = entered ?? current.depositMaxFee;
+    const depositMaxFeeByType = { ...current.depositMaxFeeByType };
+    for (const [type, value] of Object.entries(feeDrafts)) {
+      const parsed = buildDepositMaxFee(type as DepositMaxFeeType, value);
+      if (parsed) depositMaxFeeByType[type as DepositMaxFeeType] = Number(value);
+    }
     const updated: UserSettings = isDevMode
       ? {
           depositMaxFee,
+          depositMaxFeeByType,
           syncIntervalSecs: syncIntervalSecs !== '' ? Math.max(0, Math.floor(Number(syncIntervalSecs))) : undefined,
           lnurlDomain: lnurlDomain !== '' ? lnurlDomain : undefined,
           preferSparkOverLightning,
         }
-      : { ...current, depositMaxFee };
+      : { ...current, depositMaxFee, depositMaxFeeByType };
     saveSettings(updated);
     window.location.reload();
   };
@@ -195,9 +186,9 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     <SlideInPage title="Settings" onClose={onBack} slideFrom="left" footer={footer}>
       <div className="p-4">
         <div className="max-w-xl mx-auto w-full space-y-4">
-          {/* Order: page nav, exports, reconnect, toggles, inputs.
-              The "Save Changes" footer applies the toggles + inputs;
-              everything above it commits on tap. */}
+          {/* Order: page nav, exports, settings, diagnostics, developer
+              options, account deletion last. The "Save Changes" footer
+              applies the toggles + inputs; the rest commits on tap. */}
 
           {/* Lock Screen (native only: app lock needs the Capacitor
               shell). Backup is its own entry below; BackupPage runs its
@@ -266,6 +257,46 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
             </div>
           </div>
 
+          {/* Automatic claims. The network-recommended form needs a
+              paragraph to explain, so it stays in developer mode unless it
+              is already what the user picked. */}
+          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+            <h3 className="font-display font-semibold text-spark-text-primary mb-1">Automatic Claims</h3>
+            <p className="text-sm text-spark-text-muted mb-3">
+              On-chain deposits are claimed automatically while the network fee stays under this limit.
+            </p>
+            <FormGroup>
+              <div className="flex gap-2 items-center">
+                <select
+                  value={feeType}
+                  onChange={(e) => setFeeType(e.currentTarget.value as DepositMaxFeeType)}
+                  className="min-w-[160px] bg-spark-surface border border-spark-border rounded-xl px-3 py-3 text-spark-text-primary text-sm focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20"
+                  aria-label="Max fee type"
+                >
+                  <option className="bg-spark-surface" value="fixed">Fixed</option>
+                  <option className="bg-spark-surface" value="rate">Rate</option>
+                  {(isDevMode || feeType === 'networkRecommended') && (
+                    <option className="bg-spark-surface" value="networkRecommended">Network + leeway</option>
+                  )}
+                </select>
+                <div className="flex-1">
+                  <FormInput
+                    id="deposit-fee-default"
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={feeValue}
+                    onChange={(e) => setFeeDrafts({ ...feeDrafts, [feeType]: e.target.value })}
+                    placeholder={feeUnit}
+                  />
+                </div>
+                {/* The placeholder carries the unit too, but it is gone as
+                    soon as the field holds a value. */}
+                <span className="text-sm text-spark-text-muted shrink-0">{feeUnit}</span>
+              </div>
+            </FormGroup>
+          </div>
+
           {/* Passkey & Labels. Every page in the hub acts on the active
               passkey, so a mnemonic-only wallet has nothing to open. */}
           {isDevMode && isPasskeyMode() && (
@@ -300,25 +331,6 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                 <DownloadIcon size="md" />
               )}
               {isDownloadingLogs ? 'Preparing...' : 'Download Logs'}
-            </button>
-          </div>
-
-          {/* Account deletion (App Store 5.1.1(v)): opens the guide
-              explaining how to delete the account (logout wipes the
-              device) and remove the passkey. Reachable without dev
-              mode. */}
-          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-            <h3 className="font-display font-semibold text-spark-text-primary mb-3">Account</h3>
-            <button
-              className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-warning/40 rounded-xl text-spark-warning hover:bg-spark-warning/10 transition-colors"
-              type="button"
-              onClick={() => { void openExternalUrl(ACCOUNT_DELETION_GUIDE_URL); }}
-            >
-              <div className="flex items-center gap-3">
-                <TrashIcon size="md" />
-                <span>How to delete your account</span>
-              </div>
-              <ExternalLinkIcon size="sm" />
             </button>
           </div>
 
@@ -382,41 +394,6 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
             </div>
           )}
 
-          {/* Deposit Claim Fee */}
-          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-            <h3 className="font-display font-semibold text-spark-text-primary mb-1">Automatic Claims</h3>
-            <p className="text-sm text-spark-text-muted mb-3">
-              Incoming Bitcoin is claimed for you while the network fee stays under this amount.
-            </p>
-            <FormGroup>
-              <div className="flex gap-2 items-center">
-                {isDevMode && (
-                  <select
-                    value={feeType}
-                    onChange={(e) => setFeeType(e.currentTarget.value as 'fixed' | 'rate' | 'networkRecommended')}
-                    className="min-w-[160px] bg-spark-surface border border-spark-border rounded-xl px-3 py-3 text-spark-text-primary text-sm focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20"
-                    aria-label="Max fee type"
-                  >
-                    <option className="bg-spark-surface" value="fixed">Fixed (sats)</option>
-                    <option className="bg-spark-surface" value="rate">Rate (sat/vB)</option>
-                    <option className="bg-spark-surface" value="networkRecommended">Network + leeway</option>
-                  </select>
-                )}
-                <div className="flex-1">
-                  <FormInput
-                    id="deposit-fee-default"
-                    type="number"
-                    min={0}
-                    value={feeValue}
-                    onChange={(e) => setFeeValue(e.target.value)}
-                    placeholder={isDevMode && feeType !== 'fixed' ? 'sat/vB' : 'sats'}
-                    aria-label="Maximum claim fee"
-                  />
-                </div>
-              </div>
-            </FormGroup>
-          </div>
-
           {/* Sync Settings */}
           {isDevMode && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
@@ -455,6 +432,25 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
               </FormGroup>
             </div>
           )}
+
+          {/* Account deletion (App Store 5.1.1(v)): opens the guide
+              explaining how to delete the account (logout wipes the
+              device) and remove the passkey. Reachable without dev
+              mode. */}
+          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+            <h3 className="font-display font-semibold text-spark-text-primary mb-3">Account</h3>
+            <button
+              className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-warning/40 rounded-xl text-spark-warning hover:bg-spark-warning/10 transition-colors"
+              type="button"
+              onClick={() => { void openExternalUrl(ACCOUNT_DELETION_GUIDE_URL); }}
+            >
+              <div className="flex items-center gap-3">
+                <TrashIcon size="md" />
+                <span>How to delete your account</span>
+              </div>
+              <ExternalLinkIcon size="sm" />
+            </button>
+          </div>
 
           {/* Version / Dev Mode Toggle */}
           <div className="text-center pt-4">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -120,15 +120,21 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
       const parsed = buildDepositMaxFee(type as DepositMaxFeeType, value);
       if (parsed) depositMaxFeeByType[type as DepositMaxFeeType] = depositMaxFeeValue(parsed);
     }
-    const updated: UserSettings = isDevMode
-      ? {
-          depositMaxFee,
-          depositMaxFeeByType,
-          syncIntervalSecs: syncIntervalSecs !== '' ? Math.max(0, Math.floor(Number(syncIntervalSecs))) : undefined,
-          lnurlDomain: lnurlDomain !== '' ? lnurlDomain : undefined,
-          preferSparkOverLightning,
-        }
-      : { ...current, depositMaxFee, depositMaxFeeByType };
+    // Carry the stored settings through: the fields below are the only ones
+    // this page edits, and rebuilding the object without them dropped
+    // whatever the rest of the app had written, crossChainEnabled included.
+    const updated: UserSettings = {
+      ...current,
+      depositMaxFee,
+      depositMaxFeeByType,
+      ...(isDevMode
+        ? {
+            syncIntervalSecs: syncIntervalSecs !== '' ? Math.max(0, Math.floor(Number(syncIntervalSecs))) : undefined,
+            lnurlDomain: lnurlDomain !== '' ? lnurlDomain : undefined,
+            preferSparkOverLightning,
+          }
+        : {}),
+    };
     saveSettings(updated);
     window.location.reload();
   };

--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -95,3 +95,49 @@ describe('getSettings deposit claim fee', () => {
     expect(getSettings().depositMaxFee).toEqual({ type: 'fixed', amount: 500 });
   });
 });
+
+describe('deposit claim limit helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('rejects input that cannot be a limit, so the caller keeps the stored one', async () => {
+    const { buildDepositMaxFee } = await import('./settings');
+    expect(buildDepositMaxFee('fixed', '')).toBeNull();
+    expect(buildDepositMaxFee('fixed', 'abc')).toBeNull();
+    expect(buildDepositMaxFee('fixed', '-1')).toBeNull();
+  });
+
+  it('builds each limit type in its own unit', async () => {
+    const { buildDepositMaxFee } = await import('./settings');
+    expect(buildDepositMaxFee('fixed', '500.7')).toEqual({ type: 'fixed', amount: 500 });
+    expect(buildDepositMaxFee('rate', '1.5')).toEqual({ type: 'rate', satPerVbyte: 1.5 });
+    expect(buildDepositMaxFee('networkRecommended', '2')).toEqual({ type: 'networkRecommended', leewaySatPerVbyte: 2 });
+  });
+
+  it('drafts the active limit, the last value used for the others, then the defaults', async () => {
+    const { depositMaxFeeDrafts } = await import('./settings');
+    expect(
+      depositMaxFeeDrafts({
+        depositMaxFee: { type: 'rate', satPerVbyte: 3 },
+        depositMaxFeeByType: { fixed: 900 },
+      }),
+    ).toEqual({ fixed: '900', rate: '3', networkRecommended: '0' });
+  });
+
+  it('remembers a value per type across a save', async () => {
+    const { getSettings, saveSettings } = await import('./settings');
+    saveSettings({ depositMaxFee: { type: 'rate', satPerVbyte: 2 }, depositMaxFeeByType: { fixed: 900, rate: 2 } });
+    expect(getSettings().depositMaxFeeByType).toEqual({ fixed: 900, rate: 2 });
+  });
+
+  it('drops remembered values that are not usable numbers', async () => {
+    localStorage.setItem(
+      'user_settings_v1',
+      JSON.stringify({ depositMaxFee: { type: 'fixed', amount: 500 }, depositMaxFeeByType: { fixed: 'oops', rate: -2 } }),
+    );
+    const { getSettings } = await import('./settings');
+    expect(getSettings().depositMaxFeeByType).toBeUndefined();
+  });
+});

--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ensureSparkPrivateMode } from './settings';
 
 function makeSdk(sparkPrivateModeEnabled: boolean, failUpdate = false) {
@@ -69,5 +69,29 @@ describe('buildConnectConfig', () => {
     const { buildConnectConfig } = await import('../hooks/buildConnectConfig');
     expect(buildConnectConfig('mainnet').privateEnabledDefault).toBe(true);
     vi.unstubAllEnvs();
+  });
+});
+
+describe('getSettings deposit claim fee', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('defaults to a flat 500 sat claim threshold', async () => {
+    const { getSettings } = await import('./settings');
+    expect(getSettings().depositMaxFee).toEqual({ type: 'fixed', amount: 500 });
+  });
+
+  it('keeps a saved threshold', async () => {
+    const { getSettings, saveSettings } = await import('./settings');
+    saveSettings({ depositMaxFee: { type: 'fixed', amount: 1200 } });
+    expect(getSettings().depositMaxFee).toEqual({ type: 'fixed', amount: 1200 });
+  });
+
+  it('falls back to the default when the stored fee is malformed', async () => {
+    localStorage.setItem('user_settings_v1', JSON.stringify({ depositMaxFee: { type: 'fixed' } }));
+    const { getSettings } = await import('./settings');
+    expect(getSettings().depositMaxFee).toEqual({ type: 'fixed', amount: 500 });
   });
 });

--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -113,7 +113,7 @@ describe('deposit claim limit helpers', () => {
     const { buildDepositMaxFee } = await import('./settings');
     expect(buildDepositMaxFee('fixed', '500.7')).toEqual({ type: 'fixed', amount: 500 });
     expect(buildDepositMaxFee('rate', '1.5')).toEqual({ type: 'rate', satPerVbyte: 1.5 });
-    expect(buildDepositMaxFee('networkRecommended', '2')).toEqual({ type: 'networkRecommended', leewaySatPerVbyte: 2 });
+    expect(buildDepositMaxFee('networkRecommended', '2.5')).toEqual({ type: 'networkRecommended', leewaySatPerVbyte: 2.5 });
   });
 
   it('drafts the active limit, the last value used for the others, then the defaults', async () => {

--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -112,8 +112,9 @@ describe('deposit claim limit helpers', () => {
   it('builds each limit type in its own unit', async () => {
     const { buildDepositMaxFee } = await import('./settings');
     expect(buildDepositMaxFee('fixed', '500.7')).toEqual({ type: 'fixed', amount: 500 });
-    expect(buildDepositMaxFee('rate', '1.5')).toEqual({ type: 'rate', satPerVbyte: 1.5 });
-    expect(buildDepositMaxFee('networkRecommended', '2.5')).toEqual({ type: 'networkRecommended', leewaySatPerVbyte: 2.5 });
+    // Every variant is a u64 in the SDK, so a typed fraction rounds down.
+    expect(buildDepositMaxFee('rate', '1.5')).toEqual({ type: 'rate', satPerVbyte: 1 });
+    expect(buildDepositMaxFee('networkRecommended', '2.5')).toEqual({ type: 'networkRecommended', leewaySatPerVbyte: 2 });
   });
 
   it('drafts the active limit, the last value used for the others, then the defaults', async () => {

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -82,11 +82,12 @@ export function depositMaxFeeValue(fee: MaxFee): number {
 export function buildDepositMaxFee(type: DepositMaxFeeType, input: string): MaxFee | null {
   const n = Number(input);
   if (input.trim() === '' || !Number.isFinite(n) || n < 0) return null;
-  // Only a sat amount has to be whole. Both sat/vB values are legitimately
-  // fractional, and 1.5 sat/vB floored to 1 is a different limit than asked.
+  // Every variant is a u64 in the SDK, rates included. A fraction crossing
+  // the wasm boundary fails to deserialize and takes the connection with it,
+  // so round down rather than hand one over.
   if (type === 'fixed') return { type: 'fixed', amount: Math.floor(n) };
-  if (type === 'rate') return { type: 'rate', satPerVbyte: n };
-  return { type: 'networkRecommended', leewaySatPerVbyte: n };
+  if (type === 'rate') return { type: 'rate', satPerVbyte: Math.floor(n) };
+  return { type: 'networkRecommended', leewaySatPerVbyte: Math.floor(n) };
 }
 
 /** Starting field value for every limit type: the active limit first, then what was last entered for that type, then its default. */

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -82,9 +82,11 @@ export function depositMaxFeeValue(fee: MaxFee): number {
 export function buildDepositMaxFee(type: DepositMaxFeeType, input: string): MaxFee | null {
   const n = Number(input);
   if (input.trim() === '' || !Number.isFinite(n) || n < 0) return null;
+  // Only a sat amount has to be whole. Both sat/vB values are legitimately
+  // fractional, and 1.5 sat/vB floored to 1 is a different limit than asked.
   if (type === 'fixed') return { type: 'fixed', amount: Math.floor(n) };
   if (type === 'rate') return { type: 'rate', satPerVbyte: n };
-  return { type: 'networkRecommended', leewaySatPerVbyte: Math.floor(n) };
+  return { type: 'networkRecommended', leewaySatPerVbyte: n };
 }
 
 /** Starting field value for every limit type: the active limit first, then what was last entered for that type, then its default. */

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -24,6 +24,12 @@ export function filterProvidersByNetwork(providers: BuyBitcoinProvider[], networ
 
 export interface UserSettings {
   depositMaxFee: MaxFee;
+  /**
+   * Last value entered for each limit type, so switching the type back and
+   * forth keeps what the user chose instead of resetting to the default.
+   * Only the active type is what the SDK is given.
+   */
+  depositMaxFeeByType?: Partial<Record<DepositMaxFeeType, number>>;
   syncIntervalSecs?: number;
   lnurlDomain?: string;
   preferSparkOverLightning?: boolean;
@@ -43,16 +49,55 @@ const FIAT_SETTINGS_KEY = 'fiat_settings_v1';
 const ACTIVE_FIAT_KEY = 'fiat_active_currency';
 const BUY_PROVIDERS_KEY = 'buy_providers_v1';
 
+export type DepositMaxFeeType = MaxFee['type'];
+
 /**
  * Deposits are claimed automatically while the claim fee stays under this
- * limit. A flat sat amount is what the Settings page exposes; the rate and
- * network-recommended variants stay behind developer mode.
+ * limit. Each type carries its own default, so switching type gives a
+ * sensible starting value rather than reusing a number in the wrong unit.
  */
-export const DEFAULT_DEPOSIT_MAX_FEE_SATS = 500;
+export const DEFAULT_DEPOSIT_MAX_FEE_BY_TYPE: Record<DepositMaxFeeType, number> = {
+  fixed: 500,
+  rate: 1,
+  networkRecommended: 0,
+};
 
 const defaultSettings: UserSettings = {
-  depositMaxFee: { type: 'fixed', amount: DEFAULT_DEPOSIT_MAX_FEE_SATS },
+  depositMaxFee: { type: 'fixed', amount: DEFAULT_DEPOSIT_MAX_FEE_BY_TYPE.fixed },
 };
+
+/** The number carried by a limit, whatever unit its type uses. */
+export function depositMaxFeeValue(fee: MaxFee): number {
+  if (fee.type === 'fixed') return fee.amount;
+  if (fee.type === 'rate') return fee.satPerVbyte;
+  return fee.leewaySatPerVbyte;
+}
+
+/**
+ * Build a limit from what the user typed. Returns null when the field holds
+ * nothing usable, which the caller treats as "leave the stored limit alone":
+ * persisting a malformed one would fail validation on the next read and take
+ * every other setting down with it.
+ */
+export function buildDepositMaxFee(type: DepositMaxFeeType, input: string): MaxFee | null {
+  const n = Number(input);
+  if (input.trim() === '' || !Number.isFinite(n) || n < 0) return null;
+  if (type === 'fixed') return { type: 'fixed', amount: Math.floor(n) };
+  if (type === 'rate') return { type: 'rate', satPerVbyte: n };
+  return { type: 'networkRecommended', leewaySatPerVbyte: Math.floor(n) };
+}
+
+/** Starting field value for every limit type: the active limit first, then what was last entered for that type, then its default. */
+export function depositMaxFeeDrafts(settings: UserSettings): Record<DepositMaxFeeType, string> {
+  const byType = settings.depositMaxFeeByType ?? {};
+  const draft = (type: DepositMaxFeeType) =>
+    String(
+      settings.depositMaxFee.type === type
+        ? depositMaxFeeValue(settings.depositMaxFee)
+        : byType[type] ?? DEFAULT_DEPOSIT_MAX_FEE_BY_TYPE[type],
+    );
+  return { fixed: draft('fixed'), rate: draft('rate'), networkRecommended: draft('networkRecommended') };
+}
 
 const defaultFiatSettings: FiatSettings = {
   selectedCurrencies: ['USD'],
@@ -78,6 +123,15 @@ function removeCachedItem(key: string): void {
   storageCache.delete(key);
 }
 
+/** Drops any remembered per-type value that is not a usable number. */
+function sanitizeFeeByType(raw: unknown): UserSettings['depositMaxFeeByType'] {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const entries = Object.entries(raw as Record<string, unknown>).filter(
+    ([type, value]) => type in DEFAULT_DEPOSIT_MAX_FEE_BY_TYPE && typeof value === 'number' && Number.isFinite(value) && value >= 0,
+  );
+  return entries.length > 0 ? (Object.fromEntries(entries) as UserSettings['depositMaxFeeByType']) : undefined;
+}
+
 export function getSettings(): UserSettings {
   try {
     const raw = getCachedItem(SETTINGS_KEY);
@@ -100,8 +154,10 @@ export function getSettings(): UserSettings {
         return defaultSettings;
       }
     }
+    const byType = parsed.depositMaxFeeByType;
     const out: UserSettings = {
       depositMaxFee: depositMaxFee as MaxFee,
+      depositMaxFeeByType: sanitizeFeeByType(byType),
       syncIntervalSecs: typeof parsed.syncIntervalSecs === 'number' ? parsed.syncIntervalSecs : undefined,
       lnurlDomain: typeof parsed.lnurlDomain === 'string' ? parsed.lnurlDomain : undefined,
       preferSparkOverLightning: typeof parsed.preferSparkOverLightning === 'boolean' ? parsed.preferSparkOverLightning : undefined,

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -43,8 +43,15 @@ const FIAT_SETTINGS_KEY = 'fiat_settings_v1';
 const ACTIVE_FIAT_KEY = 'fiat_active_currency';
 const BUY_PROVIDERS_KEY = 'buy_providers_v1';
 
+/**
+ * Deposits are claimed automatically while the claim fee stays under this
+ * limit. A flat sat amount is what the Settings page exposes; the rate and
+ * network-recommended variants stay behind developer mode.
+ */
+export const DEFAULT_DEPOSIT_MAX_FEE_SATS = 500;
+
 const defaultSettings: UserSettings = {
-  depositMaxFee: { type: 'rate', satPerVbyte: 1 },
+  depositMaxFee: { type: 'fixed', amount: DEFAULT_DEPOSIT_MAX_FEE_SATS },
 };
 
 const defaultFiatSettings: FiatSettings = {


### PR DESCRIPTION
Closes #392

On-chain deposits are claimed automatically while the network fee stays under a limit. Setting that limit was only reachable in developer mode, so a busy fee market could have left deposits sitting unclaimed with no way to react by the user.

The limit can now be changed in **Settings**, available for everyone, as a fixed amount in `sats` defaulting to `500`. 
- Each limit type keeps its own value, so moving between them does not carry `500 sats` over as `500 sat/vB`.
- Anyone who already set their own limit keeps it.

**Note**: `Network + leeway` option stays in developer mode, and still appears for anyone whose saved choice is already that.

#### UI Changes

https://github.com/user-attachments/assets/6e7c029c-9823-4cfa-9f5b-e8845d0d9f98

- Title changed from **Deposit Claim Fee** to **Automatic Claims**
- Added "On-chain deposits are claimed automatically while the network fee stays under this limit." subtitle.
- The limit unit is moved from the label to beside the input field. 
  - The input field placeholder previously used to show the unit disappeared once a value was entered.