### PR TITLE
fix(receive): show a generic message when the Lightning address call fails

### DIFF
--- a/src/features/receive/hooks/useLightningAddress.test.tsx
+++ b/src/features/receive/hooks/useLightningAddress.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { useLightningAddress } from './useLightningAddress';
+
+// The LNURL server reaches the WebView as an opaque fetch failure, which is
+// what the user reported seeing pasted verbatim into the Receive sheet.
+const RAW_SDK_ERROR = new Error(
+  'Network error: Request error: error sending request : JsValue(TypeError: Load failed\nundefined)',
+);
+
+function renderLightningAddress(client: BreezSdk) {
+  return renderHook(() => useLightningAddress(), {
+    wrapper: ({ children }) => (
+      <WalletProvider client={client} isConnected>
+        {children}
+      </WalletProvider>
+    ),
+  });
+}
+
+describe('useLightningAddress error copy', () => {
+  it('shows a generic message instead of the raw SDK error when loading fails', async () => {
+    const client = createMockClient() as unknown as BreezSdk;
+    vi.mocked(client.getLightningAddress).mockRejectedValue(RAW_SDK_ERROR);
+
+    const { result } = renderLightningAddress(client);
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toBe("Couldn't load your Lightning address. Please try again.");
+    expect(result.current.error).not.toContain('Load failed');
+  });
+
+  it('shows a generic message instead of the raw SDK error when saving fails', async () => {
+    const client = createMockClient() as unknown as BreezSdk;
+    vi.mocked(client.registerLightningAddress).mockRejectedValue(RAW_SDK_ERROR);
+
+    const { result } = renderLightningAddress(client);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setEditValue('umiyahara'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.error).toBe("Couldn't save your Lightning address. Please try again.");
+    expect(result.current.error).not.toContain('Load failed');
+  });
+
+  it('still names a taken username rather than falling back to the generic message', async () => {
+    const client = createMockClient() as unknown as BreezSdk;
+    vi.mocked(client.checkLightningAddressAvailable).mockResolvedValue(false);
+
+    const { result } = renderLightningAddress(client);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setEditValue('umiyahara'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.error).toBe('This username is not available');
+  });
+});

--- a/src/features/receive/hooks/useLightningAddress.ts
+++ b/src/features/receive/hooks/useLightningAddress.ts
@@ -23,6 +23,15 @@ export interface UseLightningAddress {
 }
 
 const UNSUPPORTED_MESSAGE = 'Lightning addresses are not available in this environment.';
+// The SDK surfaces every failure here as one opaque string — an unreachable
+// LNURL server reads as `TypeError: Load failed`, a registration rate limit
+// and a name lost in a race both read as `Network error (status ...)`. None of
+// that is actionable, so the user gets one generic line and the raw error goes
+// to the log viewer via the `logger.error` calls below.
+// ponytail: one message for every failure; split it per case once the SDK
+// gives us a typed error to branch on.
+const LOAD_FAILED_MESSAGE = "Couldn't load your Lightning address. Please try again.";
+const SAVE_FAILED_MESSAGE = "Couldn't save your Lightning address. Please try again.";
 
 export const useLightningAddress = (): UseLightningAddress => {
   const wallet = useWallet();
@@ -112,7 +121,7 @@ export const useLightningAddress = (): UseLightningAddress => {
       if (err instanceof Error && /lnurl server is not configured/i.test(err.message)) {
         markUnsupported();
       } else {
-        setError(`Failed to load Lightning address: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        setError(LOAD_FAILED_MESSAGE);
       }
     } finally {
       setIsLoading(false);
@@ -194,7 +203,7 @@ export const useLightningAddress = (): UseLightningAddress => {
       if (err instanceof Error && /lnurl server is not configured/i.test(err.message)) {
         markUnsupported();
       } else {
-        setError(`Failed to save Lightning address: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        setError(SAVE_FAILED_MESSAGE);
       }
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
A user who could not reach the Lightning address server was shown the raw failure text inside the Receive sheet:

> Failed to save Lightning address: Network error: Request error: error sending request : JsValue(TypeError: Load failed undefined)

None of that tells anyone what to do, and the same wording now also covers the new registration rate limit and a name that gets claimed between the availability check and the save.

This replaces it with one plain line for each action: "Couldn't load your Lightning address. Please try again." and the save equivalent. The underlying failure is still recorded alongside, so Share Logs keeps everything needed to diagnose it.

A username that is genuinely taken, or held for whoever gave it up, is unaffected and still reads "This username is not available".

This is deliberately one message for every kind of failure. Telling people apart, for example "you have changed your address too many times today" versus "we couldn't reach the server", needs the server errors to arrive as distinct kinds rather than as one block of text; that is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)