### PR TITLE
fix: update the exchange rate when you open the app again

### DIFF
--- a/src/components/StableBalanceToggleFlow.tsx
+++ b/src/components/StableBalanceToggleFlow.tsx
@@ -30,7 +30,7 @@ const StableBalanceToggleFlow: React.FC<StableBalanceToggleFlowProps> = ({
 }) => {
   const wallet = useWallet();
   const stableBalance = useStableBalance();
-  const { getOrFetchFiatData } = useFiatData();
+  const { refreshFiatData } = useFiatData();
 
   const [step, setStep] = useState<FlowStep>('disclaimer');
   const [conversionEstimate, setConversionEstimate] = useState<ConversionEstimate | null>(null);
@@ -42,10 +42,12 @@ const StableBalanceToggleFlow: React.FC<StableBalanceToggleFlowProps> = ({
     setError(null);
 
     try {
-      // Fetch wallet info and ensure fiat data is available (cached or freshly fetched)
+      // The rate sizes the conversion's minimum output below, so it is fetched
+      // rather than read off the 60s refresh: a price move since the last tick
+      // would size the request against a price that no longer holds.
       const [freshInfo, fiatData, metadataResult] = await Promise.all([
         wallet.getInfo({}),
-        getOrFetchFiatData(),
+        refreshFiatData(),
         wallet.getTokensMetadata({ tokenIdentifiers: [USDB_TOKEN_IDENTIFIER] }),
       ]);
 
@@ -122,7 +124,7 @@ const StableBalanceToggleFlow: React.FC<StableBalanceToggleFlowProps> = ({
       }
       setStep('confirm');
     }
-  }, [wallet, direction, getOrFetchFiatData]);
+  }, [wallet, direction, refreshFiatData]);
 
   // Use refs so the isOpen effect snapshots the latest props/callbacks
   // without re-firing when they change mid-flow.

--- a/src/contexts/FiatDataContext.test.tsx
+++ b/src/contexts/FiatDataContext.test.tsx
@@ -18,13 +18,16 @@ function renderWithRates(client: BreezSdk) {
   );
 }
 
