### PR TITLE
fix: create an invoice for any amount

### DIFF
--- a/src/constants/receive.ts
+++ b/src/constants/receive.ts
@@ -5,16 +5,7 @@
 /**
  * Minimum amount (sats) the app will accept when generating a Lightning
  * bolt11 receive invoice. Enforced in both the AmountPanel UI (disables
- * the Generate button) and the
- * `useReceivePayment.generateBolt11Invoice` hook (defensive guard
- * before the SDK call).
- *
- * There is deliberately no matching maximum. The old 4,000,000-sat cap
- * was a product-level guess that mirrored the legacy non-wumbo bolt11
- * ceiling (2^32 msat); Spark settles receives as statechain transfers
- * through the SSP rather than as channel HTLCs, so that ceiling does
- * not apply. The only remaining upper bound is `toSats` / `MAX_SATS`
- * (21M BTC), which keeps the value inside a safe integer before it
- * reaches the SDK.
+ * the Generate button) and the `useReceivePayment.generateBolt11Invoice`
+ * hook (defensive guard before the SDK call).
  */
 export const LIGHTNING_INVOICE_MIN_SATS = 1;

--- a/src/constants/receive.ts
+++ b/src/constants/receive.ts
@@ -5,16 +5,16 @@
 /**
  * Minimum amount (sats) the app will accept when generating a Lightning
  * bolt11 receive invoice. Enforced in both the AmountPanel UI (disables
- * the Generate button + shows the range next to the Amount label) and
- * the `useReceivePayment.generateBolt11Invoice` hook (defensive guard
+ * the Generate button) and the
+ * `useReceivePayment.generateBolt11Invoice` hook (defensive guard
  * before the SDK call).
+ *
+ * There is deliberately no matching maximum. The old 4,000,000-sat cap
+ * was a product-level guess that mirrored the legacy non-wumbo bolt11
+ * ceiling (2^32 msat); Spark settles receives as statechain transfers
+ * through the SSP rather than as channel HTLCs, so that ceiling does
+ * not apply. The only remaining upper bound is `toSats` / `MAX_SATS`
+ * (21M BTC), which keeps the value inside a safe integer before it
+ * reaches the SDK.
  */
 export const LIGHTNING_INVOICE_MIN_SATS = 1;
-
-/**
- * Maximum amount (sats) the app will accept when generating a Lightning
- * bolt11 receive invoice. This is a product-level cap chosen for Glow
- * — the Lightning protocol itself can carry larger invoices. See
- * LIGHTNING_INVOICE_MIN_SATS for where it's enforced.
- */
-export const LIGHTNING_INVOICE_MAX_SATS = 4_000_000;

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -19,7 +19,7 @@ import { useAmountInput, useFiatOverride } from '../../hooks/useAmountInput';
 import { getDisplayFiatCurrency } from '../../services/settings';
 import type { Sats } from '../../types/sats';
 import { dismissKeyboard } from '../../utils/keyboard';
