### PR TITLE
fix: open Cash App from the web app and the PWA

### DIFF
--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -324,7 +324,7 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
                 aria-label={buyCopy('Buy')}
                 className={`flex items-center justify-center gap-1.5 h-9 rounded-xl transition-colors text-sm font-medium disabled:opacity-50 ${
                   isBuyIconOnly()
-                    ? 'w-9 bg-[#00D64F] hover:bg-[#00c247] border border-black/15 hover:border-black/25'
+                    ? 'w-9 bg-[#00D632] hover:bg-[#00bf2d] border border-black/15 hover:border-black/25'
                     : 'px-3 text-spark-text-secondary hover:text-spark-text-primary border border-white/10 hover:border-white/20 hover:bg-white/5'
                 }`}
                 onClick={onOpenBuyBitcoin}

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -36,21 +36,21 @@ const providerMeta: Record<BuyBitcoinProvider, { name: string; icon: React.React
   cashApp: {
     name: 'Cash App',
     icon: (
-      <div className="w-11 h-11 rounded-xl bg-[#00D64F] flex items-center justify-center shrink-0 p-1">
-        <CashAppIcon className="w-full h-full text-[#00D64F]" />
+      <div className="w-11 h-11 rounded-xl bg-[#00D632] flex items-center justify-center shrink-0 p-1">
+        <CashAppIcon className="w-full h-full text-[#00D632]" />
       </div>
     ),
     loadingIcon: (
-      <div className="w-11 h-11 rounded-xl bg-[#00D64F] flex items-center justify-center shrink-0 p-1 animate-pulse">
-        <CashAppIcon className="w-full h-full text-[#00D64F]" />
+      <div className="w-11 h-11 rounded-xl bg-[#00D632] flex items-center justify-center shrink-0 p-1 animate-pulse">
+        <CashAppIcon className="w-full h-full text-[#00D632]" />
       </div>
     ),
   },
 };
 
 const cashAppHeaderIcon = (
-  <div className="w-5 h-5 rounded-sm bg-[#00D64F] flex items-center justify-center p-0.5">
-    <CashAppIcon className="w-full h-full text-[#00D64F]" />
+  <div className="w-5 h-5 rounded-sm bg-[#00D632] flex items-center justify-center p-0.5">
+    <CashAppIcon className="w-full h-full text-[#00D632]" />
   </div>
 );
 
@@ -77,11 +77,11 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
     onInvoicePaid: onClose,
   });
 
-  // The Cash App code is scanned by another device, so nobody touches
-  // this screen while it is up. Scoped to the QR step: picking a
-  // provider and entering an amount are both tapped through.
+  // This screen waits on something outside the app: a scan from another
+  // device, or a trip through Cash App. Neither touches Glow, so the idle
+  // lock is held here and not on the steps that are tapped through.
   useEffect(() => {
-    if (!isOpen || buy.step !== 'qr') return;
+    if (!isOpen || buy.step !== 'link') return;
     return holdIdleLock();
   }, [isOpen, buy.step]);
 
@@ -125,7 +125,7 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
         {buy.step === 'amount' && (
           <>
             <DialogHeader
-              title={buyCopy('Buy with Cash App')}
+              title={buyCopy('Cash App')}
               onClose={onClose}
               onBack={buy.goBackToSelect ?? undefined}
               icon={cashAppHeaderIcon}
@@ -198,20 +198,44 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
           </>
         )}
 