-function goToBackgroundAndReturn() {
+function returnToForeground(event = 'visibilitychange', times = 1) {
   vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
   act(() => {
-    document.dispatchEvent(new Event('visibilitychange'));
+    const target = event === 'pageshow' ? window : document;
+    for (let i = 0; i < times; i++) target.dispatchEvent(new Event(event));
     vi.advanceTimersByTime(1500);
   });
 }
+
+const goToBackgroundAndReturn = () => returnToForeground();
 
 const RefreshButton = () => {
   const { fiatRates, refreshFiatData } = useFiatData();
@@ -82,6 +85,28 @@ describe('FiatDataProvider', () => {
     goToBackgroundAndReturn();
 
     await waitFor(() => expect(screen.getByTestId('usd')).toHaveTextContent('123456'));
+  });
+
+  it('refetches on a bfcache restore, which skips visibilitychange', async () => {
+    const client = createMockClient();
+    renderWithRates(client);
+    await screen.findByText('100000');
+
+    vi.mocked(client.listFiatRates).mockResolvedValue({ rates: [{ coin: 'USD', value: 123456 }] });
+    returnToForeground('pageshow');
+
+    await waitFor(() => expect(screen.getByTestId('usd')).toHaveTextContent('123456'));
+  });
+
+  it('coalesces a burst of foreground events into one refetch', async () => {
+    const client = createMockClient();
+    renderWithRates(client);
+    await screen.findByText('100000');
+    expect(client.listFiatRates).toHaveBeenCalledTimes(1);
+
+    returnToForeground('visibilitychange', 3);
+
+    await waitFor(() => expect(client.listFiatRates).toHaveBeenCalledTimes(2));
   });
 
   it('keeps the last good rates when a refetch fails', async () => {

--- a/src/contexts/FiatDataContext.test.tsx
+++ b/src/contexts/FiatDataContext.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from './WalletContext';
+import { FiatDataProvider, useFiatData } from './FiatDataContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+
+const UsdRate = () => {
+  const { fiatRates } = useFiatData();
+  return <span data-testid="usd">{fiatRates.find(r => r.coin === 'USD')?.value ?? 'none'}</span>;
+};
+
+function renderWithRates(client: BreezSdk) {
+  render(
+    <WalletProvider client={client} isConnected>
+      <FiatDataProvider><UsdRate /></FiatDataProvider>
+    </WalletProvider>
+  );
+}
+
+function goToBackgroundAndReturn() {
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(1500);
+  });
+}
+
+const RefreshButton = () => {
+  const { fiatRates, refreshFiatData } = useFiatData();
+  return (
+    <button onClick={() => void refreshFiatData()}>
+      {fiatRates.find(r => r.coin === 'USD')?.value ?? 'none'}
+    </button>
+  );
+};
+
+describe('refreshFiatData', () => {
+  it('fetches a current rate instead of reusing the loaded one', async () => {
+    const client = createMockClient();
+    render(
+      <WalletProvider client={client} isConnected>
+        <FiatDataProvider><RefreshButton /></FiatDataProvider>
+      </WalletProvider>
+    );
+    const button = await screen.findByRole('button', { name: '100000' });
+
+    vi.mocked(client.listFiatRates).mockResolvedValue({ rates: [{ coin: 'USD', value: 123456 }] });
+    button.click();
+
+    await screen.findByRole('button', { name: '123456' });
+  });
+
+  it('falls back to the last known rate so a blip does not break the caller', async () => {
+    const client = createMockClient();
+    render(
+      <WalletProvider client={client} isConnected>
+        <FiatDataProvider><RefreshButton /></FiatDataProvider>
+      </WalletProvider>
+    );
+    const button = await screen.findByRole('button', { name: '100000' });
+
+    vi.mocked(client.listFiatRates).mockRejectedValue(new Error('offline'));
+    button.click();
+
+    await waitFor(() => expect(client.listFiatRates).toHaveBeenCalledTimes(2));
+    expect(button).toHaveTextContent('100000');
+  });
+});
+
+describe('FiatDataProvider', () => {
+  beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+  afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+  it('refetches rates when the app returns to the foreground', async () => {
+    // A frozen interval is why a resumed WebView keeps showing an old price.
+    const client = createMockClient();
+    renderWithRates(client);
+    await screen.findByText('100000');
+
+    vi.mocked(client.listFiatRates).mockResolvedValue({ rates: [{ coin: 'USD', value: 123456 }] });
+    goToBackgroundAndReturn();
+
+    await waitFor(() => expect(screen.getByTestId('usd')).toHaveTextContent('123456'));
+  });
+
+  it('keeps the last good rates when a refetch fails', async () => {
+    const client = createMockClient();
+    renderWithRates(client);
+    await screen.findByText('100000');
+
+    vi.mocked(client.listFiatRates).mockRejectedValue(new Error('offline'));
+    goToBackgroundAndReturn();
+
+    await waitFor(() => expect(client.listFiatRates).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId('usd')).toHaveTextContent('100000');
+  });
+});

--- a/src/contexts/FiatDataContext.tsx
+++ b/src/contexts/FiatDataContext.tsx
@@ -71,10 +71,13 @@ export const FiatDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     // A backgrounded WebView freezes the interval, and an iOS standalone PWA
     // resumes a days-old page instead of reloading, so rates would otherwise
     // sit at whatever they were when the app last had the foreground until a
-    // relaunch. Same reason `useBreezSdk` resyncs the wallet on visibility.
+    // relaunch. Mirrors the events `useBreezSdk` resyncs the wallet on.
     let resumeTimer: ReturnType<typeof setTimeout> | undefined;
     const refetchOnResume = () => {
       if (document.visibilityState !== 'visible') return;
+      // Drop any pending one: a hide/show cycle leaves a timer per event
+      // otherwise, and they all fire together once the page is back.
+      clearTimeout(resumeTimer);
       // iOS 18+ WebKit fails a request started directly on visibilitychange
       // ("TypeError: Load failed"), so wait the same 1.5s the resync does.
       resumeTimer = setTimeout(() => {
@@ -82,12 +85,15 @@ export const FiatDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       }, 1500);
     };
     document.addEventListener('visibilitychange', refetchOnResume);
+    // pageshow catches bfcache restores, which skip visibilitychange.
+    window.addEventListener('pageshow', refetchOnResume);
 
     return () => {
       cancelled = true;
       clearInterval(interval);
       clearTimeout(resumeTimer);
       document.removeEventListener('visibilitychange', refetchOnResume);
+      window.removeEventListener('pageshow', refetchOnResume);
     };
   }, [isConnected, sdk]);
 

