### PR TITLE
feat: raise the receive quick amounts to $10/$50/$200

### DIFF
--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -107,12 +107,9 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     setAmountInput(String(quickAmount));
   };
 
-  // Receive has no balance to scale against, so both denominations offer fixed
-  // points of value, held to that value by the rate. A sat request reaches
-  // further up than a fiat one.
-  const quickAmounts = isTokenMode
-    ? fixedQuickAmounts(quickAmountScale, [5, 10, 20])
-    : fixedQuickAmounts(quickAmountScale, [1, 10, 100]);
+  // Receive has no balance to scale against, so both denominations offer the
+  // same fixed points of value, held to that value by the rate.
+  const quickAmounts = fixedQuickAmounts(quickAmountScale, [10, 50, 200]);
 
   // Mirrors the guard in `useReceivePayment.generateBolt11Invoice` so
   // the UI disables the Generate button + Enter-to-submit path for

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -111,7 +111,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   // points of value, held to that value by the rate. A sat request reaches
   // further up than a fiat one.
   const quickAmounts = isTokenMode
-    ? fixedQuickAmounts(quickAmountScale, [1, 5, 10])
+    ? fixedQuickAmounts(quickAmountScale, [5, 10, 20])
     : fixedQuickAmounts(quickAmountScale, [1, 10, 100]);
 
   // Mirrors the guard in `useReceivePayment.generateBolt11Invoice` so

--- a/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
+++ b/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
@@ -37,7 +37,7 @@ import { formatError } from '@/utils/formatError';
 
 type WorkflowStep = 'amount' | 'loading' | 'asset' | 'chain' | 'provider' | 'generating' | 'result';
 
-const QUICK_USD_AMOUNTS = [5, 10, 20];
+const QUICK_USD_AMOUNTS = [10, 50, 200];
 
 const CrossChainReceiveWorkflow: React.FC = () => {
   const wallet = useWallet();

--- a/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
+++ b/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
@@ -37,7 +37,7 @@ import { formatError } from '@/utils/formatError';
 
 type WorkflowStep = 'amount' | 'loading' | 'asset' | 'chain' | 'provider' | 'generating' | 'result';
 
-const QUICK_USD_AMOUNTS = [1, 5, 10];
+const QUICK_USD_AMOUNTS = [5, 10, 20];
 
 const CrossChainReceiveWorkflow: React.FC = () => {
   const wallet = useWallet();


### PR DESCRIPTION
The receive quick amount buttons are too low for usual requests. In fiat they show $1, $5 and $10. In sats they show the value of $1, $10 and $100. Users type the amount instead, so the buttons do little.

This PR changes all receive quick amounts to $10, $50 and $200:
- The Lightning amount panel, in fiat and in sats.
- The USD tab of the receive sheet.

In sats, each button shows the value of its dollar amount at the current rate, as the nearest round number. At 1 000 sats to the dollar, the buttons show ₿10 000, ₿50 000 and ₿200 000.

Send calculates its quick amounts from the balance. Receive has no balance to use, so these values are fixed in the code. Buy uses the same method.