-import { LIGHTNING_INVOICE_MIN_SATS, LIGHTNING_INVOICE_MAX_SATS } from '../../constants/receive';
+import { LIGHTNING_INVOICE_MIN_SATS } from '../../constants/receive';
 
 interface AmountPanelProps {
   isOpen: boolean;
@@ -112,15 +112,15 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
 
   const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
 
-  // Range-aware validity check. Mirrors the guard in
-  // `useReceivePayment.generateBolt11Invoice` so the UI disables the
-  // Generate button + Enter-to-submit path for amounts outside the
-  // configured Lightning-invoice receive bounds. Works in both sats
-  // and token mode because the parsed sats are produced by
-  // `useAmountInput` regardless of denomination.
+  // Mirrors the guard in `useReceivePayment.generateBolt11Invoice` so
+  // the UI disables the Generate button + Enter-to-submit path for
+  // amounts below the minimum. There is no upper bound: `amountSats`
+  // is already null for anything `toSats` rejects (> 21M BTC or
+  // outside safe-integer range). Works in both sats and token mode
+  // because the parsed sats are produced by `useAmountInput`
+  // regardless of denomination.
   const validAmount = amountSats !== null
-    && amountSats >= BigInt(LIGHTNING_INVOICE_MIN_SATS)
-    && amountSats <= BigInt(LIGHTNING_INVOICE_MAX_SATS);
+    && amountSats >= BigInt(LIGHTNING_INVOICE_MIN_SATS);
 
   // "Invalid amount" surfaces when the input is non-empty and positive but
   // can't safely be converted to sats: covers both unsafe-integer overflow
@@ -147,20 +147,11 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
         {/* Amount Input */}
         <div className="space-y-4">
           <div>
-            <div className="flex items-center justify-between mb-2">
-              <label className="block text-spark-text-secondary text-sm font-medium">
-                Amount
-              </label>
-              {/* Range badge — matches LnurlWorkflow's Send-side
-                  treatment at features/send/workflows/LnurlWorkflow.tsx.
-                  Uses plain "sats" (not ₿) per CLAUDE.md:
-                  "Range displays and placeholders use 'sats' text,
-                  not ₿". Thin-space separators on the max value match
-                  the Send-side formatting. */}
-              <span className="text-xs text-spark-text-muted">
-                {LIGHTNING_INVOICE_MIN_SATS.toLocaleString('en-US').replace(/,/g, ' ')} – {LIGHTNING_INVOICE_MAX_SATS.toLocaleString('en-US').replace(/,/g, ' ')} sats
-              </span>
-            </div>
+            {/* No range badge: with the maximum gone the only bound
+                left is the 1-sat minimum, which is not worth a hint. */}
+            <label className="block text-spark-text-secondary text-sm font-medium mb-2">
+              Amount
+            </label>
             <div className="relative">
               <textarea
                 inputMode={isTokenMode ? 'decimal' : 'numeric'}

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -114,9 +114,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
 
   // Mirrors the guard in `useReceivePayment.generateBolt11Invoice` so
   // the UI disables the Generate button + Enter-to-submit path for
-  // amounts below the minimum. There is no upper bound: `amountSats`
-  // is already null for anything `toSats` rejects (> 21M BTC or
-  // outside safe-integer range). Works in both sats and token mode
+  // amounts below the minimum. Works in both sats and token mode
   // because the parsed sats are produced by `useAmountInput`
   // regardless of denomination.
   const validAmount = amountSats !== null
@@ -147,8 +145,6 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
         {/* Amount Input */}
         <div className="space-y-4">
           <div>
-            {/* No range badge: with the maximum gone the only bound
-                left is the 1-sat minimum, which is not worth a hint. */}
             <label className="block text-spark-text-secondary text-sm font-medium mb-2">
               Amount
             </label>

--- a/src/features/receive/hooks/useReceivePayment.ts
+++ b/src/features/receive/hooks/useReceivePayment.ts
@@ -4,7 +4,7 @@ import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
 import { toSdkAmountNumber, type Sats } from '../../../types/sats';
 import type { PaymentMethod, ReceiveStep } from '../../../types/domain';
-import { LIGHTNING_INVOICE_MIN_SATS, LIGHTNING_INVOICE_MAX_SATS } from '../../../constants/receive';
+import { LIGHTNING_INVOICE_MIN_SATS } from '../../../constants/receive';
 
 export interface UseReceivePaymentReturn {
   // State
@@ -166,10 +166,6 @@ export function useReceivePayment(): UseReceivePaymentReturn {
     }
     if (amountSats < BigInt(LIGHTNING_INVOICE_MIN_SATS)) {
       setError(`Amount must be at least ₿${LIGHTNING_INVOICE_MIN_SATS.toLocaleString()}`);
-      return;
-    }
-    if (amountSats > BigInt(LIGHTNING_INVOICE_MAX_SATS)) {
-      setError(`Amount must be at most ₿${LIGHTNING_INVOICE_MAX_SATS.toLocaleString()}`);
       return;
     }
 


### PR DESCRIPTION
Creating an invoice for more than 4,000,000 sats was refused with "Amount must be at most ₿4,000,000". The 4M cap is Glow's own hardcoded number, not a Spark or SDK limit.

This PR removes the ceiling cap and lets user create an invoice for any amount. 

#### UI changes
The limit range hint beside the Amount label is removed, since a one sat minimum is all that was left to announce. The minimum stays, as does the existing amount validation.