--- a/src/contexts/FiatDataContext.tsx
+++ b/src/contexts/FiatDataContext.tsx
@@ -9,8 +9,12 @@ interface FiatData {
 }
 
 interface FiatDataContextValue extends FiatData {
-  /** Returns cached fiat data if available, otherwise fetches and caches it. */
-  getOrFetchFiatData: () => Promise<FiatData>;
+  /**
+   * Fetch the current rates and publish them, for a caller that prices
+   * something and can't ride the 60s refresh. Falls back to the last known
+   * values on failure, so a blip degrades the price instead of the flow.
+   */
+  refreshFiatData: () => Promise<FiatData>;
 }
 
 const FiatDataContext = createContext<FiatDataContextValue | null>(null);
@@ -20,18 +24,23 @@ export const FiatDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [fiatRates, setFiatRates] = useState<Rate[]>([]);
   const [fiatCurrencies, setFiatCurrencies] = useState<FiatCurrency[]>([]);
 
-  const getOrFetchFiatData = useCallback(async (): Promise<FiatData> => {
-    if (fiatRates.length > 0 && fiatCurrencies.length > 0) {
-      return { fiatRates, fiatCurrencies };
+  const refreshFiatData = useCallback(async (): Promise<FiatData> => {
+    const known = { fiatRates, fiatCurrencies };
+    if (!sdk) return known;
+    try {
+      const [ratesResult, currenciesResult] = await Promise.all([
+        sdk.listFiatRates(),
+        sdk.listFiatCurrencies(),
+      ]);
+      setFiatRates(ratesResult.rates);
+      setFiatCurrencies(currenciesResult.currencies);
+      return { fiatRates: ratesResult.rates, fiatCurrencies: currenciesResult.currencies };
+    } catch (error) {
+      logger.warn(LogCategory.SDK, 'Failed to refresh fiat data', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return known;
     }
-    if (!sdk) return { fiatRates: [], fiatCurrencies: [] };
-    const [ratesResult, currenciesResult] = await Promise.all([
-      sdk.listFiatRates(),
-      sdk.listFiatCurrencies(),
-    ]);
-    setFiatRates(ratesResult.rates);
-    setFiatCurrencies(currenciesResult.currencies);
-    return { fiatRates: ratesResult.rates, fiatCurrencies: currenciesResult.currencies };
   }, [sdk, fiatRates, fiatCurrencies]);
 
   useEffect(() => {
@@ -58,14 +67,32 @@ export const FiatDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     };
     void fetchFiatData();
     const interval = setInterval(() => { void fetchFiatData(); }, 60000);
+
+    // A backgrounded WebView freezes the interval, and an iOS standalone PWA
+    // resumes a days-old page instead of reloading, so rates would otherwise
+    // sit at whatever they were when the app last had the foreground until a
+    // relaunch. Same reason `useBreezSdk` resyncs the wallet on visibility.
+    let resumeTimer: ReturnType<typeof setTimeout> | undefined;
+    const refetchOnResume = () => {
+      if (document.visibilityState !== 'visible') return;
+      // iOS 18+ WebKit fails a request started directly on visibilitychange
+      // ("TypeError: Load failed"), so wait the same 1.5s the resync does.
+      resumeTimer = setTimeout(() => {
+        if (document.visibilityState === 'visible') void fetchFiatData();
+      }, 1500);
+    };
+    document.addEventListener('visibilitychange', refetchOnResume);
+
     return () => {
       cancelled = true;
       clearInterval(interval);
+      clearTimeout(resumeTimer);
+      document.removeEventListener('visibilitychange', refetchOnResume);
     };
   }, [isConnected, sdk]);
 
   return (
-    <FiatDataContext.Provider value={{ fiatRates, fiatCurrencies, getOrFetchFiatData }}>
+    <FiatDataContext.Provider value={{ fiatRates, fiatCurrencies, refreshFiatData }}>
       {children}
     </FiatDataContext.Provider>
   );


### PR DESCRIPTION
This PR fetches a fresh exchange rate whenever you reopen the app. If a request fails, the app falls back to the most recently fetched rate, which would usually be fairly recent.