-        {buy.step === 'qr' && buy.cashAppUrl && buy.generatedAmountSats !== null && (
+        {buy.step === 'link' && buy.cashAppUrl && buy.generatedAmountSats !== null && (
           <>
             <DialogHeader
-              title={buyCopy('Buy with Cash App')}
+              title={buyCopy('Cash App')}
               onClose={onClose}
               onBack={buy.goBackToAmount}
               icon={cashAppHeaderIcon}
             />
             <div className="flex flex-col items-center gap-6 pt-2">
+              {/* Both openers are real anchors, never a button with a handler:
+                  only a tap on one makes iOS resolve the universal link, or
+                  Chrome hand the App Link to Cash App. A scripted navigation
+                  reaches the cash.app web page instead. `_blank` keeps Glow
+                  behind it, which an installed PWA has no other way back
+                  from. */}
               <p className="text-center text-sm text-spark-text-secondary">
-                Scan this code with Cash App
+                <a
+                  href={buy.cashAppUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-spark-primary underline underline-offset-4 hover:text-spark-primary/80 transition-colors"
+                  data-testid="cashapp-open-link"
+                >
+                  Open Cash App
+                </a>
+                , or scan from another device.
               </p>
 
-              <QRCodeContainer value={buy.cashAppUrl} />
+              <a
+                href={buy.cashAppUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open Cash App"
+                className="rounded-xl focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-spark-primary"
+                data-testid="cashapp-open-qr"
+              >
+                <QRCodeContainer value={buy.cashAppUrl} />
+              </a>
 
               <CopyableText
                 text={buy.cashAppUrl}

--- a/src/features/buy/hooks/useBuyBitcoin.test.tsx
+++ b/src/features/buy/hooks/useBuyBitcoin.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { ToastProvider } from '@/contexts/ToastContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { useBuyBitcoin } from './useBuyBitcoin';
+import BuyBitcoinDialog from '../BuyBitcoinDialog';
+
+const CASH_APP_URL = 'https://cash.app/launch/lightning/lnbc100n1test';
+
+function renderBuy() {
+  const client = createMockClient({
+    buyBitcoin: vi.fn().mockResolvedValue({ url: CASH_APP_URL }),
+  } as never);
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WalletProvider client={client} isConnected>
+      <FiatDataProvider>
+        <StableBalanceProvider>{children}</StableBalanceProvider>
+      </FiatDataProvider>
+    </WalletProvider>
+  );
+  return { client, ...renderHook(() => useBuyBitcoin({
+    isOpen: true,
+    onSelectRedirectProvider: vi.fn(),
+    onMobileRedirectComplete: vi.fn(),
+    onInvoicePaid: vi.fn(),
+  }), { wrapper }) };
+}
+
+describe('Cash App on mobile web', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('hands the URL to the link step instead of navigating for the user', async () => {
+    // Scripted navigation loses the tap: iOS only resolves a universal link
+    // from a real click, and Chrome will not hand an App Link to an app
+    // without user activation, which awaiting the invoice has already spent.
+    const open = vi.spyOn(window, 'open');
+    const { result } = renderBuy();
+
+    act(() => result.current.setAmount('50000'));
+    await act(() => result.current.generate());
+
+    await waitFor(() => expect(result.current.step).toBe('link'));
+    expect(result.current.cashAppUrl).toBe(CASH_APP_URL);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('stays on the amount step when the invoice fails', async () => {
+    const { client, result } = renderBuy();
+    vi.mocked(client.buyBitcoin).mockRejectedValueOnce(new Error('nope'));
+
+    act(() => result.current.setAmount('50000'));
+    await act(() => result.current.generate());
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(result.current.cashAppUrl).toBeNull();
+  });
+});
+
+describe('the Cash App link', () => {
+  it('reaches the person as an anchor they tap, not a scripted navigation', async () => {
+    const client = createMockClient({
+      buyBitcoin: vi.fn().mockResolvedValue({ url: CASH_APP_URL }),
+    } as never);
+    render(
+      <ToastProvider>
+        <WalletProvider client={client} isConnected>
+          <FiatDataProvider>
+            <StableBalanceProvider>
+              <BuyBitcoinDialog
+                isOpen
+                onClose={vi.fn()}
+                onBuyBitcoin={vi.fn()}
+                network="mainnet"
+              />
+            </StableBalanceProvider>
+          </FiatDataProvider>
+        </WalletProvider>
+      </ToastProvider>,
+    );
+
+    await userEvent.click(await screen.findByText('Cash App'));
+    await userEvent.type(screen.getByTestId('cashapp-amount-input'), '50000');
+    await userEvent.click(screen.getByTestId('cashapp-continue-button'));
+
+    // Both openers, the worded link and the code itself.
+    for (const id of ['cashapp-open-link', 'cashapp-open-qr']) {
+      const link = await screen.findByTestId(id);
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', CASH_APP_URL);
+      // Without `_blank` an installed PWA navigates its own window away, and
+      // standalone mode leaves no way back to Glow.
+      expect(link).toHaveAttribute('target', '_blank');
+    }
+  });
+});

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -3,14 +3,12 @@ import { Capacitor } from '@capacitor/core';
 import { AppLauncher } from '@capacitor/app-launcher';
 import type { Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '../../../contexts/WalletContext';
-import { usePlatform } from '../../../hooks/usePlatform';
 import { useInvoicePaid } from '../../../hooks/useInvoicePaid';
 import { useAmountInput } from '../../../hooks/useAmountInput';
 import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
 import { fixedQuickAmounts, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
 import { toSdkAmountNumber, type Sats } from '../../../types/sats';
-import { isStandalonePwa, openExternalUrl } from '../../../utils/externalLink';
 import {
   getBuyProviderSettings,
   filterProvidersByNetwork,
@@ -20,7 +18,7 @@ import {
 } from '../../../services/settings';
 import { useCashAppInstalled } from '../../../hooks/useCashAppInstalled';
 
-export type BuyStep = 'select' | 'amount' | 'qr';
+export type BuyStep = 'select' | 'amount' | 'link';
 
 /** What a Cash App quick amount is worth, in dollars. They start where a
  *  purchase is worth making: below this the provider's fee takes much of it.
@@ -35,9 +33,9 @@ export interface UseBuyBitcoinOptions {
   network?: Network;
   /** Called for providers that redirect externally (MoonPay). */
   onSelectRedirectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
-  /** Called after a mobile/native Cash App redirect; the caller closes the dialog. */
+  /** Called after the native Cash App handoff; the caller closes the dialog. */
   onMobileRedirectComplete: () => void;
-  /** Called when the displayed QR invoice is paid; the caller typically closes the dialog. */
+  /** Called when the displayed invoice is paid; the caller typically closes the dialog. */
   onInvoicePaid: () => void;
 }
 
@@ -77,8 +75,6 @@ export function useBuyBitcoin({
   onInvoicePaid,
 }: UseBuyBitcoinOptions): UseBuyBitcoinReturn {
   const sdk = useWallet();
-  const platform = usePlatform();
-  const isMobile = platform.isIOS || platform.isAndroid;
 
   const input = useAmountInput();
   const {
@@ -188,17 +184,10 @@ export function useBuyBitcoin({
     setError(null);
     setIsGenerating(true);
 
-    // Mobile web: pre-open a blank tab synchronously in the tap gesture so
-    // navigating it later doesn't trip popup blockers. Native must not do
-    // this (or fall back to window.location.href): navigating the WebView
-    // to cash.app strands the user.
-    const isNative = Capacitor.isNativePlatform();
-    const mobileTab = isMobile && !isNative ? window.open('', '_blank') : null;
-
     try {
       const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: amountSatsForSdk });
       setGeneratedAmountSats(amountSats);
-      if (isNative) {
+      if (Capacitor.isNativePlatform()) {
         // AppLauncher bridges to UIApplication.open, the only iOS API that
         // hands an https universal link (cash.app/launch/...) off to the
         // Cash App app. Browser.open (SFSafariViewController) only loads the
@@ -206,40 +195,28 @@ export function useBuyBitcoin({
         // in-app-browser load. Falls back to Safari if Cash App is absent.
         await AppLauncher.openUrl({ url: response.url });
         onMobileRedirectComplete();
-      } else if (isMobile) {
-        // Navigate immediately: the cash.app universal link only bounces
-        // to the app inside the tap's user-activation window, so any await
-        // before this (e.g. a sheet-close animation) drops it to the web
-        // page.
-        if (mobileTab) {
-          mobileTab.location.href = response.url;
-        } else if (isStandalonePwa()) {
-          // window.open returns null in an installed PWA, so this is the
-          // normal path there: navigating the standalone window itself
-          // would leave no way back.
-          await openExternalUrl(response.url);
-        } else {
-          window.location.href = response.url;
-        }
-        onMobileRedirectComplete();
-      } else {
-        setCashAppUrl(response.url);
-        setStep('qr');
+        return;
       }
+      // Web hands the URL to a real anchor the person taps (see the `link`
+      // step). Scripted navigation cannot reach the Cash App app: iOS only
+      // resolves a universal link from a genuine tap, and Chrome refuses to
+      // hand an App Link to an app without user activation, which the await
+      // above has already spent.
+      setCashAppUrl(response.url);
+      setStep('link');
     } catch (e) {
-      mobileTab?.close();
       logger.error(LogCategory.SDK, 'Failed to create Cash App buy URL', { error: formatError(e) });
       setError('Failed to create invoice. Please try again.');
     } finally {
       setIsGenerating(false);
     }
-  }, [amountSats, isMobile, sdk, onMobileRedirectComplete]);
+  }, [amountSats, sdk, onMobileRedirectComplete]);
 
   // Cash App URLs are `https://cash.app/launch/lightning/<bolt11>`. Extract the
-  // invoice only while we're showing the QR so the bus subscription pauses
+  // invoice only while the link is on screen so the bus subscription pauses
   // once we leave that step.
   const activeInvoice = useMemo(() => {
-    if (step !== 'qr' || !cashAppUrl) return null;
+    if (step !== 'link' || !cashAppUrl) return null;
     return cashAppUrl.split('/').pop() ?? null;
   }, [step, cashAppUrl]);
 

--- a/src/pages/BuyProvidersPage.tsx
+++ b/src/pages/BuyProvidersPage.tsx
@@ -22,7 +22,7 @@ const providerMeta: Record<BuyBitcoinProvider, { name: string; icon: React.React
   },
   cashApp: {
     name: 'Cash App',
-    icon: <CashAppIcon size="lg" className="text-[#00D64F]" />,
+    icon: <CashAppIcon size="lg" className="text-[#00D632]" />,
   },
 };
 


### PR DESCRIPTION
Cash App did not open when you buy Bitcoin from a mobile browser or from the installed PWA. The browser showed the Cash App web page instead of the Cash App app. Only the Android and iOS app worked.

Glow tried to open Cash App for you, after it made the invoice. iOS and Android open Cash App only when you tap a link yourself. They ignore a redirect that a page starts.

The purchase screen now tells you the invoice is ready and gives you a Cash App link to tap. Your tap opens the app. The QR code below it is also tappable, and does the same thing. You can still scan that code from another device.

The screen also stays open behind Cash App. It closes by itself when your Bitcoin arrives.

The screen titles are shorter. On iOS the title still reads **Add funds from Cash App**. The Cash App mark now uses the brand green. The Android and iOS app is not changed.