### PR TITLE
fix: show why a payment could not be prepared

### DIFF
--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -120,7 +120,7 @@ export function useSendPayment(): UseSendPaymentReturn {
       setCurrentStep('workflow');
     } catch (err) {
       logger.error(LogCategory.PAYMENT, 'Failed to prepare payment', { error: formatError(err) });
-      setError(`Failed to prepare payment ${err instanceof Error ? err.message : 'Unknown error'}`);
+      setError(`Failed to prepare payment: ${err instanceof Error ? err.message : 'Unknown error'}`);
       // Clear any stale response so the confirm step renders its prepare-failed
       // fallback (error + disabled send) instead of an old success render.
       setPrepareResponse(null);

--- a/src/features/send/steps/ConfirmStep.test.tsx
+++ b/src/features/send/steps/ConfirmStep.test.tsx
@@ -4,9 +4,12 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import { FiatDataProvider } from '@/contexts/FiatDataContext';
 import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
 import { createMockClient } from '@/test/mocks/mockWalletApi';
-import ConfirmStep from './ConfirmStep';
+import ConfirmStep, { type ConfirmStepProps } from './ConfirmStep';
 
-function renderConfirmStep(destination?: { label: string; value: string }) {
+function renderConfirmStep(
+  destination?: { label: string; value: string },
+  overrides?: Partial<ConfirmStepProps>,
+) {
   render(
     <WalletProvider client={createMockClient()} isConnected>
       <FiatDataProvider>
@@ -19,6 +22,7 @@ function renderConfirmStep(destination?: { label: string; value: string }) {
             error={null}
             isLoading={false}
             onConfirm={vi.fn()}
+            {...overrides}
           />
         </StableBalanceProvider>
       </FiatDataProvider>
@@ -41,5 +45,23 @@ describe('ConfirmStep destination', () => {
   it('renders without a destination when prepare produced no payment method', () => {
     renderConfirmStep(undefined);
     expect(screen.queryByTestId('send-destination')).toBeNull();
+  });
+});
+
+describe('ConfirmStep prepare failure', () => {
+  it('shows the prepare error, not a balance verdict it cannot make', () => {
+    // Sat balance below the amount is the normal state for a wallet holding
+    // its balance in a token: the sat funding comes from a conversion the
+    // failed prepare never got to quote.
+    renderConfirmStep(undefined, {
+      feesSat: null,
+      balanceSats: 0,
+      error: 'Failed to prepare payment: no route to destination',
+      disableConfirm: true,
+    });
+
+    expect(screen.getByText(/no route to destination/)).toBeInTheDocument();
+    expect(screen.queryByText('Insufficient funds')).toBeNull();
+    expect(screen.getByTestId('send-confirm-button')).toBeDisabled();
   });
 });

--- a/src/features/send/steps/ConfirmStep.tsx
+++ b/src/features/send/steps/ConfirmStep.tsx
@@ -87,9 +87,13 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
   // sourced from a prepare response so in practice this never exceeds the
   // cap; if it somehow did, treat as insufficient funds.
   const totalSats = toSats(total);
-  const insufficientBalance = totalSats === null
+  // The prepare-failed render has no fee and no conversion estimate to check
+  // against, so the check reduces to "amount > sat balance" and reports
+  // insufficient funds for a wallet holding its balance in a token. Skip it:
+  // the prepare error is the one worth showing, and send is disabled anyway.
+  const insufficientBalance = !disableConfirm && (totalSats === null
     ? true
-    : balance.checkInsufficientFunds({ totalSats, conversionEstimate });
+    : balance.checkInsufficientFunds({ totalSats, conversionEstimate }));
   const balanceError = insufficientBalance ? 'Insufficient funds' : null;
 
   // Token-formatted values from conversion estimate


### PR DESCRIPTION
Glow incorrectly showed "Insufficient funds" for an invoice with a non-existent node and no route hints*, even if the user had enough balance.

When preparing a payment failed, the confirm screen has no fee and conversion estimate information, and the balance check validates the invoice amount only against the sat balance, which showed it's own verdict instead of the prepare error.

The confirm screen no longer does balance validation when prepare fails, and shows the real reason.

<sub>*: Unable to compute fees for invoice; there is no way to pay this invoice (NO_PATH_FOUND)</sub>