### PR TITLE
Bitcoin sign matches the app's own type on every platform

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -77,6 +77,86 @@
   src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-600-normal.woff2') format('woff2');
 }
 
+/* U+20BF BITCOIN SIGN, the ₿ every sat amount is prefixed with. The latin
+   subsets above stop at U+20AC, so the glyph fell through to whatever the
+   platform supplies: Roboto on Android, SF on iOS, a different shape again in
+   each desktop browser. The latin-ext subsets of both families carry it.
+   Scoped to that single codepoint so the rest of the text keeps coming off the
+   smaller latin files, and so a face is only fetched at the weights a ₿ is
+   actually rendered at. */
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 300;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-ext-300-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-ext-400-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-ext-500-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-ext-600-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-ext-700-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 800;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-ext-800-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-ext-400-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 500;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-ext-500-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 600;
+  font-display: block;
+  unicode-range: U+20BF;
+  src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-ext-600-normal.woff2') format('woff2');
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme {


### PR DESCRIPTION
This PR makes the ₿ in front of every sat amount look the same everywhere. Until now that one character was not part of the fonts Glow ships, so each platform substituted its own: the symbol on iOS was noticeably thinner and narrower than the one on Android, and neither matched the digits sitting next to it.

### Changes
- Ship the bitcoin sign as part of Glow's own fonts, in both the display and the numeric typeface.
- Load it only where it is needed, so the change adds nothing to the fonts already downloaded for the rest of the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)