### PR TITLE
feat: fit the quick amounts to your balance

### DIFF
--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -143,8 +143,8 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
                     onChange={(e) => buy.setAmount(e.target.value)}
                     placeholder={
                       buy.isTokenMode && buy.tokenConfig
-                        ? `Enter amount in ${buy.tokenConfig.symbol}`
-                        : 'Enter amount in satoshis'
+                        ? `Enter amount in ${buy.tokenConfig.currencyCode}`
+                        : 'Enter amount in sats'
                     }
                     disabled={buy.isGenerating}
                     min={buy.isTokenMode ? undefined : 1}

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -8,7 +8,7 @@ import { useInvoicePaid } from '../../../hooks/useInvoicePaid';
 import { useAmountInput } from '../../../hooks/useAmountInput';
 import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
-import { type TokenDisplayConfig } from '../../../utils/tokenFormatting';
+import { fixedQuickAmounts, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
 import { toSdkAmountNumber, type Sats } from '../../../types/sats';
 import { isStandalonePwa, openExternalUrl } from '../../../utils/externalLink';
 import {
@@ -19,8 +19,10 @@ import {
 
 export type BuyStep = 'select' | 'amount' | 'qr';
 
-const CASH_APP_QUICK_AMOUNTS_SATS = [10000, 50000, 100000];
-const CASH_APP_QUICK_AMOUNTS_TOKEN = [5, 10, 25];
+/** What a Cash App quick amount is worth, in dollars. They start where a
+ *  purchase is worth making: below this the provider's fee takes much of it.
+ *  Any amount can still be typed, down to `MIN_CASH_APP_SATS`. */
+const CASH_APP_POINTS_USD = [20, 50, 100];
 const MIN_CASH_APP_SATS: Sats = 1n as Sats;
 
 export interface UseBuyBitcoinOptions {
@@ -87,6 +89,7 @@ export function useBuyBitcoin({
     config: tokenConfig,
     amountSats,
     btcFiatRate,
+    quickAmountScale,
   } = input;
 
   // Detect "too large" inputs: parseAmountToSats returns null once the result
@@ -247,7 +250,10 @@ export function useBuyBitcoin({
 
   const displayedError = error ?? (amountTooLarge ? 'Invalid amount' : null);
 
-  const quickAmounts = isTokenMode ? CASH_APP_QUICK_AMOUNTS_TOKEN : CASH_APP_QUICK_AMOUNTS_SATS;
+  // Buying adds funds, so there is no balance to scale against: fixed points of
+  // value, held there by the rate. One set covers both denominations, since a
+  // purchase has no reason to reach higher in sats than in fiat.
+  const quickAmounts = fixedQuickAmounts(quickAmountScale, CASH_APP_POINTS_USD);
 
   return {
     step,

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -8,11 +8,7 @@ import {
   DialogHeader,
 } from '../../components/ui';
 import { LightningBoltIcon } from '../../components/Icons';
-import {
-  SATS_QUICK_AMOUNTS,
-  fixedQuickAmounts,
-  formatQuickAmount,
-} from '../../utils/tokenFormatting';
+import { fixedQuickAmounts, formatQuickAmount } from '../../utils/tokenFormatting';
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
 import { SatAmount } from '../../components/SatAmount';
 import { useAmountInput, useFiatOverride } from '../../hooks/useAmountInput';
@@ -111,7 +107,13 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     setAmountInput(String(quickAmount));
   };
 
-  const quickAmounts = isTokenMode ? fixedQuickAmounts(unitsPerUsd) : SATS_QUICK_AMOUNTS;
+  // Receive has no balance to scale against, so both denominations offer fixed
+  // points of value. They differ by design: a sat request reaches further up
+  // than a fiat one. Deriving them from the rate keeps each worth what it says
+  // instead of drifting with the BTC price.
+  const quickAmounts = isTokenMode
+    ? fixedQuickAmounts(unitsPerUsd, [1, 5, 10])
+    : fixedQuickAmounts(unitsPerUsd, [1, 10, 100]);
 
   // Range-aware validity check. Mirrors the guard in
   // `useReceivePayment.generateBolt11Invoice` so the UI disables the

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -64,7 +64,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     tokenSymbol,
     config,
     btcFiatRate,
-    unitsPerUsd,
+    quickAmountScale,
     amountSats: parsedSats,
   } = input;
 
@@ -112,8 +112,8 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   // than a fiat one. Deriving them from the rate keeps each worth what it says
   // instead of drifting with the BTC price.
   const quickAmounts = isTokenMode
-    ? fixedQuickAmounts(unitsPerUsd, [1, 5, 10])
-    : fixedQuickAmounts(unitsPerUsd, [1, 10, 100]);
+    ? fixedQuickAmounts(quickAmountScale, [1, 5, 10])
+    : fixedQuickAmounts(quickAmountScale, [1, 10, 100]);
 
   // Range-aware validity check. Mirrors the guard in
   // `useReceivePayment.generateBolt11Invoice` so the UI disables the

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -108,9 +108,8 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   };
 
   // Receive has no balance to scale against, so both denominations offer fixed
-  // points of value. They differ by design: a sat request reaches further up
-  // than a fiat one. Deriving them from the rate keeps each worth what it says
-  // instead of drifting with the BTC price.
+  // points of value, held to that value by the rate. A sat request reaches
+  // further up than a fiat one.
   const quickAmounts = isTokenMode
     ? fixedQuickAmounts(quickAmountScale, [1, 5, 10])
     : fixedQuickAmounts(quickAmountScale, [1, 10, 100]);

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -9,8 +9,8 @@ import {
 } from '../../components/ui';
 import { LightningBoltIcon } from '../../components/Icons';
 import {
-  TOKEN_QUICK_AMOUNTS,
   SATS_QUICK_AMOUNTS,
+  fixedQuickAmounts,
   formatQuickAmount,
 } from '../../utils/tokenFormatting';
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
@@ -68,6 +68,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     tokenSymbol,
     config,
     btcFiatRate,
+    unitsPerUsd,
     amountSats: parsedSats,
   } = input;
 
@@ -110,7 +111,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     setAmountInput(String(quickAmount));
   };
 
-  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
+  const quickAmounts = isTokenMode ? fixedQuickAmounts(unitsPerUsd) : SATS_QUICK_AMOUNTS;
 
   // Range-aware validity check. Mirrors the guard in
   // `useReceivePayment.generateBolt11Invoice` so the UI disables the

--- a/src/features/send/hooks/useBalanceValidation.ts
+++ b/src/features/send/hooks/useBalanceValidation.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
-import { fiatToSats, parseAmountToSats, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
+import { fiatToSats, satsToFiat, parseAmountToSats, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
 import type { Sats } from '../../../types/sats';
 import type { ConversionEstimate } from '@breeztech/breez-sdk-spark';
 
@@ -14,6 +14,12 @@ interface BalanceValidation {
    * value is the raw display value, not a validated Sats.
    */
   exceedsBalance: (displayAmount: number) => boolean;
+  /**
+   * The balance in the unit the user types in: fiat in token mode, sats
+   * otherwise. 0 when it isn't known yet, so callers offer nothing rather than
+   * offering amounts they can't check.
+   */
+  spendableDisplay: number;
   validateAmount: (input: string, feesIncluded?: boolean) => string | null;
   checkInsufficientFunds: (opts: {
     totalSats: Sats;
@@ -57,6 +63,11 @@ export function useBalanceValidation(
     const tokenFallback = isActive && tokenBalanceSats !== null ? tokenBalanceSats : 0;
     return Math.max(balanceSats, tokenFallback);
   };
+
+  const availableSats = maxAvailableSats();
+  const spendableDisplay = availableSats === undefined
+    ? 0
+    : isTokenMode ? satsToFiat(availableSats, btcFiatRate) : availableSats;
 
   const exceedsBalance = (displayAmount: number): boolean => {
     if (isTokenMode && config) {
@@ -115,6 +126,7 @@ export function useBalanceValidation(
     setIsTokenMode,
     parseInputToSats,
     exceedsBalance,
+    spendableDisplay,
     validateAmount,
     checkInsufficientFunds,
     config,

--- a/src/features/send/hooks/useBalanceValidation.ts
+++ b/src/features/send/hooks/useBalanceValidation.ts
@@ -58,6 +58,10 @@ export function useBalanceValidation(
   const parseInputToSats = (input: string): Sats | null =>
     parseAmountToSats(input, isTokenMode, btcFiatRate);
 
+  // Max, not sum: a partial send converts with MinAmountOut(amount), so the
+  // token has to cover the whole payment on its own and the sat change is left
+  // where it is. Send All is the exception, and the SDK sweeps both there by
+  // adding the sat balance to the conversion output.
   const maxAvailableSats = (): number | undefined => {
     if (balanceSats === undefined) return undefined;
     const tokenFallback = isActive && tokenBalanceSats !== null ? tokenBalanceSats : 0;

--- a/src/features/send/steps/AmountStep.test.tsx
+++ b/src/features/send/steps/AmountStep.test.tsx
@@ -89,25 +89,56 @@ describe('AmountStep USD entry (no stable balance)', () => {
 
   const buttonLabels = () => screen.getAllByRole('button').map((b) => b.textContent);
 
-  it('offers only quick amounts the balance covers', () => {
+  // The mock puts BTC at $100,000, which is also the pre-rate fallback scale, so
+  // a test that asserts against it cannot tell the two apart. Waiting for the
+  // switcher is what proves the rate landed first.
+  const ratedLabels = async () => {
+    await screen.findByRole('button', { name: '₿' });
+    return buttonLabels();
+  };
+
+  it('offers only quick amounts the balance covers', async () => {
     // 3,000 sats clears ₿1 000 and ₿2 000 and nothing above.
     renderAmountStep({ balanceSats: 3000 });
 
-    const labels = buttonLabels();
+    const labels = await ratedLabels();
     expect(labels).toContain('₿1 000');
     expect(labels).toContain('₿2 000');
     expect(labels).not.toContain('₿5 000');
     expect(labels).not.toContain('₿100 000');
   });
 
-  it('never offers the whole balance as a quick amount', () => {
+  it('never offers the whole balance as a quick amount', async () => {
     // 100,000 sats: the largest round amount inside the fee headroom is
     // ₿50 000, so tapping a quick amount can't dead-end on insufficient funds.
     renderAmountStep();
 
-    const labels = buttonLabels();
+    const labels = await ratedLabels();
     expect(labels).toEqual(expect.arrayContaining(['₿2 000', '₿10 000', '₿50 000']));
     expect(labels).not.toContain('₿100 000');
+  });
+
+  it('scales the quick amounts to the loaded rate, not the fallback', async () => {
+    // BTC at $50,000 makes a dollar 2,000 sats, so the smallest round amount
+    // worth a dollar is ₿2 000. The fallback scale would still offer ₿1 000.
+    const client = createMockClient({
+      listFiatRates: vi.fn().mockResolvedValue({ rates: [{ coin: 'USD', value: 50000 }] }),
+    } as unknown as Partial<BreezSdk>);
+    renderAmountStep({ balanceSats: 3000 }, client);
+
+    await waitFor(() => expect(buttonLabels()).not.toContain('₿1 000'));
+    expect(buttonLabels()).toContain('₿2 000');
+  });
+
+  it('offers sat quick amounts before any rate has loaded', () => {
+    // Sats entry works without a rate, so the row falls back rather than
+    // waiting. Asserted synchronously: the rate never arrives here.
+    const client = createMockClient({
+      listFiatRates: vi.fn(() => new Promise(() => {})),
+    } as unknown as Partial<BreezSdk>);
+    renderAmountStep({ balanceSats: 3000 }, client);
+
+    expect(buttonLabels()).toEqual(expect.arrayContaining(['₿1 000', '₿2 000']));
   });
 
   it('keeps cross-chain (amountFirst) USD-only with no toggle', async () => {

--- a/src/features/send/steps/AmountStep.test.tsx
+++ b/src/features/send/steps/AmountStep.test.tsx
@@ -37,7 +37,7 @@ describe('AmountStep USD entry (no stable balance)', () => {
     const { onNext } = renderAmountStep();
 
     const input = screen.getByTestId('amount-input');
-    expect(input).toHaveAttribute('placeholder', 'Enter amount in satoshis');
+    expect(input).toHaveAttribute('placeholder', 'Enter amount in sats');
 
     fireEvent.change(input, { target: { value: '1500' } });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
@@ -53,7 +53,7 @@ describe('AmountStep USD entry (no stable balance)', () => {
     fireEvent.click(switcher);
 
     const input = screen.getByTestId('amount-input');
-    expect(input).toHaveAttribute('placeholder', 'Enter amount in $');
+    expect(input).toHaveAttribute('placeholder', 'Enter amount in USD');
 
     fireEvent.change(input, { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
@@ -83,7 +83,7 @@ describe('AmountStep USD entry (no stable balance)', () => {
     expect(screen.queryByRole('button', { name: '₿' })).toBeNull();
     expect(screen.getByTestId('amount-input')).toHaveAttribute(
       'placeholder',
-      'Enter amount in satoshis'
+      'Enter amount in sats'
     );
   });
 

--- a/src/features/send/steps/AmountStep.test.tsx
+++ b/src/features/send/steps/AmountStep.test.tsx
@@ -87,6 +87,29 @@ describe('AmountStep USD entry (no stable balance)', () => {
     );
   });
 
+  const buttonLabels = () => screen.getAllByRole('button').map((b) => b.textContent);
+
+  it('offers only quick amounts the balance covers', () => {
+    // 3,000 sats clears ₿1 000 and ₿2 000 and nothing above.
+    renderAmountStep({ balanceSats: 3000 });
+
+    const labels = buttonLabels();
+    expect(labels).toContain('₿1 000');
+    expect(labels).toContain('₿2 000');
+    expect(labels).not.toContain('₿5 000');
+    expect(labels).not.toContain('₿100 000');
+  });
+
+  it('never offers the whole balance as a quick amount', () => {
+    // 100,000 sats: the largest round amount inside the fee headroom is
+    // ₿50 000, so tapping a quick amount can't dead-end on insufficient funds.
+    renderAmountStep();
+
+    const labels = buttonLabels();
+    expect(labels).toEqual(expect.arrayContaining(['₿2 000', '₿10 000', '₿50 000']));
+    expect(labels).not.toContain('₿100 000');
+  });
+
   it('keeps cross-chain (amountFirst) USD-only with no toggle', async () => {
     renderAmountStep({ amountFirst: true });
 

--- a/src/features/send/steps/AmountStep.test.tsx
+++ b/src/features/send/steps/AmountStep.test.tsx
@@ -7,7 +7,7 @@ import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
 import { createMockClient } from '@/test/mocks/mockWalletApi';
 import AmountStep, { AmountStepProps } from './AmountStep';
 
-// Mock rates put BTC at $100,000, so $1 = 1,000 sats.
+// The mock rate makes a dollar 1,000 sats.
 function renderAmountStep(props: Partial<AmountStepProps> = {}, client?: BreezSdk) {
   const onNext = vi.fn();
   const mockClient = client ?? createMockClient();
@@ -89,9 +89,9 @@ describe('AmountStep USD entry (no stable balance)', () => {
 
   const buttonLabels = () => screen.getAllByRole('button').map((b) => b.textContent);
 
-  // The mock puts BTC at $100,000, which is also the pre-rate fallback scale, so
-  // a test that asserts against it cannot tell the two apart. Waiting for the
-  // switcher is what proves the rate landed first.
+  // The mock rate matches the pre-rate fallback scale, so a test that asserts
+  // against it cannot tell the two apart. Waiting for the switcher is what
+  // proves the rate landed first.
   const ratedLabels = async () => {
     await screen.findByRole('button', { name: '₿' });
     return buttonLabels();
@@ -119,8 +119,8 @@ describe('AmountStep USD entry (no stable balance)', () => {
   });
 
   it('scales the quick amounts to the loaded rate, not the fallback', async () => {
-    // BTC at $50,000 makes a dollar 2,000 sats, so the smallest round amount
-    // worth a dollar is ₿2 000. The fallback scale would still offer ₿1 000.
+    // A rate of 2,000 sats to the dollar puts the smallest round amount worth a
+    // dollar at ₿2 000. The fallback scale would still offer ₿1 000.
     const client = createMockClient({
       listFiatRates: vi.fn().mockResolvedValue({ rates: [{ coin: 'USD', value: 50000 }] }),
     } as unknown as Partial<BreezSdk>);

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -194,7 +194,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
                 }
               }
             }}
-            placeholder={amountFirst ? 'Enter amount in USD' : isTokenMode && tokenSymbol ? `Enter amount in ${tokenSymbol}` : 'Enter amount in satoshis'}
+            placeholder={isTokenMode && config ? `Enter amount in ${config.currencyCode}` : 'Enter amount in sats'}
             className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none read-only:cursor-not-allowed"
             disabled={isLoading}
             readOnly={isSendAll}

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -50,7 +50,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
     tokenIdentifier,
     tokenSymbol,
     config,
-    unitsPerUsd,
+    quickAmountScale,
     parseToSats,
     tokenBalanceDisplay,
     formatSatsAsTokenDisplay,
@@ -83,7 +83,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
     ? localAmount !== '' && parseFloat(localAmount) > 0
     : localAmount !== '' && parseInt(localAmount) > 0;
 
-  const quickAmounts = pickQuickAmounts(balance.spendableDisplay, unitsPerUsd);
+  const quickAmounts = pickQuickAmounts(balance.spendableDisplay, quickAmountScale);
   const amountNum = isTokenMode ? parseFloat(localAmount) || 0 : parseInt(localAmount) || 0;
 
   // Send All target value in BTC-as-fiat (when in token mode without a token

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -2,11 +2,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import type { ConversionOptions } from '@breeztech/breez-sdk-spark';
 import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
 import { SpinnerIcon } from '../../../components/Icons';
-import {
-  TOKEN_QUICK_AMOUNTS,
-  SATS_QUICK_AMOUNTS,
-  formatQuickAmount,
-} from '../../../utils/tokenFormatting';
+import { formatQuickAmount, pickQuickAmounts } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
 import { useAmountInput, useFiatOverride } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
@@ -54,6 +50,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
     tokenIdentifier,
     tokenSymbol,
     config,
+    unitsPerUsd,
     parseToSats,
     tokenBalanceDisplay,
     formatSatsAsTokenDisplay,
@@ -86,7 +83,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
     ? localAmount !== '' && parseFloat(localAmount) > 0
     : localAmount !== '' && parseInt(localAmount) > 0;
 
-  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
+  const quickAmounts = pickQuickAmounts(balance.spendableDisplay, unitsPerUsd);
   const amountNum = isTokenMode ? parseFloat(localAmount) || 0 : parseInt(localAmount) || 0;
 
   // Send All target value in BTC-as-fiat (when in token mode without a token
@@ -218,19 +215,15 @@ const AmountStep: React.FC<AmountStepProps> = ({
         {/* Quick amount buttons */}
         <div className="flex gap-2 mt-3">
           {quickAmounts.map((quickAmount) => {
-            const disabled = balance.exceedsBalance(quickAmount);
             const isSelected = amountNum === quickAmount && !isSendAll;
             return (
               <button
                 key={quickAmount}
                 onClick={() => { setLocalAmount(String(quickAmount)); setFeesIncluded(false); setLocalError(null); }}
-                disabled={disabled}
                 className={`flex-1 py-2 rounded-lg text-sm font-mono font-medium transition-all ${
                   isSelected
                     ? 'bg-spark-primary text-white'
-                    : disabled
-                      ? 'opacity-40 cursor-not-allowed border border-spark-border text-spark-text-secondary'
-                      : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                    : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
                 }`}
               >
                 {isTokenMode && config ? formatQuickAmount(quickAmount, config) : <SatAmount sats={quickAmount} />}

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -42,7 +42,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     tokenSymbol,
     config,
     btcFiatRate,
-    unitsPerUsd,
+    quickAmountScale,
     tokenBalanceDisplay,
     formatSatsAsTokenDisplay,
     tokenSendAllBelowThreshold,
@@ -269,7 +269,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   const toTypedUnit = (sats: number) => (isTokenMode ? satsToFiat(sats, btcFiatRate) : sats);
   const quickAmounts = pickQuickAmounts(
     balance.spendableDisplay,
-    unitsPerUsd,
+    quickAmountScale,
     toTypedUnit(maxSats),
   ).filter((amt) => amt >= toTypedUnit(minSats));
 

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -263,11 +263,14 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
 
   // Quick amounts answer to the request's own send limits as well as the
   // balance. Both bounds convert into the typed unit, so fiat mode is held to
-  // them too, which the fixed presets never were.
+  // them too, which the fixed presets never were. The max goes in as a hard
+  // ceiling rather than as a smaller balance, so it keeps its own value instead
+  // of losing the balance's fee headroom on top.
   const toTypedUnit = (sats: number) => (isTokenMode ? satsToFiat(sats, btcFiatRate) : sats);
   const quickAmounts = pickQuickAmounts(
-    Math.min(balance.spendableDisplay, toTypedUnit(maxSats)),
+    balance.spendableDisplay,
     unitsPerUsd,
+    toTypedUnit(maxSats),
   ).filter((amt) => amt >= toTypedUnit(minSats));
 
   // amount + optional comment form

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -299,8 +299,8 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
               setAmount(e.target.value);
               setFeesIncluded(false);
             }}
-            placeholder={isTokenMode && tokenSymbol
-              ? `Enter amount in ${tokenSymbol}`
+            placeholder={isTokenMode && config
+              ? `Enter amount in ${config.currencyCode}`
               : `Between ${minSats.toLocaleString('en-US').replace(/,/g, ' ')} and ${maxSats.toLocaleString('en-US').replace(/,/g, ' ')} sats`
             }
             className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none read-only:cursor-not-allowed"

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -262,10 +262,9 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     : null;
 
   // Quick amounts answer to the request's own send limits as well as the
-  // balance. Both bounds convert into the typed unit, so fiat mode is held to
-  // them too, which the fixed presets never were. The max goes in as a hard
-  // ceiling rather than as a smaller balance, so it keeps its own value instead
-  // of losing the balance's fee headroom on top.
+  // balance. Both bounds convert into the typed unit so they bind in fiat mode
+  // too. The max is the request's limit, not the user's, so it goes in as a
+  // hard ceiling and keeps its own value.
   const toTypedUnit = (sats: number) => (isTokenMode ? satsToFiat(sats, btcFiatRate) : sats);
   const quickAmounts = pickQuickAmounts(
     balance.spendableDisplay,

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -5,10 +5,7 @@ import { FormError, PrimaryButton, SecondaryButton } from '../../../components/u
 import ConfirmStep from '../steps/ConfirmStep';
 import { logger, LogCategory } from '@/services/logger';
 import { SpinnerIcon } from '@/components/Icons';
-import {
-  TOKEN_QUICK_AMOUNTS,
-  formatQuickAmount,
-} from '../../../utils/tokenFormatting';
+import { formatQuickAmount, pickQuickAmounts, satsToFiat } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
 import { SatAmount } from '../../../components/SatAmount';
 import { formatWithSpaces } from '../../../utils/formatNumber';
@@ -44,6 +41,8 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     tokenIdentifier,
     tokenSymbol,
     config,
+    btcFiatRate,
+    unitsPerUsd,
     tokenBalanceDisplay,
     formatSatsAsTokenDisplay,
     tokenSendAllBelowThreshold,
@@ -262,6 +261,15 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     ? 'Amount exceeds available balance'
     : null;
 
+  // Quick amounts answer to the request's own send limits as well as the
+  // balance. Both bounds convert into the typed unit, so fiat mode is held to
+  // them too, which the fixed presets never were.
+  const toTypedUnit = (sats: number) => (isTokenMode ? satsToFiat(sats, btcFiatRate) : sats);
+  const quickAmounts = pickQuickAmounts(
+    Math.min(balance.spendableDisplay, toTypedUnit(maxSats)),
+    unitsPerUsd,
+  ).filter((amt) => amt >= toTypedUnit(minSats));
+
   // amount + optional comment form
   return (
     <div className="space-y-5">
@@ -313,20 +321,16 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
 
         {/* Quick amount buttons */}
         <div className="flex gap-2 mt-3">
-          {(isTokenMode ? TOKEN_QUICK_AMOUNTS : [1000, 10000, 100000].filter(v => v >= minSats && v <= maxSats)).map((quickAmount) => {
-            const disabled = balance.exceedsBalance(quickAmount);
+          {quickAmounts.map((quickAmount) => {
             const isSelected = amountNum === quickAmount && !isSendAll;
             return (
               <button
                 key={quickAmount}
                 onClick={() => { setAmountInput(String(quickAmount)); setFeesIncluded(false); }}
-                disabled={disabled}
                 className={`flex-1 py-2 text-sm font-medium rounded-lg transition-all ${
                   isSelected
                     ? 'bg-spark-primary text-white'
-                    : disabled
-                      ? 'opacity-40 cursor-not-allowed border border-spark-border text-spark-text-secondary'
-                      : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                    : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
                 }`}
               >
                 {isTokenMode && config ? formatQuickAmount(quickAmount, config) : <SatAmount sats={quickAmount} />}

--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useStableBalance } from '../contexts/StableBalanceContext';
 import { useFiatData } from '../contexts/FiatDataContext';
 import {
+  FALLBACK_SATS_PER_USD,
   buildFiatDisplayConfig,
   parseAmountToSats,
   sanitizeTokenInput,
@@ -86,6 +87,12 @@ export interface UseAmountInputResult {
   config: TokenDisplayConfig | null;
   /** BTC→fiat rate. Escape hatch; prefer the formatting helpers. */
   btcFiatRate: number;
+  /**
+   * How many units of the current denomination make one US dollar: sats per
+   * dollar in sats mode, currency units per dollar in fiat mode. Quick amounts
+   * are the round numbers on this scale. 0 until the USD rate loads.
+   */
+  unitsPerUsd: number;
 
   // ----- Parsing -----
   /** Parse the current input (or a passed string) to a validated Sats value. */
@@ -131,6 +138,7 @@ export interface UseAmountInputResult {
 export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountInputResult {
   const { initialAmount = '', balanceSats, tokenBalance, fiatOverride } = options;
   const stableBalance = useStableBalance();
+  const { fiatRates } = useFiatData();
 
   // When stable balance is off, a fiat override (USD toggle, cross-chain
   // "Send USD") supplies the currency config + rate so the user can still
@@ -174,6 +182,16 @@ export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountIn
     setIsTokenMode((prev) => !prev);
     setAmountInput('');
   }, []);
+
+  // Both rates are quoted per BTC, so dividing one by the other drops BTC out
+  // and leaves the cross rate against the dollar.
+  const unitsPerUsd = useMemo(() => {
+    const usdPerBtc = fiatRates.find(r => r.coin === 'USD')?.value ?? 0;
+    // Sats entry works without a rate, so it falls back rather than dropping
+    // its quick amounts. Fiat entry is gated on the rate anyway.
+    if (usdPerBtc <= 0) return isTokenMode ? 0 : FALLBACK_SATS_PER_USD;
+    return isTokenMode ? btcFiatRate / usdPerBtc : 100_000_000 / usdPerBtc;
+  }, [fiatRates, isTokenMode, btcFiatRate]);
 
   const parseToSats = useCallback(
     (input?: string): Sats | null =>
@@ -230,6 +248,7 @@ export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountIn
     tokenSymbol: config?.symbol ?? null,
     config,
     btcFiatRate,
+    unitsPerUsd,
     parseToSats,
     amountSats,
     tokenBalanceDisplay,

--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -3,10 +3,12 @@ import { useStableBalance } from '../contexts/StableBalanceContext';
 import { useFiatData } from '../contexts/FiatDataContext';
 import {
   FALLBACK_SATS_PER_USD,
+  MIN_SATS_QUICK_AMOUNT,
   buildFiatDisplayConfig,
   parseAmountToSats,
   sanitizeTokenInput,
   tokenAmountDisplaysAsZero,
+  type QuickAmountScale,
   type TokenDisplayConfig,
 } from '../utils/tokenFormatting';
 import { normalizeDecimalInput } from '../utils/decimalInput';
@@ -88,11 +90,11 @@ export interface UseAmountInputResult {
   /** BTC→fiat rate. Escape hatch; prefer the formatting helpers. */
   btcFiatRate: number;
   /**
-   * How many units of the current denomination make one US dollar: sats per
-   * dollar in sats mode, currency units per dollar in fiat mode. Quick amounts
-   * are the round numbers on this scale. 0 until the USD rate loads.
+   * The denomination quick amounts are drawn in: how many of its units make a
+   * dollar, and the smallest unit worth offering. The rate is 0 until the USD
+   * one loads, which is what fiat entry waits on.
    */
-  unitsPerUsd: number;
+  quickAmountScale: QuickAmountScale;
 
   // ----- Parsing -----
   /** Parse the current input (or a passed string) to a validated Sats value. */
@@ -185,12 +187,15 @@ export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountIn
 
   // Both rates are quoted per BTC, so dividing one by the other drops BTC out
   // and leaves the cross rate against the dollar.
-  const unitsPerUsd = useMemo(() => {
+  const quickAmountScale = useMemo<QuickAmountScale>(() => {
     const usdPerBtc = fiatRates.find(r => r.coin === 'USD')?.value ?? 0;
-    // Sats entry works without a rate, so it falls back rather than dropping
-    // its quick amounts. Fiat entry is gated on the rate anyway.
-    if (usdPerBtc <= 0) return isTokenMode ? 0 : FALLBACK_SATS_PER_USD;
-    return isTokenMode ? btcFiatRate / usdPerBtc : 100_000_000 / usdPerBtc;
+    // Sats entry works without the USD rate, so it falls back rather than drop
+    // its quick amounts. Fiat entry cannot parse without a rate at all, so it
+    // has nothing to fall back to.
+    const unitsPerUsd = usdPerBtc <= 0
+      ? (isTokenMode ? 0 : FALLBACK_SATS_PER_USD)
+      : (isTokenMode ? btcFiatRate / usdPerBtc : 100_000_000 / usdPerBtc);
+    return { unitsPerUsd, minUnit: isTokenMode ? 0 : MIN_SATS_QUICK_AMOUNT };
   }, [fiatRates, isTokenMode, btcFiatRate]);
 
   const parseToSats = useCallback(
@@ -248,7 +253,7 @@ export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountIn
     tokenSymbol: config?.symbol ?? null,
     config,
     btcFiatRate,
-    unitsPerUsd,
+    quickAmountScale,
     parseToSats,
     amountSats,
     tokenBalanceDisplay,

--- a/src/utils/tokenFormatting.test.ts
+++ b/src/utils/tokenFormatting.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { pickQuickAmounts, fixedQuickAmounts } from './tokenFormatting';
+import { pickQuickAmounts, fixedQuickAmounts, MIN_SATS_QUICK_AMOUNT } from './tokenFormatting';
 
-// `unitsPerUsd`: 1 for dollars, 150 for a yen-scale currency, and 1000 for
-// sats at $100,000 per BTC.
-const USD = 1;
-const JPY = 150;
-const SATS = 1000;
+/** A fiat denomination: `unitsPerUsd` is 1 for dollars, 150 for a yen scale. */
+const fiat = (unitsPerUsd: number) => ({ unitsPerUsd, minUnit: 0 });
+/** Sats, whose `unitsPerUsd` is sats per dollar: 1000 at $100,000 per BTC. */
+const sats = (unitsPerUsd = 1000) => ({ unitsPerUsd, minUnit: MIN_SATS_QUICK_AMOUNT });
+
+const USD = fiat(1);
+const JPY = fiat(150);
+const SATS = sats();
 
 describe('pickQuickAmounts', () => {
   it('offers nothing without a balance or a rate', () => {
     expect(pickQuickAmounts(0, USD)).toEqual([]);
     expect(pickQuickAmounts(0.9, USD)).toEqual([]);
-    expect(pickQuickAmounts(1000, 0)).toEqual([]);
+    expect(pickQuickAmounts(1000, fiat(0))).toEqual([]);
   });
 
   it('scales the whole row with the balance', () => {
@@ -19,6 +22,8 @@ describe('pickQuickAmounts', () => {
     expect(pickQuickAmounts(10, USD)).toEqual([1, 2, 5]);
     expect(pickQuickAmounts(130, USD)).toEqual([5, 20, 100]);
     expect(pickQuickAmounts(700, USD)).toEqual([20, 100, 500]);
+    expect(pickQuickAmounts(30_000, SATS)).toEqual([1000, 5000, 20_000]);
+    expect(pickQuickAmounts(700_000, SATS)).toEqual([20_000, 100_000, 500_000]);
   });
 
   it('keeps the largest pick clear of the balance, which is Send All', () => {
@@ -46,14 +51,21 @@ describe('pickQuickAmounts', () => {
   it('offers the same steps in either denomination', () => {
     // $3.48 of stable balance at 1136 sats to the dollar (BTC near $88,000),
     // where 1000 sats is worth $0.88 and a hard $1 floor would drop it.
-    expect(pickQuickAmounts(3.48, 1)).toEqual([1, 2]);
-    expect(pickQuickAmounts(3.48 * 1136, 1136)).toEqual([1000, 2000]);
+    expect(pickQuickAmounts(3.48, USD)).toEqual([1, 2]);
+    expect(pickQuickAmounts(3.48 * 1136, sats(1136))).toEqual([1000, 2000]);
   });
 
   it('follows the BTC price in sats, so the floor stays worth a dollar', () => {
     // 10,000 sats is $10 at $100,000 per BTC, and $2.50 at a quarter of that.
-    expect(pickQuickAmounts(10_000, 1000)).toEqual([1000, 2000, 5000]);
-    expect(pickQuickAmounts(10_000, 4000)).toEqual([5000]);
+    expect(pickQuickAmounts(10_000, sats(1000))).toEqual([1000, 2000, 5000]);
+    expect(pickQuickAmounts(10_000, sats(4000))).toEqual([5000]);
+  });
+
+  it('never offers sats below the round minimum, however high BTC goes', () => {
+    // At $500,000 a dollar is 200 sats, so an unfloored ladder would start at
+    // ₿200. Sat amounts stay in thousands instead.
+    expect(pickQuickAmounts(30_000, sats(200))).toEqual([1000, 5000, 20_000]);
+    expect(pickQuickAmounts(3000, sats(200))).toEqual([1000, 2000]);
   });
 });
 
@@ -61,22 +73,25 @@ describe('fixedQuickAmounts', () => {
   it('offers the round amount nearest each named value', () => {
     expect(fixedQuickAmounts(USD, [1, 5, 10])).toEqual([1, 5, 10]);
     expect(fixedQuickAmounts(JPY, [1, 5, 10])).toEqual([200, 1000, 2000]);
-    expect(fixedQuickAmounts(0.307, [1, 5, 10])).toEqual([0.5, 2, 5]);
+    expect(fixedQuickAmounts(fiat(0.307), [1, 5, 10])).toEqual([0.5, 2, 5]);
   });
 
   it('holds the sat points at their value as the BTC price moves', () => {
-    // 1000 sats to the dollar, then 400: the same three values in sats.
-    expect(fixedQuickAmounts(1000, [1, 10, 100])).toEqual([1000, 10_000, 100_000]);
-    expect(fixedQuickAmounts(400, [1, 10, 100])).toEqual([500, 5000, 50_000]);
+    expect(fixedQuickAmounts(sats(1000), [1, 10, 100])).toEqual([1000, 10_000, 100_000]);
+  });
+
+  it('holds the sat minimum rather than follow a dollar down', () => {
+    // At 400 sats to the dollar the $1 point would land on ₿500.
+    expect(fixedQuickAmounts(sats(400), [1, 10, 100])).toEqual([1000, 5000, 50_000]);
   });
 
   it('keeps the points on separate steps when the ladder is coarse', () => {
     // A unit worth several dollars puts $5 and $10 on the same step.
-    expect(fixedQuickAmounts(0.307, [1, 5, 10])).toEqual([0.5, 2, 5]);
+    expect(fixedQuickAmounts(fiat(0.307), [1, 5, 10])).toEqual([0.5, 2, 5]);
     expect(fixedQuickAmounts(USD, [1, 1.1])).toEqual([1, 2]);
   });
 
   it('offers nothing without a rate', () => {
-    expect(fixedQuickAmounts(0, [1, 5, 10])).toEqual([]);
+    expect(fixedQuickAmounts(fiat(0), [1, 5, 10])).toEqual([]);
   });
 });

--- a/src/utils/tokenFormatting.test.ts
+++ b/src/utils/tokenFormatting.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { pickQuickAmounts, fixedQuickAmounts } from './tokenFormatting';
+
+// `unitsPerUsd`: 1 for dollars, 150 for a yen-scale currency, and 1000 for
+// sats at $100,000 per BTC.
+const USD = 1;
+const JPY = 150;
+const SATS = 1000;
+
+describe('pickQuickAmounts', () => {
+  it('offers nothing without a balance or a rate', () => {
+    expect(pickQuickAmounts(0, USD)).toEqual([]);
+    expect(pickQuickAmounts(1.2, USD)).toEqual([]);
+    expect(pickQuickAmounts(1000, 0)).toEqual([]);
+  });
+
+  it('scales the whole row with the balance', () => {
+    expect(pickQuickAmounts(2, USD)).toEqual([1]);
+    expect(pickQuickAmounts(10, USD)).toEqual([1, 2, 5]);
+    expect(pickQuickAmounts(130, USD)).toEqual([5, 20, 100]);
+    expect(pickQuickAmounts(700, USD)).toEqual([20, 100, 500]);
+  });
+
+  it('keeps the largest pick clear of the balance, which is Send All', () => {
+    expect(pickQuickAmounts(1000, USD)).not.toContain(1000);
+    expect(pickQuickAmounts(500_000, SATS)).not.toContain(500_000);
+  });
+
+  it('caps the value at $1000 however large the balance', () => {
+    expect(pickQuickAmounts(1_000_000, USD)).toEqual([50, 200, 1000]);
+    expect(pickQuickAmounts(100_000_000, SATS)).toEqual([20_000, 100_000, 500_000]);
+  });
+
+  it('offers amounts worth having in a currency whose unit is worth a cent', () => {
+    // ¥1 is under a cent, so the ladder starts where a dollar of value does.
+    expect(pickQuickAmounts(1500, JPY)).toEqual([200, 500, 1000]);
+    expect(pickQuickAmounts(100_000, JPY)).toEqual([2000, 10_000, 50_000]);
+  });
+
+  it('follows the BTC price in sats, so the floor stays worth a dollar', () => {
+    // 10,000 sats is $10 at $100,000 per BTC, and $2.50 at a quarter of that.
+    expect(pickQuickAmounts(10_000, 1000)).toEqual([1000, 2000, 5000]);
+    expect(pickQuickAmounts(10_000, 4000)).toEqual([5000]);
+  });
+});
+
+describe('fixedQuickAmounts', () => {
+  it('offers about $1, $5 and $10 in the display currency', () => {
+    expect(fixedQuickAmounts(USD)).toEqual([1, 5, 10]);
+    expect(fixedQuickAmounts(JPY)).toEqual([200, 1000, 2000]);
+    expect(fixedQuickAmounts(0.307)).toEqual([0.5, 2, 5]);
+  });
+
+  it('offers nothing without a rate', () => {
+    expect(fixedQuickAmounts(0)).toEqual([]);
+  });
+});

--- a/src/utils/tokenFormatting.test.ts
+++ b/src/utils/tokenFormatting.test.ts
@@ -37,6 +37,13 @@ describe('pickQuickAmounts', () => {
     expect(pickQuickAmounts(100_000, JPY)).toEqual([2000, 10_000, 50_000]);
   });
 
+  it('offers the same steps in either denomination', () => {
+    // $3.48 of stable balance at 1136 sats to the dollar (BTC near $88,000),
+    // where 1000 sats is worth $0.88 and a hard $1 floor would drop it.
+    expect(pickQuickAmounts(3.48, 1)).toEqual([1, 2]);
+    expect(pickQuickAmounts(3.48 * 1136, 1136)).toEqual([1000, 2000]);
+  });
+
   it('follows the BTC price in sats, so the floor stays worth a dollar', () => {
     // 10,000 sats is $10 at $100,000 per BTC, and $2.50 at a quarter of that.
     expect(pickQuickAmounts(10_000, 1000)).toEqual([1000, 2000, 5000]);

--- a/src/utils/tokenFormatting.test.ts
+++ b/src/utils/tokenFormatting.test.ts
@@ -58,13 +58,25 @@ describe('pickQuickAmounts', () => {
 });
 
 describe('fixedQuickAmounts', () => {
-  it('offers about $1, $5 and $10 in the display currency', () => {
-    expect(fixedQuickAmounts(USD)).toEqual([1, 5, 10]);
-    expect(fixedQuickAmounts(JPY)).toEqual([200, 1000, 2000]);
-    expect(fixedQuickAmounts(0.307)).toEqual([0.5, 2, 5]);
+  it('offers the round amount nearest each named value', () => {
+    expect(fixedQuickAmounts(USD, [1, 5, 10])).toEqual([1, 5, 10]);
+    expect(fixedQuickAmounts(JPY, [1, 5, 10])).toEqual([200, 1000, 2000]);
+    expect(fixedQuickAmounts(0.307, [1, 5, 10])).toEqual([0.5, 2, 5]);
+  });
+
+  it('holds the sat points at their value as the BTC price moves', () => {
+    // 1000 sats to the dollar, then 400: the same three values in sats.
+    expect(fixedQuickAmounts(1000, [1, 10, 100])).toEqual([1000, 10_000, 100_000]);
+    expect(fixedQuickAmounts(400, [1, 10, 100])).toEqual([500, 5000, 50_000]);
+  });
+
+  it('keeps the points on separate steps when the ladder is coarse', () => {
+    // A unit worth several dollars puts $5 and $10 on the same step.
+    expect(fixedQuickAmounts(0.307, [1, 5, 10])).toEqual([0.5, 2, 5]);
+    expect(fixedQuickAmounts(USD, [1, 1.1])).toEqual([1, 2]);
   });
 
   it('offers nothing without a rate', () => {
-    expect(fixedQuickAmounts(0)).toEqual([]);
+    expect(fixedQuickAmounts(0, [1, 5, 10])).toEqual([]);
   });
 });

--- a/src/utils/tokenFormatting.test.ts
+++ b/src/utils/tokenFormatting.test.ts
@@ -3,7 +3,7 @@ import { pickQuickAmounts, fixedQuickAmounts, MIN_SATS_QUICK_AMOUNT } from './to
 
 /** A fiat denomination: `unitsPerUsd` is 1 for dollars, 150 for a yen scale. */
 const fiat = (unitsPerUsd: number) => ({ unitsPerUsd, minUnit: 0 });
-/** Sats, whose `unitsPerUsd` is sats per dollar: 1000 at $100,000 per BTC. */
+/** Sats, whose `unitsPerUsd` is sats per dollar. */
 const sats = (unitsPerUsd = 1000) => ({ unitsPerUsd, minUnit: MIN_SATS_QUICK_AMOUNT });
 
 const USD = fiat(1);
@@ -49,21 +49,21 @@ describe('pickQuickAmounts', () => {
   });
 
   it('offers the same steps in either denomination', () => {
-    // $3.48 of stable balance at 1136 sats to the dollar (BTC near $88,000),
-    // where 1000 sats is worth $0.88 and a hard $1 floor would drop it.
+    // A stable balance at 1136 sats to the dollar, where ₿1 000 is worth just
+    // under a dollar and a hard floor would drop it.
     expect(pickQuickAmounts(3.48, USD)).toEqual([1, 2]);
     expect(pickQuickAmounts(3.48 * 1136, sats(1136))).toEqual([1000, 2000]);
   });
 
   it('follows the BTC price in sats, so the floor stays worth a dollar', () => {
-    // 10,000 sats is $10 at $100,000 per BTC, and $2.50 at a quarter of that.
+    // The same sats are worth a quarter as much at four times the sats per dollar.
     expect(pickQuickAmounts(10_000, sats(1000))).toEqual([1000, 2000, 5000]);
     expect(pickQuickAmounts(10_000, sats(4000))).toEqual([5000]);
   });
 
   it('never offers sats below the round minimum, however high BTC goes', () => {
-    // At $500,000 a dollar is 200 sats, so an unfloored ladder would start at
-    // ₿200. Sat amounts stay in thousands instead.
+    // At 200 sats to the dollar an unfloored ladder would start at ₿200. Sat
+    // amounts stay in thousands instead.
     expect(pickQuickAmounts(30_000, sats(200))).toEqual([1000, 5000, 20_000]);
     expect(pickQuickAmounts(3000, sats(200))).toEqual([1000, 2000]);
   });
@@ -84,7 +84,7 @@ describe('fixedQuickAmounts', () => {
   });
 
   it('holds the sat minimum rather than follow a dollar down', () => {
-    // At 400 sats to the dollar the $1 point would land on ₿500.
+    // At 400 sats to the dollar the lowest point would land on ₿500.
     expect(fixedQuickAmounts(sats(400), [1, 10, 100])).toEqual([1000, 5000, 50_000]);
   });
 

--- a/src/utils/tokenFormatting.test.ts
+++ b/src/utils/tokenFormatting.test.ts
@@ -10,7 +10,7 @@ const SATS = 1000;
 describe('pickQuickAmounts', () => {
   it('offers nothing without a balance or a rate', () => {
     expect(pickQuickAmounts(0, USD)).toEqual([]);
-    expect(pickQuickAmounts(1.2, USD)).toEqual([]);
+    expect(pickQuickAmounts(0.9, USD)).toEqual([]);
     expect(pickQuickAmounts(1000, 0)).toEqual([]);
   });
 
@@ -24,6 +24,12 @@ describe('pickQuickAmounts', () => {
   it('keeps the largest pick clear of the balance, which is Send All', () => {
     expect(pickQuickAmounts(1000, USD)).not.toContain(1000);
     expect(pickQuickAmounts(500_000, SATS)).not.toContain(500_000);
+  });
+
+  it('treats a destination maximum as its own limit, with no headroom taken', () => {
+    // An LNURL max of $500 is payable in full, unlike $500 of balance.
+    expect(pickQuickAmounts(1_000_000, USD, 500)).toContain(500);
+    expect(pickQuickAmounts(500, USD)).not.toContain(500);
   });
 
   it('caps the value at $1000 however large the balance', () => {

--- a/src/utils/tokenFormatting.test.ts
+++ b/src/utils/tokenFormatting.test.ts
@@ -78,6 +78,9 @@ describe('fixedQuickAmounts', () => {
 
   it('holds the sat points at their value as the BTC price moves', () => {
     expect(fixedQuickAmounts(sats(1000), [1, 10, 100])).toEqual([1000, 10_000, 100_000]);
+    // Buy's points, the same values in either denomination.
+    expect(fixedQuickAmounts(sats(1000), [20, 50, 100])).toEqual([20_000, 50_000, 100_000]);
+    expect(fixedQuickAmounts(USD, [20, 50, 100])).toEqual([20, 50, 100]);
   });
 
   it('holds the sat minimum rather than follow a dollar down', () => {

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -279,11 +279,10 @@ export function getTokenAmountFromPayment(payment: Payment): TokenPaymentInfo | 
 const MIN_USD = 1;
 const MAX_USD = 1000;
 
-/** How far under `MIN_USD` a rung may sit and still count. Rungs are about 2x
- *  apart, so a hard floor drops the one just below it and nearly doubles the
- *  smallest offer: at 1136 sats to the dollar, 1000 sats is worth $0.88, and
- *  the sat row would start at 2000 while the same balance in fiat starts at $1.
- *  Half a rung of slack keeps the two denominations offering the same steps. */
+/** How far under `MIN_USD` a step may sit and still count. Steps are about 2x
+ *  apart, so a hard floor drops the one just below it, nearly doubling the
+ *  smallest offer and splitting the denominations apart. Half a step of slack
+ *  keeps them aligned. */
 const MIN_USD_SLACK = Math.SQRT2;
 
 /** Seven digits is where a label stops fitting the four-button row on a phone.
@@ -298,8 +297,9 @@ const MAX_UNITS = 999_999;
 export const FALLBACK_SATS_PER_USD = 1000;
 
 /** Smallest sat amount worth offering. A dollar buys fewer sats as BTC rises,
- *  and without this the row follows it down to ₿500 and then ₿200, which read
- *  as change rather than as amounts. */
+ *  and without a floor the row follows it down into amounts that read as
+ *  change. Steps are 1, 2 and 5 times a power of ten, so a floor here also
+ *  keeps every sat amount a round thousand. */
 export const MIN_SATS_QUICK_AMOUNT = 1000;
 
 /** The denomination a row of quick amounts is drawn in. */
@@ -311,12 +311,10 @@ export interface QuickAmountScale {
 }
 
 /** Share of the balance the largest quick amount may reach. The rest covers the
- *  conversion (10 bps slippage cap plus pool and integrator fees) and a
- *  Lightning base fee, and keeps the top amount off the balance exactly, which
- *  dead-ends on insufficient funds and duplicates Send All. Steps sit about 2x
- *  apart, so a tighter value would rarely change the pick but would remove that
- *  margin. A flat onchain fee is quoted after the amount is picked and can
- *  outrun any proportional reserve. */
+ *  conversion and a Lightning base fee, and keeps the top amount off the
+ *  balance exactly, which dead-ends on insufficient funds and duplicates Send
+ *  All. A flat onchain fee is quoted only after the amount is picked, so no
+ *  proportional reserve bounds it. */
 const SPENDABLE_HEADROOM = 0.98;
 
 /** Round amounts (1, 2 and 5 times a power of ten) from `min` to `max`, ascending. */

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -297,6 +297,19 @@ const MAX_UNITS = 999_999;
  *  a rung. */
 export const FALLBACK_SATS_PER_USD = 1000;
 
+/** Smallest sat amount worth offering. A dollar buys fewer sats as BTC rises,
+ *  and without this the row follows it down to ₿500 and then ₿200, which read
+ *  as change rather than as amounts. */
+export const MIN_SATS_QUICK_AMOUNT = 1000;
+
+/** The denomination a row of quick amounts is drawn in. */
+export interface QuickAmountScale {
+  /** Units of that denomination in one US dollar. 0 when no rate has loaded. */
+  unitsPerUsd: number;
+  /** Smallest amount to offer, in the denomination's own units. */
+  minUnit: number;
+}
+
 /** Share of the balance the largest quick amount may reach. The rest covers the
  *  conversion (10 bps slippage cap plus pool and integrator fees) and a
  *  Lightning base fee, and keeps the top amount off the balance exactly, which
@@ -330,18 +343,18 @@ function roundAmountsBetween(min: number, max: number): number[] {
  * unit. Every such currency has a fraction size of at least 2, so the value is
  * always representable.
  */
-function quickAmountLadder(unitsPerUsd: number): number[] {
+function quickAmountLadder({ unitsPerUsd, minUnit }: QuickAmountScale): number[] {
   return roundAmountsBetween(
-    (MIN_USD * unitsPerUsd) / MIN_USD_SLACK,
+    Math.max((MIN_USD * unitsPerUsd) / MIN_USD_SLACK, minUnit),
     Math.min(MAX_USD * unitsPerUsd, MAX_UNITS),
   );
 }
 
 /**
  * Up to three round quick amounts, scaled to what the user can send.
- * `spendable` is the balance in the unit being typed. 0 for either of the first
- * two arguments (unknown balance or no rate yet) offers nothing.
- * `hardCeiling` caps the picks at a destination's own maximum.
+ * `spendable` is the balance in the unit being typed; 0 for it or for the
+ * scale's rate (none loaded yet) offers nothing. `hardCeiling` caps the picks
+ * at a destination's own maximum.
  *
  * The largest pick is the biggest round amount inside the headroom, and the
  * other two step down the ladder from it. Anchoring to the top is what makes
@@ -350,10 +363,10 @@ function quickAmountLadder(unitsPerUsd: number): number[] {
  */
 export function pickQuickAmounts(
   spendable: number,
-  unitsPerUsd: number,
+  scale: QuickAmountScale,
   hardCeiling = Infinity,
 ): number[] {
-  const ladder = quickAmountLadder(unitsPerUsd);
+  const ladder = quickAmountLadder(scale);
   // `hardCeiling` is a limit of the destination's own, not of the balance, so
   // it takes no headroom: an amount equal to it is payable.
   const ceiling = Math.min(spendable * SPENDABLE_HEADROOM, hardCeiling);
@@ -370,12 +383,12 @@ export function pickQuickAmounts(
  * round amount nearest each of `usdPoints`, which names the values wanted in
  * dollars, ascending.
  */
-export function fixedQuickAmounts(unitsPerUsd: number, usdPoints: number[]): number[] {
-  const ladder = quickAmountLadder(unitsPerUsd);
+export function fixedQuickAmounts(scale: QuickAmountScale, usdPoints: number[]): number[] {
+  const ladder = quickAmountLadder(scale);
   if (ladder.length === 0) return [];
   const picked: number[] = [];
   for (const usd of usdPoints) {
-    const target = usd * unitsPerUsd;
+    const target = usd * scale.unitsPerUsd;
     // Nearest by ratio, not by difference: steps are spaced multiplicatively,
     // so subtracting would pull every point towards the top of the ladder.
     const nearest = ladder.reduce((best, amount) =>

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -275,6 +275,13 @@ export const SATS_QUICK_AMOUNTS = [1000, 10000, 100000];
 const MIN_USD = 1;
 const MAX_USD = 1000;
 
+/** How far under `MIN_USD` a rung may sit and still count. Rungs are about 2x
+ *  apart, so a hard floor drops the one just below it and nearly doubles the
+ *  smallest offer: at 1136 sats to the dollar, 1000 sats is worth $0.88, and
+ *  the sat row would start at 2000 while the same balance in fiat starts at $1.
+ *  Half a rung of slack keeps the two denominations offering the same steps. */
+const MIN_USD_SLACK = Math.SQRT2;
+
 /** Seven digits is where a label stops fitting the four-button row on a phone.
  *  Only binds in a currency whose unit is worth a fraction of a cent, which
  *  gets a lower ceiling in exchange for a row that still lays out. */
@@ -316,7 +323,10 @@ function roundAmountsBetween(min: number, max: number): number[] {
  * always representable.
  */
 function quickAmountLadder(unitsPerUsd: number): number[] {
-  return roundAmountsBetween(MIN_USD * unitsPerUsd, Math.min(MAX_USD * unitsPerUsd, MAX_UNITS));
+  return roundAmountsBetween(
+    (MIN_USD * unitsPerUsd) / MIN_USD_SLACK,
+    Math.min(MAX_USD * unitsPerUsd, MAX_UNITS),
+  );
 }
 
 /**

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -275,9 +275,6 @@ export function getTokenAmountFromPayment(payment: Payment): TokenPaymentInfo | 
   return null;
 }
 
-/** Quick amount presets for sat-denominated inputs. */
-export const SATS_QUICK_AMOUNTS = [1000, 10000, 100000];
-
 /** Value a quick amount may be worth, in US dollars (#393). */
 const MIN_USD = 1;
 const MAX_USD = 1000;
@@ -370,11 +367,28 @@ export function pickQuickAmounts(
 
 /**
  * Quick amounts for an input with no balance to scale against (receive): the
- * round amounts worth roughly $1, $5 and $10 in the display currency.
+ * round amount nearest each of `usdPoints`, which names the values wanted in
+ * dollars, ascending.
  */
-export function fixedQuickAmounts(unitsPerUsd: number): number[] {
+export function fixedQuickAmounts(unitsPerUsd: number, usdPoints: number[]): number[] {
   const ladder = quickAmountLadder(unitsPerUsd);
-  return [0, 2, 3].map((i) => ladder[i]).filter((amount) => amount !== undefined);
+  if (ladder.length === 0) return [];
+  const picked: number[] = [];
+  for (const usd of usdPoints) {
+    const target = usd * unitsPerUsd;
+    // Nearest by ratio, not by difference: steps are spaced multiplicatively,
+    // so subtracting would pull every point towards the top of the ladder.
+    const nearest = ladder.reduce((best, amount) =>
+      Math.abs(Math.log(amount / target)) < Math.abs(Math.log(best / target)) ? amount : best);
+    const last = picked[picked.length - 1];
+    // Step up rather than repeat: in a currency whose unit is worth several
+    // dollars, two points can land on one step and spend two buttons on it.
+    const choice = last !== undefined && nearest <= last
+      ? ladder.find((amount) => amount > last)
+      : nearest;
+    if (choice !== undefined && choice !== last) picked.push(choice);
+  }
+  return picked;
 }
 
 /** Format a token-denominated quick amount label, respecting symbol position.

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -300,12 +300,14 @@ const MAX_UNITS = 999_999;
  *  a rung. */
 export const FALLBACK_SATS_PER_USD = 1000;
 
-/** Share of the balance the largest quick amount may reach. The rest is fee
- *  headroom: an amount equal to the balance dead-ends on insufficient funds,
- *  and Send All already spends everything. Being proportional it covers a Spark
- *  or Lightning send, but not a flat onchain fee, which is quoted after the
- *  amount is picked and can outrun it on a small balance. */
-const SPENDABLE_HEADROOM = 0.8;
+/** Share of the balance the largest quick amount may reach. The rest covers the
+ *  conversion (10 bps slippage cap plus pool and integrator fees) and a
+ *  Lightning base fee, and keeps the top amount off the balance exactly, which
+ *  dead-ends on insufficient funds and duplicates Send All. Steps sit about 2x
+ *  apart, so a tighter value would rarely change the pick but would remove that
+ *  margin. A flat onchain fee is quoted after the amount is picked and can
+ *  outrun any proportional reserve. */
+const SPENDABLE_HEADROOM = 0.98;
 
 /** Round amounts (1, 2 and 5 times a power of ten) from `min` to `max`, ascending. */
 function roundAmountsBetween(min: number, max: number): number[] {
@@ -340,17 +342,25 @@ function quickAmountLadder(unitsPerUsd: number): number[] {
 
 /**
  * Up to three round quick amounts, scaled to what the user can send.
- * `spendable` is the balance in the unit being typed. 0 for either argument
- * (unknown balance or no rate yet) offers nothing.
+ * `spendable` is the balance in the unit being typed. 0 for either of the first
+ * two arguments (unknown balance or no rate yet) offers nothing.
+ * `hardCeiling` caps the picks at a destination's own maximum.
  *
  * The largest pick is the biggest round amount inside the headroom, and the
  * other two step down the ladder from it. Anchoring to the top is what makes
  * the row scale: a large balance gets amounts worth sending rather than the
  * ladder's floor, which no balance would ever price out.
  */
-export function pickQuickAmounts(spendable: number, unitsPerUsd: number): number[] {
+export function pickQuickAmounts(
+  spendable: number,
+  unitsPerUsd: number,
+  hardCeiling = Infinity,
+): number[] {
   const ladder = quickAmountLadder(unitsPerUsd);
-  const top = ladder.filter((amount) => amount <= spendable * SPENDABLE_HEADROOM).length - 1;
+  // `hardCeiling` is a limit of the destination's own, not of the balance, so
+  // it takes no headroom: an amount equal to it is payable.
+  const ceiling = Math.min(spendable * SPENDABLE_HEADROOM, hardCeiling);
+  const top = ladder.filter((amount) => amount <= ceiling).length - 1;
   // Two rungs apart (roughly 5x) once the balance leaves room for it, so the
   // three cover a range; adjacent rungs when it doesn't. Negative indices fall
   // out, which is also how a balance under the smallest rung returns nothing.

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -161,6 +161,12 @@ export function fiatToSats(fiatAmount: number, btcFiatRate: number): number {
   return Math.round((fiatAmount / btcFiatRate) * 100_000_000);
 }
 
+/** Inverse of `fiatToSats`. 0 when no rate has loaded. */
+export function satsToFiat(sats: number, btcFiatRate: number): number {
+  if (btcFiatRate <= 0) return 0;
+  return (sats / 100_000_000) * btcFiatRate;
+}
+
 /**
  * Parse a user-entered amount string to a validated `Sats` value.
  * - Token mode: input is fiat (e.g. "10.50") → converts via btcFiatRate
@@ -262,11 +268,85 @@ export function getTokenAmountFromPayment(payment: Payment): TokenPaymentInfo | 
   return null;
 }
 
-/** Quick amount presets for token-denominated inputs. */
-export const TOKEN_QUICK_AMOUNTS = [1, 5, 10];
-
 /** Quick amount presets for sat-denominated inputs. */
 export const SATS_QUICK_AMOUNTS = [1000, 10000, 100000];
+
+/** Value a quick amount may be worth, in US dollars (#393). */
+const MIN_USD = 1;
+const MAX_USD = 1000;
+
+/** Seven digits is where a label stops fitting the four-button row on a phone.
+ *  Only binds in a currency whose unit is worth a fraction of a cent, which
+ *  gets a lower ceiling in exchange for a row that still lays out. */
+const MAX_UNITS = 999_999;
+
+/** Sats per dollar to fall back on before a rate has loaded, so sat quick
+ *  amounts still render on a cold start. It only decides which round numbers
+ *  get offered, never a conversion, so being off by a price move costs at most
+ *  a rung. */
+export const FALLBACK_SATS_PER_USD = 1000;
+
+/** Share of the balance the largest quick amount may reach. The rest is fee
+ *  headroom: an amount equal to the balance dead-ends on insufficient funds at
+ *  the confirm step, and Send All already spends everything. */
+const SPENDABLE_HEADROOM = 0.8;
+
+/** Round amounts (1, 2 and 5 times a power of ten) from `min` to `max`, ascending. */
+function roundAmountsBetween(min: number, max: number): number[] {
+  if (!(min > 0) || !(max >= min)) return [];
+  const amounts: number[] = [];
+  for (let exponent = Math.floor(Math.log10(min)); 10 ** exponent <= max; exponent++) {
+    for (const step of [1, 2, 5]) {
+      const amount = step * 10 ** exponent;
+      if (amount >= min && amount <= max) amounts.push(amount);
+    }
+  }
+  return amounts;
+}
+
+/**
+ * The round amounts worth between $1 and $1000 in the unit the user is typing.
+ * `unitsPerUsd` is how many of that unit make a dollar: sats per dollar in sats
+ * mode, currency units per dollar in fiat mode. Deriving the ladder from the
+ * rate is what keeps the amounts round in a currency whose unit is worth a
+ * hundredth of a dollar, where a fixed 1 to 1000 ladder would be all dust.
+ *
+ * Rungs can carry one decimal place in a currency worth more than a dollar per
+ * unit. Every such currency has a fraction size of at least 2, so the value is
+ * always representable.
+ */
+function quickAmountLadder(unitsPerUsd: number): number[] {
+  return roundAmountsBetween(MIN_USD * unitsPerUsd, Math.min(MAX_USD * unitsPerUsd, MAX_UNITS));
+}
+
+/**
+ * Up to three round quick amounts, scaled to what the user can send.
+ * `spendable` is the balance in the unit being typed. 0 for either argument
+ * (unknown balance or no rate yet) offers nothing.
+ *
+ * The largest pick is the biggest round amount inside the headroom, and the
+ * other two step down the ladder from it. Anchoring to the top is what makes
+ * the row scale: a large balance gets amounts worth sending rather than the
+ * ladder's floor, which no balance would ever price out.
+ */
+export function pickQuickAmounts(spendable: number, unitsPerUsd: number): number[] {
+  const ladder = quickAmountLadder(unitsPerUsd);
+  const top = ladder.filter((amount) => amount <= spendable * SPENDABLE_HEADROOM).length - 1;
+  // Two rungs apart (roughly 5x) once the balance leaves room for it, so the
+  // three cover a range; adjacent rungs when it doesn't. Negative indices fall
+  // out, which is also how a balance under the smallest rung returns nothing.
+  const stride = top >= 4 ? 2 : 1;
+  return [top - 2 * stride, top - stride, top].filter((i) => i >= 0).map((i) => ladder[i]);
+}
+
+/**
+ * Quick amounts for an input with no balance to scale against (receive): the
+ * round amounts worth roughly $1, $5 and $10 in the display currency.
+ */
+export function fixedQuickAmounts(unitsPerUsd: number): number[] {
+  const ladder = quickAmountLadder(unitsPerUsd);
+  return [0, 2, 3].map((i) => ladder[i]).filter((amount) => amount !== undefined);
+}
 
 /** Format a token-denominated quick amount label, respecting symbol position.
  *  Sat-denominated buttons render `SatAmount` instead. */

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -294,8 +294,10 @@ const MAX_UNITS = 999_999;
 export const FALLBACK_SATS_PER_USD = 1000;
 
 /** Share of the balance the largest quick amount may reach. The rest is fee
- *  headroom: an amount equal to the balance dead-ends on insufficient funds at
- *  the confirm step, and Send All already spends everything. */
+ *  headroom: an amount equal to the balance dead-ends on insufficient funds,
+ *  and Send All already spends everything. Being proportional it covers a Spark
+ *  or Lightning send, but not a flat onchain fee, which is quoted after the
+ *  amount is picked and can outrun it on a small balance. */
 const SPENDABLE_HEADROOM = 0.8;
 
 /** Round amounts (1, 2 and 5 times a power of ten) from `min` to `max`, ascending. */

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -4,6 +4,9 @@ import { isCrossChainPayment } from './paymentDescription';
 
 export interface TokenDisplayConfig {
   symbol: string;
+  /** Code to name the unit in prose ("Enter amount in USD"), where the symbol
+   *  reads as decoration rather than a unit. Falls back to the token ticker. */
+  currencyCode: string;
   symbolPosition: 'before' | 'after';
   fractionSize: number;
   decimals: number;
@@ -38,6 +41,7 @@ export function buildFiatDisplayConfig(
   if (match) {
     return {
       symbol: match.info.symbol?.grapheme || match.id,
+      currencyCode: match.id,
       symbolPosition: match.info.symbol?.rtl ? 'after' : 'before',
       fractionSize: match.info.fractionSize,
       decimals: match.info.fractionSize,
@@ -47,6 +51,7 @@ export function buildFiatDisplayConfig(
   }
   return {
     symbol: currencyId === 'USD' ? '$' : currencyId,
+    currencyCode: currencyId,
     symbolPosition: 'before',
     fractionSize: 2,
     decimals: 2,
@@ -79,6 +84,7 @@ export function buildTokenDisplayConfig(
   if (bestMatch) {
     return {
       symbol: bestMatch.info.symbol?.grapheme || bestMatch.id,
+      currencyCode: bestMatch.id,
       symbolPosition: bestMatch.info.symbol?.rtl ? 'after' : 'before',
       fractionSize: bestMatch.info.fractionSize,
       decimals: tokenMetadata.decimals,
@@ -93,6 +99,7 @@ export function buildTokenDisplayConfig(
 
   return {
     symbol: displayTicker,
+    currencyCode: tokenMetadata.ticker,
     symbolPosition: 'before',
     fractionSize: Math.min(tokenMetadata.decimals, 2),
     decimals: tokenMetadata.decimals,


### PR DESCRIPTION
Closes #393

The send screen always showed the same three quick amounts. On a small balance, most of them were more than you have. On a large balance, all of them were too small to use. The largest amount you could afford was your exact balance. Sending that amoun failed, because it did not cover fees.

This PR picks the quick amounts from your balance. It offers round amounts that you can afford. It keeps the largest amount below your balance, so it has enough headroom for fees. The amounts get larger as your balance gets larger, capped at $1000.

The amounts also follow the exchange rate. Before, they were fixed numbers that only made sense in dollars. If you select a currency where one unit is worth less than a cent, the receive screen offered you amounts worth a few cents. Now each currency gets round amounts of a similar value.

#### UI

Each preview shows the same balance in BTC mode and token mode. Click a preview for full size.
| # | Scenario | BTC mode | Token mode | Preview |
| --- | --- | --- | --- | --- |
| 1 | Empty wallet | none | none | <img width="380" alt="1empty" src="https://github.com/user-attachments/assets/39ebc49b-e1ca-413d-9b15-978c947837ef" /> |
| 2 | Dust only, 900 sats | none | none | <img width="380" alt="2dust" src="https://github.com/user-attachments/assets/886cbb2f-017d-4202-8244-457222c6e4a6" /> |
| 3 | Small BTC, 3 000 sats (about $2.64) | ₿1 000, ₿2 000 | $1, $2 | <img width="380" alt="3smallbtc" src="https://github.com/user-attachments/assets/bfa1096c-7334-429c-acb5-26050a75fcea" /> |
| 4 | Mid BTC, 100 000 sats (about $88) | ₿2 000, ₿10 000, ₿50 000 | $2, $10, $50 | <img width="380" alt="4midbtc" src="https://github.com/user-attachments/assets/e4c3d9ab-88ea-4d7c-b84f-238defb771ff" /> |
| 5 | Large BTC, 5 000 000 sats, hits the cap | ₿20 000, ₿100 000, ₿500 000 | $50, $200, $1000 | <img width="380" alt="5largebtc" src="https://github.com/user-attachments/assets/ff324627-e8d4-48a6-a14f-e52cf8e6607c" /> |
| 6 | Stable balance, $3.48 in USDB plus 784 sats of change | ₿1 000, ₿2 000 | $1, $2 | <img width="380" alt="6stablereported" src="https://github.com/user-attachments/assets/33b9741b-820e-4ada-9257-6feb4ebff6ba" /> |
| 7 | Stable balance, $130 in USDB | ₿5 000, ₿20 000, ₿100 000 | $5, $20, $100 | <img width="380" alt="7stablemid" src="https://github.com/user-attachments/assets/ec93551a-e4b9-4c87-bea4-ea72041e311f" /> |
| 8 | Stable balance, $1 200 in USDB, hits the $1000 cap | ₿20 000, ₿100 000, ₿500 000 | $20, $100, $500 | <img width="380" alt="8stablelarge" src="https://github.com/user-attachments/assets/5846253b-5789-4630-a4e5-ba032cab004f" /> |