### PR TITLE
fix: polish the transfer claim sheet

### DIFF
--- a/src/components/FeeBreakdownCard.tsx
+++ b/src/components/FeeBreakdownCard.tsx
@@ -11,6 +11,12 @@ export interface FeeBreakdownItem {
   value: number | bigint | string;
   unit?: string;
   highlight?: boolean;
+  /**
+   * Lifts a row without giving it the accent: for the figure a control on the
+   * screen changes, where `highlight` is reserved for the one the user is
+   * actually here for. Ignored on a `highlight` row.
+   */
+  emphasis?: boolean;
   /** Marker set before the amount, e.g. "~" for a figure that is estimated. */
   prefix?: string;
 }
@@ -46,10 +52,10 @@ export const FeeBreakdownCard: React.FC<FeeBreakdownCardProps> = ({
         <React.Fragment key={item.label}>
           {index > 0 && <div className="border-t border-spark-border/50" />}
           <div className="flex justify-between items-center">
-            <span className={`text-sm ${item.highlight ? 'text-spark-text-primary font-semibold' : 'text-spark-text-secondary'}`}>
+            <span className={`text-sm ${item.highlight ? 'text-spark-text-primary font-semibold' : item.emphasis ? 'text-spark-text-primary' : 'text-spark-text-secondary'}`}>
               {item.label}
             </span>
-            <span className={`font-mono text-sm ${item.highlight ? 'font-bold text-spark-primary' : 'text-spark-text-primary'}`}>
+            <span className={`font-mono text-sm ${item.highlight ? 'font-bold text-spark-primary' : item.emphasis ? 'font-semibold text-spark-text-primary' : 'text-spark-text-primary'}`}>
               {item.prefix}
               {useRawStrings || typeof item.value === 'string'
                 ? String(item.value)

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -136,9 +136,11 @@ export const DialogHeader: React.FC<{
 
 export const PaymentInfoCard: React.FC<{
   children: ReactNode;
+  /** Tighter padding, for a card holding a single row rather than a list. */
+  compact?: boolean;
   className?: string;
-}> = ({ children, className = "" }) => (
-  <div className={`bg-spark-dark/50 border border-spark-border rounded-2xl p-5 space-y-4 ${className}`}>
+}> = ({ children, compact = false, className = "" }) => (
+  <div className={`bg-spark-dark/50 border border-spark-border rounded-2xl ${compact ? 'p-4' : 'p-5'} space-y-4 ${className}`}>
     {children}
   </div>
 );
@@ -181,7 +183,9 @@ export const CollapsibleSection: React.FC<{
   <div className="py-2">
     <button
       onClick={onToggle}
-      className="flex justify-between items-center w-full text-left"
+      // py-2 for a 44px target, pulled back by -my-2 so the row occupies the
+      // height it always did. Same trick as DialogHeader's close control.
+      className="flex justify-between items-center w-full text-left py-2 -my-2"
     >
       <span className="text-spark-text-secondary text-sm">{label}</span>
       <span className="text-spark-primary hover:text-spark-primary-light flex items-center transition-colors p-1">

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -22,7 +22,7 @@ import { logger, LogCategory, logSdkMessage } from '../services/logger';
 import { formatError } from '../utils/formatError';
 import { isStandalonePwa, openExternalUrl } from '../utils/externalLink';
 import { INSTANT_CLAIM_SUBMITTED_TOAST, forgetAnnouncedClaims, splitClaimedDeposits, takeUnannouncedClaims } from '../utils/depositClaimQuote';
-import { isDepositRejected, clearRejectedDeposits } from '../services/depositState';
+import { isDepositRejected, clearRejectedDeposits, clearClaimFees } from '../services/depositState';
 import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, ensureSparkPrivateMode, type BuyBitcoinProvider } from '../services/settings';
 import { wipeAllLocalData } from '../services/accountDeletion';
 import { hideSplash } from '../main';
@@ -639,6 +639,7 @@ export function useBreezSdk(
     setCachedStableTicker(null);
     clearStableRestorePrompted();
     clearRejectedDeposits();
+    clearClaimFees();
     shownPaymentIdsRef.current.clear();
     forgetAnnouncedClaims();
     setIsConnected(false);

--- a/src/pages/UnclaimedDepositDetailsPage.test.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { ComponentProps } from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import type { BreezSdk, DepositInfo, FetchClaimDepositQuoteResponse } from '@breeztech/breez-sdk-spark';
 import { WalletProvider } from '@/contexts/WalletContext';
 import { ToastProvider } from '@/contexts/ToastContext';
@@ -146,6 +146,16 @@ function button(name: string | RegExp): HTMLButtonElement {
   return found;
 }
 
+/** Picking Instant is what arms the claim button, so most tests start here. */
+async function turnOnInstant() {
+  await screen.findByTestId('delivery-speed');
+  fireEvent.click(button(/^Instant delivery/));
+}
+
+/** The delivery speed group, present only when both speeds are on offer. */
+const queryInstantRow = () => screen.queryByTestId('delivery-speed');
+const findInstantRow = () => screen.findByTestId('delivery-speed');
+
 /** The temporary dev setting that gates the priority claim. */
 function setPriorityClaim(enabled: boolean) {
   saveSettings({
@@ -181,44 +191,55 @@ describe('a confirming deposit with both routes on offer', () => {
     await waitFor(() => expect(client.fetchClaimDepositQuote).toHaveBeenCalledWith({
       txid: 'a'.repeat(64), vout: 0,
     }));
-    expect(await screen.findByText('Priority')).toBeInTheDocument();
-    expect(screen.getByText('Standard')).toBeInTheDocument();
+    expect(await findInstantRow()).toBeInTheDocument();
   });
 
-  it('shows what each route costs and how long it takes', async () => {
-    renderSheet(makeDeposit(), withQuote(quote()));
+  it('names both speeds, so waiting is not the unnamed one', async () => {
+    const group = await (async () => { renderSheet(makeDeposit(), withQuote(quote())); return findInstantRow(); })();
 
-    await screen.findByText('Priority');
-    // Early is claimable at the current depth; maturity is 2 blocks out.
-    expect(button(/^Priority/)).toHaveTextContent('Now');
-    expect(button(/^Standard/)).toHaveTextContent('~20 min');
-    expect(button(/^Standard/)).toHaveTextContent('198');
+    expect(group).toHaveTextContent('Standard delivery');
+    expect(group).toHaveTextContent('Instant delivery');
+    expect(group).toHaveTextContent('Arrives in seconds');
+    // Each speed carries its own fee, in one column down the right.
+    expect(group).toHaveTextContent('198');
+    expect(group).toHaveTextContent('3 200');
   });
 
-  it('says nothing about waiting, the options and button speaking for it', async () => {
+  // Waiting is what happens anyway, so it is never armed without being asked for.
+  it('selects standard by default and leaves the button inert', async () => {
     renderSheet(makeDeposit(), withQuote(quote()));
 
-    await screen.findByText('Priority');
-    expect(screen.queryByText(/Waiting for/)).not.toBeInTheDocument();
+    await findInstantRow();
+    expect(button(/^Standard delivery/)).toHaveAttribute('aria-checked', 'true');
+    expect(button(/^Instant delivery/)).toHaveAttribute('aria-checked', 'false');
+    expect(button('Claim Now')).toBeDisabled();
   });
 
   it('marks the estimated fee and leaves the quoted one bare', async () => {
     renderSheet(makeDeposit(), withQuote(quote()));
 
-    await screen.findByText('Priority');
+    await findInstantRow();
     // The provider will not quote maturity before a deposit matures.
-    expect(button(/^Standard/).textContent).toContain('~');
-    expect(button(/^Priority/).textContent).not.toContain('~');
+    expect(button(/^Standard delivery/).textContent).toContain('~');
+    expect(button(/^Instant delivery/).textContent).not.toContain('~');
   });
 
-  it('carries the estimate marker into the breakdown, which reprices too', async () => {
+  // The group names both waits, so a line below repeating one says it twice.
+  it('leaves the wait to the group rather than restating it', async () => {
     renderSheet(makeDeposit(), withQuote(quote()));
 
-    await screen.findByText('Priority');
-    const feeRow = (label: string) => screen.getByText(label).parentElement?.textContent ?? '';
-    expect(feeRow('Priority fee')).not.toContain('~');
-    fireEvent.click(button(/^Standard/));
-    expect(feeRow('Network fee')).toContain('~');
+    await findInstantRow();
+    expect(screen.queryByText(/Waiting for/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Claimed automatically after/)).toBeNull();
+  });
+
+  it('carries the estimate marker into the breakdown when waiting is priced', async () => {
+    // The provider will not quote maturity before a deposit matures.
+    const noEarly = quote();
+    delete noEarly.instant;
+    renderSheet(makeDeposit(), withQuote(noEarly));
+
+    await waitFor(() => expect(screen.getByText('Network fee').parentElement?.textContent).toContain('~'));
   });
 
   it('re-prices when a block lands, so the route unlocks without reopening', async () => {
@@ -226,15 +247,48 @@ describe('a confirming deposit with both routes on offer', () => {
     const stream = eventStream();
     renderSheet(makeDeposit(), client, stream.subscribe);
 
-    // Early unlocks at depth 1, and the deposit is at 0: nothing to claim yet.
-    await screen.findByText('Priority');
-    expect(screen.getByText('Waiting for 1 confirmation.')).toBeInTheDocument();
+    // Early unlocks at depth 1, and the deposit is at 0: priced but not takeable.
+    await findInstantRow();
+    expect(button(/^Instant delivery/)).toHaveAttribute('aria-disabled', 'true');
+    expect(button(/^Instant delivery/)).toHaveTextContent('Unlocks in 1 confirmation');
 
     vi.mocked(client.fetchClaimDepositQuote).mockResolvedValue(quote({ confirmations: 1 }));
     stream.emitSynced();
 
-    await waitFor(() => expect(screen.queryByText('Waiting for 1 confirmation.')).toBeNull());
-    expect(button('Claim now')).toBeEnabled();
+    // The block lands and the route becomes selectable, without reopening.
+    await waitFor(() =>
+      expect(button(/^Instant delivery/)).toHaveAttribute('aria-disabled', 'false'));
+    expect(button('Claim Now')).toBeDisabled();
+    await turnOnInstant();
+    expect(button('Claim Now')).toBeEnabled();
+  });
+
+  // The provider re-quotes on every sync, so the depth it wants can rise after
+  // the paid route was picked. Claiming against a floor above the deposit's
+  // depth throws, so the pick cannot survive the route locking under it.
+  it('falls back to waiting when a re-price locks the route after it was picked', async () => {
+    const client = withQuote(quote({ confirmations: 1 }));
+    const stream = eventStream();
+    renderSheet(makeDeposit(), client, stream.subscribe);
+
+    await turnOnInstant();
+    expect(button('Claim Now')).toBeEnabled();
+    expect(button(/^Instant delivery/)).toHaveAttribute('aria-checked', 'true');
+
+    // Same depth, but the provider now wants two confirmations rather than one.
+    vi.mocked(client.fetchClaimDepositQuote).mockResolvedValue(quote({
+      confirmations: 1,
+      instant: { confirmationsRequired: 2, creditAmountSats: 96_800, feeSats: 3_200,
+        feeRateSatPerVbyte: 4, isEstimate: false },
+    }));
+    stream.emitSynced();
+
+    await waitFor(() => expect(button('Claim Now')).toBeDisabled());
+    expect(button(/^Standard delivery/)).toHaveAttribute('aria-checked', 'true');
+    expect(button(/^Instant delivery/)).toHaveAttribute('aria-checked', 'false');
+    // Priced as waiting, not at the spread it can no longer buy.
+    expect(screen.getByText('Network fee')).toBeInTheDocument();
+    expect(screen.queryByText('Delivery fee')).toBeNull();
   });
 
   it('does not re-price under a claim already sent', async () => {
@@ -244,7 +298,8 @@ describe('a confirming deposit with both routes on offer', () => {
     vi.mocked(client.claimDeposit).mockReturnValue(new Promise(() => {}));
     renderSheet(makeDeposit(), client, stream.subscribe);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
     await screen.findByText('Processing...');
     const quotesBefore = vi.mocked(client.fetchClaimDepositQuote).mock.calls.length;
 
@@ -257,7 +312,7 @@ describe('a confirming deposit with both routes on offer', () => {
     const client = withQuote(quote());
     const stream = eventStream();
     const { onChanged } = renderSheet(makeDeposit(), client, stream.subscribe);
-    await screen.findByText('Priority');
+    await findInstantRow();
 
     // Claimed elsewhere: it has left the unclaimed set entirely.
     vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({ deposits: [] });
@@ -271,7 +326,7 @@ describe('a confirming deposit with both routes on offer', () => {
     const client = withQuote(quote());
     const stream = eventStream();
     renderSheet(makeDeposit(), client, stream.subscribe);
-    await screen.findByText('Priority');
+    await findInstantRow();
 
     // It matures with the sheet open and the automatic claim trips the ceiling.
     vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
@@ -289,7 +344,7 @@ describe('a confirming deposit with both routes on offer', () => {
     await waitFor(() => expect(button('Approve')).toBeInTheDocument());
     expect(screen.getByText('Network fee').parentElement).toHaveTextContent('512');
     // The approve panel owns the sheet: no route button still offering a claim.
-    expect(queryButton('Claim now')).toBeNull();
+    expect(queryButton('Claim Now')).toBeNull();
   });
 
   it('does not let a sync re-announce a claim the sheet already toasted', async () => {
@@ -297,7 +352,8 @@ describe('a confirming deposit with both routes on offer', () => {
     vi.mocked(client.claimDeposit).mockResolvedValue({});
     const { onChanged } = renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
 
     // Sync reports the same outpoint as submitted; it is no longer news.
@@ -308,7 +364,7 @@ describe('a confirming deposit with both routes on offer', () => {
     const client = withQuote(quote());
     const stream = eventStream();
     renderSheet(makeDeposit(), client, stream.subscribe);
-    await screen.findByText('Priority');
+    await findInstantRow();
 
     vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
       deposits: [makeDeposit({
@@ -342,30 +398,33 @@ describe('a confirming deposit with both routes on offer', () => {
       .mockRejectedValue(new Error('quote unavailable'));
     renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
     await screen.findByText('network unreachable');
-    // The options came from the first quote and still describe the deposit.
-    expect(queryButton(/^Priority/)).not.toBeNull();
-    expect(queryButton(/^Standard/)).not.toBeNull();
+    // The row came from the first quote and still describes the deposit.
+    expect(queryInstantRow()).not.toBeNull();
   });
 
-  it('leaves a deposit at maturity depth to the automatic claim', async () => {
-    // Deep enough for Standard, which is not the user's to commit: the SDK
-    // claims it at maturity, so offering a button would only race that.
+  // Once the automatic claim is due the spread buys one sync cycle at sixteen
+  // times the fee the SDK is about to pay anyway, so it stops being offered.
+  // Otherwise this reads exactly like a deposit the provider never offered to
+  // front, which is a different thing entirely.
+  it('says the claim is happening, not that it will', async () => {
     renderSheet(makeDeposit(), withQuote(quote({ confirmations: 3 })));
 
-    await screen.findByText('Standard');
-    fireEvent.click(button(/^Standard/));
-    expect(screen.getByText('This transfer will be claimed automatically.')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('This transfer is being claimed.')).toBeInTheDocument());
+  });
+
+  it('withdraws the early route once the automatic claim is already due', async () => {
+    renderSheet(makeDeposit(), withQuote(quote({ confirmations: 3 })));
+
+    await waitFor(() =>
+      expect(screen.getByText('This transfer is being claimed.')).toBeInTheDocument());
+    expect(queryInstantRow()).toBeNull();
     expect(queryButton(/^Claim/)).toBeNull();
-  });
-
-  it('still commits the early route itself', async () => {
-    renderSheet(makeDeposit(), withQuote(quote({ confirmations: 3 })));
-
-    await screen.findByText('Priority');
-    expect(button('Claim now')).toBeEnabled();
-    expect(screen.queryByText('This transfer will be claimed automatically.')).toBeNull();
+    // Waiting is what will happen, so waiting is what the breakdown prices.
+    expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198');
   });
 
   it('reports a claim already in flight as submitted, not as a failure', async () => {
@@ -378,64 +437,99 @@ describe('a confirming deposit with both routes on offer', () => {
     });
     renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
     await screen.findByText(CLAIM_SUBMITTED_LINE);
     expect(screen.queryByText(/in progress/)).toBeNull();
   });
 
-  it('drops the previous route failure when the other is chosen', async () => {
-    const client = withQuote(quote());
-    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('network unreachable'));
-    renderSheet(makeDeposit(), client);
-
-    fireEvent.click(await screen.findByText('Claim now'));
-    await screen.findByText('network unreachable');
-
-    fireEvent.click(screen.getByText('Standard'));
-    // It priced the route that is no longer selected.
-    expect(screen.queryByText('network unreachable')).not.toBeInTheDocument();
-  });
-
-  it('drops the previous route re-price when the other is chosen', async () => {
-    const client = withQuote(quote());
-    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('Max deposit claim fee exceeded'));
-    vi.mocked(client.fetchClaimDepositQuote)
-      .mockResolvedValueOnce(quote())
-      .mockResolvedValue(quote({
-        instant: { confirmationsRequired: 1, creditAmountSats: 91_000, feeSats: 9_000,
-          feeRateSatPerVbyte: 9, isEstimate: false },
-      }));
-    renderSheet(makeDeposit(), client);
-
-    fireEvent.click(await screen.findByText('Claim now'));
-    await screen.findByText('Fee changed');
-
-    fireEvent.click(button(/^Standard/));
-    expect(screen.queryByText('Fee changed')).not.toBeInTheDocument();
-  });
-
-  it('defaults to the early route and prices the breakdown against it', async () => {
+  // The switch sits above the breakdown because turning it on reprices it.
+  it('prices the wait until the paid route is asked for', async () => {
     renderSheet(makeDeposit(), withQuote(quote()));
 
-    await screen.findByText('Priority');
-    expect(screen.getByText('Priority fee').parentElement).toHaveTextContent('3 200');
+    await findInstantRow();
+    expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198');
+    expect(screen.getByText('You receive').parentElement).toHaveTextContent('99 802');
+
+    await turnOnInstant();
+    expect(screen.getByText('Delivery fee').parentElement).toHaveTextContent('3 200');
     expect(screen.getByText('You receive').parentElement).toHaveTextContent('96 800');
   });
 
-  it('reprices the breakdown when the other route is chosen', async () => {
+  // Priced before it unlocks, the early route would headline the proceeds of a
+  // purchase the user cannot make, against a wait that is what will happen.
+  it('prices the wait while the early route is still locked', async () => {
+    renderSheet(makeDeposit(), withQuote(quote({ confirmations: 0 })));
+
+    await waitFor(() => expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198'));
+    expect(screen.getByText('You receive').parentElement).toHaveTextContent('99 802');
+  });
+
+  // The wait belongs to the group, where it can be weighed against the fee for
+  // skipping it. With no offer on the table there is nothing to weigh, so the
+  // line says what happens and stops.
+  it('quotes no wait on the states with nothing to choose', async () => {
+    const noEarly = quote();
+    delete noEarly.instant;
+    renderSheet(makeDeposit(), withQuote(noEarly));
+
+    await waitFor(() =>
+      expect(screen.getByText('This transfer will be claimed automatically.')).toBeInTheDocument());
+    expect(document.body.textContent).not.toMatch(/confirmations \(~/);
+  });
+
+  // The Standard row is where a wait earns its place: beside the fee for skipping it.
+  it('carries the wait in the group, count first and minutes in parentheses', async () => {
     renderSheet(makeDeposit(), withQuote(quote()));
 
-    fireEvent.click(await screen.findByText('Standard'));
+    expect(await findInstantRow()).toHaveTextContent('2 confirmations (~20 mins)');
+  });
 
+  // Waiting needs no control to happen, but with none on screen the sheet
+  // offered the paid route and nothing beside it.
+  // Picking Standard again is the whole of "no thanks": it disarms the button
+  // and puts the wait back in the breakdown.
+  it('disarms again when standard is picked back', async () => {
+    const client = withQuote(quote());
+    renderSheet(makeDeposit(), client);
+
+    await turnOnInstant();
+    expect(button('Claim Now')).toBeEnabled();
+
+    fireEvent.click(button(/^Standard delivery/));
+    expect(button('Claim Now')).toBeDisabled();
     expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198');
-    expect(screen.getByText('You receive').parentElement).toHaveTextContent('99 802');
+    expect(client.claimDeposit).not.toHaveBeenCalled();
+  });
+
+  it('offers nothing to turn on when the provider will not front it', async () => {
+    const noEarly = quote();
+    delete noEarly.instant;
+    renderSheet(makeDeposit(), withQuote(noEarly));
+
+    await waitFor(() => expect(screen.getByText('This transfer will be claimed automatically.')).toBeInTheDocument());
+    expect(queryInstantRow()).toBeNull();
+  });
+
+  // The reviewer asked for the fee off the label; a screen reader still has to
+  // hear what the button buys, so it is described by the row's fee instead.
+  it('describes the button by the offer without labelling it with a price', async () => {
+    renderSheet(makeDeposit(), withQuote(quote()));
+
+    await turnOnInstant();
+    const cta = button('Claim Now');
+    expect(cta.textContent).not.toMatch(/3 200|3 002/);
+    // Described by the whole offer, so the route and its price are both read out.
+    expect(document.getElementById(cta.getAttribute('aria-describedby') ?? ''))
+      .toHaveTextContent('Instant delivery');
   });
 
   it('claims at a ceiling that covers the chosen route', async () => {
     const client = withQuote(quote());
     renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
 
     await waitFor(() => expect(client.claimDeposit).toHaveBeenCalled());
     // Below the quoted fee the SDK declines the route and waits for maturity.
@@ -450,10 +544,66 @@ describe('a confirming deposit with both routes on offer', () => {
     vi.mocked(client.claimDeposit).mockResolvedValue({});
     const { onChanged } = renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
 
     expect(await screen.findByText('Claim Submitted')).toBeInTheDocument();
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+});
+
+// The automatic claim runs only while the fee stays under the configured
+// ceiling, so a fee above it means approval, not an automatic claim.
+describe('a wait the fee ceiling will not cover', () => {
+  it('warns before the refusal instead of promising a claim it cannot make', async () => {
+    saveSettings({ depositMaxFee: { type: 'fixed', amount: 400 }, priorityDepositClaimEnabled: true });
+    const dear = quote({
+      mature: { confirmationsRequired: 3, creditAmountSats: 99_400, feeSats: 600,
+        feeRateSatPerVbyte: 5, isEstimate: true },
+    });
+    delete dear.instant;
+    renderSheet(makeDeposit(), withQuote(dear));
+
+    // Future tense, and no buttons: nothing is claimable yet. The panel with
+    // Approve and Reject is the state after the SDK has actually been refused.
+    const line = await screen.findByText(/will be asked to approve/);
+    expect(line).toHaveTextContent('400');
+    expect(screen.queryByText(/claimed automatically/i)).toBeNull();
+  });
+
+  // The SDK refuses on a sync after maturity, not at maturity itself. Dropping
+  // the warning at the boundary would spend that window promising the claim it
+  // is about to refuse, which is the promise the warning exists to avoid.
+  it('keeps warning once the deposit matures, until the claim is actually refused', async () => {
+    saveSettings({ depositMaxFee: { type: 'fixed', amount: 400 }, priorityDepositClaimEnabled: true });
+    const dear = quote({
+      mature: { confirmationsRequired: 3, creditAmountSats: 99_400, feeSats: 600,
+        feeRateSatPerVbyte: 5, isEstimate: true },
+    });
+    delete dear.instant;
+    const client = withQuote(dear);
+    const confirming = makeDeposit();
+
+    const { rerender } = render(
+      <ToastProvider>
+        <WalletProvider client={client} isConnected>
+          <UnclaimedDepositDetailsPage deposit={confirming} onBack={vi.fn()} />
+        </WalletProvider>
+      </ToastProvider>,
+    );
+    await screen.findByText(/will be asked to approve/);
+
+    // Matured, and the SDK has not refused it yet: no claimError on the record.
+    rerender(
+      <ToastProvider>
+        <WalletProvider client={client} isConnected>
+          <UnclaimedDepositDetailsPage deposit={makeDeposit({ isMature: true })} onBack={vi.fn()} />
+        </WalletProvider>
+      </ToastProvider>,
+    );
+
+    expect(screen.getByText(/will be asked to approve/)).toHaveTextContent('400');
+    expect(screen.queryByText(/claimed automatically/i)).toBeNull();
   });
 });
 
@@ -473,14 +623,59 @@ describe('a fee that rises between quoting and claiming', () => {
       .mockResolvedValue(risen());
     renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
 
-    expect(await screen.findByText('Fee changed')).toBeInTheDocument();
-    expect(screen.getByText('Claim again to accept the new fee.')).toBeInTheDocument();
-    // The card says it better than the SDK's message, so that stays off screen.
+    // A failed tap, reported like any other failed tap, naming the figure it
+    // moved from: the row and the breakdown below already carry the new one.
+    // The amount is one element, so it cannot break across lines mid-figure.
+    const changed = await screen.findByText(/Your claim did not go through/);
+    expect(changed).toHaveTextContent('3 200');
+    expect(changed.querySelector('.font-mono')?.textContent).toContain('3 200');
+    // Whether to pay the new price is the user's call, so the line does not ask.
+    expect(changed.textContent).not.toMatch(/Claim again|accept it/);
+    // The line says it better than the SDK's message, so that stays off screen.
     expect(screen.queryByText(/early claim was declined/)).not.toBeInTheDocument();
-    // The new figure lives in the breakdown, which has repriced.
-    expect(screen.getByText('Priority fee').parentElement).toHaveTextContent('4 600');
+    expect(screen.getByText('Delivery fee').parentElement).toHaveTextContent('4 600');
+  });
+
+  // The container measures content once and holds that snap, so a body that
+  // grew when the failure arrived would carry the footer off the bottom of the
+  // viewport with it. The cap stays put and the message is scrolled to instead.
+  it('keeps the body bounded when the failure appears', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('early claim was declined'));
+    vi.mocked(client.fetchClaimDepositQuote)
+      .mockResolvedValueOnce(quote())
+      .mockResolvedValue(risen());
+    renderSheet(makeDeposit(), client);
+
+    const cap = () => document.querySelector<HTMLElement>('[style*="dvh"]')?.style.maxHeight;
+    await turnOnInstant();
+    expect(cap()).toBe('74dvh');
+
+    fireEvent.click(button('Claim Now'));
+    await screen.findByText(/did not go through/);
+    expect(cap()).toBe('74dvh');
+  });
+
+  // A re-price is not gentler news than any other decline: the tap failed and
+  // nothing was claimed, so it reads the same way.
+  it('reports a re-price as a failure rather than as a note', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockRejectedValue(new Error('early claim was declined'));
+    vi.mocked(client.fetchClaimDepositQuote)
+      .mockResolvedValueOnce(quote())
+      .mockResolvedValue(risen());
+    renderSheet(makeDeposit(), client);
+
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
+
+    const line = await screen.findByText(/Your claim did not go through/);
+    // The same inline treatment a raw decline gets, and no icon of its own.
+    expect(line.className).toContain('text-spark-primary');
+    expect(line.querySelector('svg')).toBeNull();
   });
 
   it('keeps the raw error when the fee is not what failed', async () => {
@@ -488,10 +683,11 @@ describe('a fee that rises between quoting and claiming', () => {
     vi.mocked(client.claimDeposit).mockRejectedValue(new Error('network unreachable'));
     renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
 
     expect(await screen.findByText('network unreachable')).toBeInTheDocument();
-    expect(screen.queryByText('Fee changed')).not.toBeInTheDocument();
+    expect(screen.queryByText(/fee changed from/)).toBeNull();
   });
 });
 
@@ -504,33 +700,36 @@ describe('an early route that has not unlocked yet', () => {
     },
   });
 
-  it('says how much longer rather than offering a dead button', async () => {
+  // Shown, so the route is known to be coming and at what price, but not
+  // selectable: claiming below its floor is refused. It is also the only thing
+  // telling this state apart from one the provider will not front at all.
+  it('prices the route while it is still locked, without offering it', async () => {
     renderSheet(makeDeposit(), withQuote(notYet()));
 
-    expect(await screen.findByText('Waiting for 1 confirmation.')).toBeInTheDocument();
-    // Calling claimDeposit before the floor throws, so nothing is pressable.
-    expect(queryButton('Claim now')).not.toBeInTheDocument();
+    await findInstantRow();
+    const locked = button(/^Instant delivery/);
+    expect(locked).toHaveAttribute('aria-disabled', 'true');
+    expect(locked).toHaveTextContent('Unlocks in 1 confirmation');
+
+    fireEvent.click(locked);
+    expect(button('Claim Now')).toBeDisabled();
   });
 });
 
 describe('a deposit the provider will not front', () => {
-  it('keeps the layout but fades the route that is not on offer', async () => {
+  // A faded, unpressable card at the top of the sheet says less than dropping
+  // it and pricing the wait that will actually happen.
+  it('drops the route rather than fading it, and prices the wait', async () => {
     const noEarly = quote();
     delete noEarly.instant;
     renderSheet(makeDeposit(), withQuote(noEarly));
 
-    await screen.findByText('Priority');
-    // aria-disabled rather than disabled, so it still reads as a route that
-    // exists and is unavailable instead of vanishing from the group.
-    expect(button(/^Priority/)).toHaveAttribute('aria-disabled', 'true');
-    expect(button(/^Priority/)).toHaveTextContent('Not available');
-    // Still inert: tapping it must not steal the selection from Standard.
-    fireEvent.click(button(/^Priority/));
-    expect(button(/^Priority/)).toHaveAttribute('aria-checked', 'false');
-    expect(button(/^Standard/)).toHaveAttribute('aria-checked', 'true');
-    // Waiting is still priced, so the screen says what the claim will cost.
-    expect(button(/^Standard/)).toHaveTextContent('198');
-    expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198');
+    await waitFor(() =>
+      expect(screen.getByText('Network fee').parentElement).toHaveTextContent('198'));
+    expect(queryInstantRow()).toBeNull();
+    // The count is what moves between one look and the next, so it is what the
+    // line carries rather than a wall-clock estimate that would not.
+    expect(screen.getByText('This transfer will be claimed automatically.')).toBeInTheDocument();
   });
 
   it('leaves nothing to press, the claim happening at maturity', async () => {
@@ -538,9 +737,8 @@ describe('a deposit the provider will not front', () => {
     delete noEarly.instant;
     renderSheet(makeDeposit(), withQuote(noEarly));
 
-    await screen.findByText('Priority');
-    expect(queryButton('Claim now')).not.toBeInTheDocument();
-    expect(queryButton('Claim')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Network fee')).toBeInTheDocument());
+    expect(queryButton(/^Claim/)).toBeNull();
   });
 
   it('offers nothing when the early route unlocks no sooner than waiting', async () => {
@@ -553,11 +751,33 @@ describe('a deposit the provider will not front', () => {
     });
     renderSheet(makeDeposit(), withQuote(pointless));
 
-    await waitFor(() => expect(screen.queryByText('Priority')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Network fee')).toBeInTheDocument());
+    expect(queryInstantRow()).toBeNull();
   });
 });
 
 describe('a claim already in flight', () => {
+  // The SDK keeps no fee on a submitted claim and a fresh quote would be a
+  // different number, so the sheet remembers what it charged at submit time.
+  it('prices a reopened sheet from what the claim actually cost', async () => {
+    const client = withQuote(quote());
+    vi.mocked(client.claimDeposit).mockResolvedValue({});
+    const submitted = makeDeposit({ instantClaimStatus: { type: 'submitted', claimId: 'c' } });
+
+    const first = renderSheet(makeDeposit(), client);
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
+    await waitFor(() => expect(first.onChanged).toHaveBeenCalled());
+    cleanup();
+
+    // Reopened mid-settlement: no quote is fetched, so this can only come from
+    // the receipt written when the claim was sent.
+    renderSheet(submitted, withQuote(quote()));
+    expect(screen.getByText(CLAIM_SUBMITTED_LINE)).toBeInTheDocument();
+    expect(screen.getByText('Delivery fee').parentElement).toHaveTextContent('3 200');
+    expect(screen.getByText('You receive').parentElement).toHaveTextContent('96 800');
+  });
+
   const inFlight = (isMature = false) =>
     makeDeposit({ isMature, instantClaimStatus: { type: 'submitted', claimId: 'c' } });
 
@@ -566,8 +786,8 @@ describe('a claim already in flight', () => {
     renderSheet(inFlight(), client);
 
     expect(screen.getByText(CLAIM_SUBMITTED_LINE)).toBeInTheDocument();
-    expect(queryButton('Claim now')).not.toBeInTheDocument();
-    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+    expect(queryButton('Claim Now')).toBeNull();
+    expect(queryInstantRow()).toBeNull();
     // No point pricing a deposit whose claim is already settling.
     expect(client.fetchClaimDepositQuote).not.toHaveBeenCalled();
   });
@@ -576,7 +796,7 @@ describe('a claim already in flight', () => {
     const client = withQuote(quote());
     const stream = eventStream();
     renderSheet(makeDeposit(), client, stream.subscribe);
-    await screen.findByText('Priority');
+    await findInstantRow();
 
     vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
       deposits: [makeDeposit({ instantClaimStatus: { type: 'submitted', claimId: 'c' } })],
@@ -585,7 +805,7 @@ describe('a claim already in flight', () => {
 
     // The quote is still loaded: only the in-flight status hides the choice.
     await screen.findByText(CLAIM_SUBMITTED_LINE);
-    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+    expect(queryInstantRow()).toBeNull();
     expect(queryButton(/^Claim/)).toBeNull();
   });
 
@@ -593,6 +813,29 @@ describe('a claim already in flight', () => {
     renderSheet(inFlight(true), withQuote(quote()));
     expect(screen.getByText(CLAIM_SUBMITTED_LINE)).toBeInTheDocument();
     expect(screen.queryByText(/claimed automatically/)).not.toBeInTheDocument();
+  });
+});
+
+// The footer never consulted claimError, and isConfirming reads a record the
+// sync handler has already moved past, so both could be true at once.
+describe('an automatic claim that fails under the sheet', () => {
+  it('offers a refund without still offering to claim', async () => {
+    const client = withQuote(quote());
+    const stream = eventStream();
+    renderSheet(makeDeposit(), client, stream.subscribe);
+    await findInstantRow();
+
+    vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({
+      deposits: [makeDeposit({
+        isMature: true,
+        claimError: { type: 'generic', message: 'operator unavailable' },
+      })],
+    });
+    stream.emitSynced();
+
+    await screen.findByText('operator unavailable');
+    expect(button('Reject')).toBeInTheDocument();
+    expect(queryButton(/^Claim/)).toBeNull();
   });
 });
 
@@ -605,8 +848,9 @@ describe('a route the background sync passed over', () => {
       withQuote(quote()),
     );
 
-    expect(await screen.findByText('Priority')).toBeInTheDocument();
-    expect(button('Claim now')).toBeInTheDocument();
+    expect(await findInstantRow()).toBeInTheDocument();
+    await turnOnInstant();
+    expect(button('Claim Now')).toBeInTheDocument();
     expect(screen.queryByText(/above your limit/)).not.toBeInTheDocument();
   });
 });
@@ -619,11 +863,12 @@ describe('a deposit claimed while the sheet was working', () => {
     vi.mocked(client.listUnclaimedDeposits).mockResolvedValue({ deposits: [] });
     const { onChanged } = renderSheet(makeDeposit(), client);
 
-    fireEvent.click(await screen.findByText('Claim now'));
+    await turnOnInstant();
+    fireEvent.click(button('Claim Now'));
 
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
     expect(screen.queryByText('already claimed')).not.toBeInTheDocument();
-    expect(screen.queryByText('Fee changed')).not.toBeInTheDocument();
+    expect(screen.queryByText(/fee changed from/)).toBeNull();
   });
 });
 
@@ -636,8 +881,8 @@ describe('the dev setting that gates it', () => {
     // Falls back to what the sheet was before the feature.
     await waitFor(() => expect(screen.getByText(/Waiting for 3 confirmations/)).toBeInTheDocument());
     expect(client.fetchClaimDepositQuote).not.toHaveBeenCalled();
-    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
-    expect(queryButton('Claim now')).not.toBeInTheDocument();
+    expect(queryInstantRow()).toBeNull();
+    expect(queryButton('Claim Now')).toBeNull();
   });
 });
 
@@ -646,6 +891,6 @@ describe('when the quote cannot be fetched', () => {
     renderSheet(makeDeposit(), withQuote(new Error('offline')));
 
     await waitFor(() => expect(screen.getByText(/Waiting for 3 confirmations/)).toBeInTheDocument());
-    expect(queryButton('Claim now')).not.toBeInTheDocument();
+    expect(queryButton('Claim Now')).toBeNull();
   });
 });

--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -9,14 +9,15 @@ import type {
   InstantClaimStatus,
   MaxFee,
 } from '@breeztech/breez-sdk-spark';
-import { BottomSheetContainer, BottomSheetCard, DialogHeader, FormError, PrimaryButton, SecondaryButton, PaymentInfoCard, CollapsibleCodeField } from '../components/ui';
+import { BottomSheetContainer, BottomSheetCard, DialogHeader, PrimaryButton, SecondaryButton, PaymentInfoCard, CollapsibleCodeField } from '../components/ui';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
 import { SpinnerIcon } from '../components/Icons';
 import { AlertCard } from '../components/AlertCard';
 import { SatAmount } from '../components/SatAmount';
-import { rejectDeposit, removeRejectedDeposit } from '../services/depositState';
+import { forgetClaimFee, readClaimFee, rejectDeposit, rememberClaimFee, removeRejectedDeposit } from '../services/depositState';
 import { explorerTxUrl } from '../utils/explorer';
-import { isPriorityDepositClaimEnabled } from '../services/settings';
+import { getSettings, isPriorityDepositClaimEnabled } from '../services/settings';
+import { formatWithSpaces } from '../utils/formatNumber';
 import {
   CLAIM_SUBMITTED_LINE,
   INSTANT_CLAIM_SUBMITTED_TOAST,
@@ -94,58 +95,95 @@ async function findFreshDeposit(wallet: BreezSdk, deposit: DepositInfo): Promise
 }
 
 /**
+ * True while there is content below the scroller's current position: not merely
+ * whether it can scroll, so the hint disappears once you have reached the end
+ * rather than sitting over the last line of it.
+ */
+function useMoreBelow(ref: React.RefObject<HTMLDivElement | null>, deps: unknown[]) {
+  const [moreBelow, setMoreBelow] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => setMoreBelow(el.scrollHeight - el.scrollTop - el.clientHeight > 1);
+    measure();
+    el.addEventListener('scroll', measure, { passive: true });
+    // Catches the sheet resizing; the deps catch the content changing under it.
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener('scroll', measure);
+      observer.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref, ...deps]);
+  return moreBelow;
+}
+
+/**
  * The sheet body, capped in dvh so the card stays fully on screen: unbounded,
  * the content snap is measured against the URL-bar-hidden viewport, so the card
  * runs past the visible one while its scroller still believes it fits.
  *
- * Its own component because the cap reads the sheet's snap, and that context is
- * provided by BottomSheetContainer. Read in the component that renders the
- * container it would only ever see the default, leaving the cap stuck at 65dvh.
+ * 74dvh is the smallest cap that fits every ordinary state on an iPhone 14 with
+ * nothing clipped. It stays a cap rather than growing for the taller states: the
+ * container measures content once and holds that snap, so a body that grew
+ * afterwards would carry the footer past the bottom of the viewport with it.
  */
 const SheetBody: React.FC<{ children: ReactNode }> = ({ children }) => {
   const isSheetFull = useSheetFullSnap();
   return (
-    <div className="flex flex-col" style={{ maxHeight: isSheetFull ? '85dvh' : '65dvh' }}>
+    <div className="flex flex-col" style={{ maxHeight: isSheetFull ? '85dvh' : '74dvh' }}>
       {children}
     </div>
   );
 };
 
-/** One of the two ways to claim, or a faded placeholder when it is not on offer. */
-const DeliveryOption: React.FC<{
+/** Ties the claim button to the offer it takes without putting it in the label. */
+const INSTANT_OFFER_ID = 'instant-claim-offer';
+
+/**
+ * One delivery speed. A full-width row rather than a half-width tile: the names
+ * are what distinguish the two, so they get the space, and the fees line up in
+ * one column down the right where they can be compared.
+ */
+const SpeedOption: React.FC<{
   label: string;
-  active: boolean;
+  detail: string;
+  feeSats: number;
+  isEstimate: boolean;
+  selected: boolean;
+  /** Priced and named, but not yet claimable: shown so the route is known to be
+   *  coming, disabled because claiming below its floor is refused. */
+  locked?: boolean;
   onSelect: () => void;
-  /** The quote, or null when this route is not on offer for this deposit. */
-  option: ClaimDepositQuote | null;
-  wait: string | null;
-}> = ({ label, active, onSelect, option, wait }) => (
+}> = ({ label, detail, feeSats, isEstimate, selected, locked = false, onSelect }) => (
   <button
     role="radio"
-    aria-checked={active}
-    onClick={option ? onSelect : undefined}
-    // aria-disabled, not disabled: the route being unavailable is the point, and
-    // a disabled control drops out of the group rather than announcing that.
-    aria-disabled={!option}
-    className={`flex-1 p-3 rounded-2xl border text-left transition-all ${
-      !option
-        ? 'bg-spark-dark border-spark-border opacity-40 cursor-not-allowed'
-        : active
+    aria-checked={selected}
+    aria-disabled={locked}
+    onClick={locked ? undefined : onSelect}
+    className={`w-full flex items-center justify-between gap-3 p-3 rounded-2xl border text-left transition-colors ${
+      locked
+        ? 'bg-spark-dark border-spark-border opacity-60 cursor-default'
+        : selected
           ? 'bg-spark-primary/10 border-spark-primary'
           : 'bg-spark-dark border-spark-border hover:border-spark-border-light'
     }`}
   >
-    <div className="font-display font-medium text-spark-text-primary">{label}</div>
-    <div className="text-xs text-spark-text-muted mt-0.5">
-      {option ? (wait ?? 'Now') : 'Not available'}
-    </div>
-    {option && (
-      <div className="text-sm text-spark-text-secondary mt-1">
-        {/* Until a deposit is deep enough to claim at maturity there is nothing
-            for the provider to price, so that figure comes off onchain rates. */}
-        {option.isEstimate && '~'}<SatAmount sats={option.feeSats} />
-      </div>
-    )}
+    <span className="flex items-center gap-3 min-w-0">
+      <span className={`shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center ${
+        selected ? 'border-spark-primary' : 'border-spark-border-light'
+      }`}>
+        {selected && <span className="w-2 h-2 rounded-full bg-spark-primary" />}
+      </span>
+      <span className="min-w-0">
+        <span className="block font-display font-medium text-spark-text-primary">{label}</span>
+        <span className="block text-xs text-spark-text-muted mt-0.5">{detail}</span>
+      </span>
+    </span>
+    <span className="shrink-0 text-sm text-spark-text-secondary whitespace-nowrap">
+      {isEstimate && '~'}<SatAmount sats={feeSats} />
+    </span>
   </button>
 );
 
@@ -158,9 +196,9 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
   const subscribeToSdkEvents = useSdkEvents();
   const { showToast } = useToast();
 
-  // Parent keys this component on deposit identity, so the prop is stable per
-  // mount and never picks up a later claim outcome. Everything after the first
-  // read comes from handleClaim's retries or from the sync listener below.
+  // Seeded from the record and kept current by handleClaim's retries and by the
+  // sync listener below, either of which can turn a confirming deposit into one
+  // whose automatic claim has already run and been refused.
   const [{ claimError, requiredFeeSats }, setClaim] = useState<ClaimState>(() => deriveClaimState(deposit));
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const [feeRaised, setFeeRaised] = useState<boolean>(false);
@@ -174,51 +212,117 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
   );
   const [instantError, setInstantError] = useState<string | null>(null);
   const [quote, setQuote] = useState<FetchClaimDepositQuoteResponse | null>(null);
-  const [preferEarly, setPreferEarly] = useState<boolean>(true);
-  const [feeRequoted, setFeeRequoted] = useState(false);
+  // The fee a rejected claim was quoted at, so the re-price can name what moved.
+  const [instantFeeFrom, setInstantFeeFrom] = useState<number | null>(null);
+  // Which delivery speed is selected. Standard by default: it is what happens
+  // anyway, so the paid route is never armed without being asked for.
+  const [instantOn, setInstantOn] = useState<boolean>(false);
   // Read by the sync listener, which must not re-price under a claim already
   // sent: the sheet would restate the fee, and could drop the button, while the
   // user is looking at "Processing...".
   const claimInFlightRef = useRef(false);
+
+  // The prop is re-derived from the unclaimed list on every sync, so it is a new
+  // object each time with the same identity. Effects key on the outpoint and read
+  // the record through the ref, or each sync would re-subscribe and re-quote.
+  const depositRef = useLatest(deposit);
+  const txid = deposit?.txid;
+  const vout = deposit?.vout;
 
   const isConfirming = deposit ? !deposit.isMature : false;
   const isClaimInFlight = isClaimInFlightStatus(instantStatus);
 
   const early = earlyOption(quote);
   const confirmations = quote?.confirmations ?? 0;
-  // Without an early route there is nothing to pick, but waiting is still worth
-  // pricing: the breakdown shows what the automatic claim will cost.
-  const chosen: ClaimDepositQuote | null = selectOption(quote, preferEarly);
-  // Which fee is being priced: the provider's spread, or the onchain claim fee
-  // that the matured path above already calls "Network fee".
-  const chosenIsEarly = Boolean(early) && preferEarly;
-
-  /** Switching route drops the last attempt's failure, which priced a different one. */
-  const chooseRoute = (early_: boolean) => {
-    setPreferEarly(early_);
-    setInstantError(null);
-    setFeeRequoted(false);
-  };
-  // Quoted is not claimable: an option whose floor is above the deposit's
-  // current depth is an offer for N blocks' time, and claiming against it throws.
-  const chosenReady = chosen ? isClaimable(chosen, confirmations) : false;
-  const blocksLeft = chosen ? blocksToWait(chosen, confirmations) : 0;
+  // An offer for N blocks' time is not one the user can take now: claiming
+  // against a floor above the deposit's depth throws.
+  const earlyReady = early !== null && isClaimable(early, confirmations);
+  // The offer worth putting a switch beside, when there is one to take.
+  const offer = early && quote && !isClaimInFlight
+    ? { option: early, premiumSats: early.feeSats - quote.mature.feeSats, locked: !earlyReady }
+    : null;
+  // Which fee is being priced: the provider's spread once the user has asked
+  // for it, or the onchain claim fee the matured path calls "Network fee".
+  // A locked route can never be the chosen one, and a re-price can raise the
+  // floor above the deposit's depth after it was picked, so readiness is read
+  // here rather than trusted from the tap that set it.
+  const chosenIsEarly = offer !== null && !offer.locked && instantOn;
+  // Waiting is still worth pricing without an early route: the breakdown then
+  // shows what the automatic claim will cost.
+  const chosen: ClaimDepositQuote | null = quote
+    ? (chosenIsEarly && early ? early : quote.mature)
+    : null;
+  // A submitted claim is never re-quoted, so the breakdown would otherwise show
+  // the deposit and nothing about what it cost. The receipt is the figure the
+  // user agreed to, which a fresh quote would not be.
+  const receipt = deposit && isClaimInFlight ? readClaimFee(deposit.txid, deposit.vout) : null;
+  /** Choosing a speed, refused mid-flight so the route cannot change under it. */
+  const chooseSpeed = (early: boolean) => { if (!isProcessing) setInstantOn(early); };
+  // Null once the automatic claim is due, which is a different sentence.
+  const matureWait = quote ? formatWait(blocksToWait(quote.mature, confirmations)) : null;
+  // Deep enough that the SDK's own claim is due rather than pending. Without
+  // this the screen reads exactly like a deposit the provider never offered to
+  // front, which is a different thing entirely.
+  const matureDue = quote !== null && blocksToWait(quote.mature, confirmations) === 0;
+  // The automatic claim runs only while the fee stays under the configured
+  // ceiling, so promising it outright is a promise the SDK may refuse. A fixed
+  // ceiling is a sat figure we can compare now; the rate types depend on the
+  // tx at claim time, so those keep the plain sentence.
+  const maxFee = getSettings().depositMaxFee;
+  const overCeiling = quote !== null
+    && maxFee.type === 'fixed'
+    && quote.mature.feeSats > maxFee.amount
+    ? maxFee.amount
+    : null;
+  // Both ways a tap on the claim button ends badly, reported the same way: a
+  // re-price is not gentler news than any other decline, the claim did not
+  // happen either way. The amount goes through SatAmount rather than into the
+  // string, or its grouping space becomes a line break and splits the figure.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const failureRef = useRef<HTMLParagraphElement>(null);
+  // The body is capped, so a failure arriving under the fold is a message the
+  // user never sees. Bring it into the scroller rather than growing the sheet,
+  // which would carry the footer past the bottom of the viewport with it.
+  // Keyed on the state behind the message: the message itself is a node, and a
+  // new one every render would re-fire this on every render.
+  useEffect(() => {
+    if (instantFeeFrom !== null || instantError) {
+      failureRef.current?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [instantFeeFrom, instantError]);
+  const claimFailure: ReactNode = instantFeeFrom !== null
+    ? <>Your claim did not go through: the fee changed from <SatAmount sats={instantFeeFrom} />.</>
+    : instantError;
   // What the deposit is doing, when nothing else on screen already says it. A
-  // ready early route speaks through its own button, so it needs no line, and a
-  // line about waiting would contradict the one being offered.
+  // ready early route speaks through its own button, so it needs no line.
+  // Only draw the scroll fade when something is actually under it: on the states
+  // that fit, an unconditional one dims the last card for no reason.
+  const moreBelow = useMoreBelow(scrollRef, [quote, instantOn, instantFeeFrom, instantError, requiredFeeSats, claimError, isClaimInFlight]);
   const statusLine = isClaimInFlight
     // Says what the toast said, so reopening the sheet mid-settlement reports
     // the claim rather than showing an amount and nothing else.
     ? CLAIM_SUBMITTED_LINE
-    : !isConfirming
-      ? 'This transfer will be claimed automatically.'
-      : chosen
-        ? (blocksLeft > 0
-            ? `Waiting for ${blocksLeft} confirmation${blocksLeft === 1 ? '' : 's'}.`
-            // Nothing left to wait for, and no button on this route: the only
-            // thing left to say is who does the claiming.
-            : chosenIsEarly ? null : 'This transfer will be claimed automatically.')
-        : 'Waiting for 3 confirmations.';
+    // Ahead of the maturity branch on purpose. The warning has to survive the
+    // window between maturity and the sync that refuses the claim, or the sheet
+    // spends it promising the automatic claim the SDK is about to refuse.
+    // Future tense throughout that window: refused is when there is something to
+    // approve, and that state is the approve panel, not this line.
+    : overCeiling !== null
+      ? `The fee is above your ₿${formatWithSpaces(overCeiling)} limit. You will be asked to approve this claim.`
+      : !isConfirming
+        ? 'This transfer will be claimed automatically.'
+        : !quote
+          ? 'Waiting for 3 confirmations.'
+          // The group names both speeds and both waits, so a line under it
+          // repeating either would only say the same thing twice.
+          : offer !== null
+            ? null
+            // No wait quoted here either: with no offer on the table there is
+            // nothing for a countdown to be weighed against. The wait is priced
+            // inside the group, or it is not priced at all.
+            : matureDue
+              ? 'This transfer is being claimed.'
+              : 'This transfer will be claimed automatically.';
 
   const handleClose = () => {
     onBack();
@@ -260,6 +364,8 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
 
   /** Stands the sheet down: the deposit is settled or gone, so it has no actions left. */
   const dismissAsSettled = () => {
+    // Settled or gone: the receipt has nothing left to describe.
+    if (deposit) forgetClaimFee(deposit.txid, deposit.vout);
     onChanged?.();
     handleClose();
   };
@@ -297,20 +403,21 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
     // loadQuote awaits the SDK before it sets anything, so nothing is written during this render.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadQuote(deposit);
-  }, [deposit, loadQuote]);
+    // Prices once on open; the listener below re-prices from there.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [txid, vout, loadQuote]);
 
   // A quote is a snapshot at one depth. Left alone it goes stale in place: the
   // block that unlocks the early route lands, and the sheet still shows the
   // wait and no button until it is reopened.
   useEffect(() => {
-    if (!deposit || deposit.isMature) return;
-    // TEMPORARY: the same dev gate as the quote above, and it goes with it.
-    if (!isPriorityDepositClaimEnabled()) return;
+    const target = depositRef.current;
+    if (!target) return;
     let cancelled = false;
     const unsubscribe = subscribeToSdkEvents(event => {
       if (event.type !== 'synced' || claimInFlightRef.current) return;
       void (async () => {
-        const found = await findFreshDeposit(wallet, deposit);
+        const found = await findFreshDeposit(wallet, target);
         if (cancelled || claimInFlightRef.current) return;
         if (found.kind === 'gone') {
           // Claimed by background sync. Leaving the sheet up would keep offering
@@ -326,19 +433,26 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
         // unread on the record and the approve panel never appears.
         setClaim(deriveClaimState(found.deposit));
         if (isClaimInFlightStatus(found.deposit.instantClaimStatus)) return;
-        await loadQuote(deposit);
+        // Nothing left to price once it matures: the SDK claims it itself, and
+        // the approve panel is priced off the record rather than off a quote.
+        if (found.deposit.isMature) return;
+        // TEMPORARY: the same dev gate as the quote effect above, and it goes
+        // with it. Kept out of the subscribe so a gated sheet still stands down
+        // when the deposit settles.
+        if (!isPriorityDepositClaimEnabled()) return;
+        await loadQuote(found.deposit);
       })();
     });
     return () => {
       cancelled = true;
       unsubscribe();
     };
-  }, [deposit, dismissAsSettledRef, loadQuote, subscribeToSdkEvents, wallet]);
+  }, [txid, vout, depositRef, dismissAsSettledRef, loadQuote, subscribeToSdkEvents, wallet]);
 
   const handleQuotedClaim = async () => {
     if (!deposit || !chosen) return;
     setInstantError(null);
-    setFeeRequoted(false);
+    setInstantFeeFrom(null);
     setIsProcessing(true);
     claimInFlightRef.current = true;
     try {
@@ -351,6 +465,13 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
       // nothing else will announce it: the sheet is about to close over it.
       // Marked first, or the next sync reports the same claim as news.
       if (!payment) {
+        // The only record of what this cost: the SDK keeps no fee on a
+        // submitted claim, so without this the sheet cannot price itself when
+        // it is reopened mid-settlement.
+        rememberClaimFee(deposit.txid, deposit.vout, {
+          feeSats: chosen.feeSats,
+          creditAmountSats: chosen.creditAmountSats,
+        });
         markClaimAnnounced(deposit);
         showToast('success', INSTANT_CLAIM_SUBMITTED_TOAST.title, INSTANT_CLAIM_SUBMITTED_TOAST.detail);
       }
@@ -375,11 +496,12 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
       }
       // The price moves with depth, so a failure is a reason to re-price rather
       // than to retry against the figure that just failed.
-      const fresh = selectOption(await loadQuote(deposit), preferEarly);
+      const fresh = selectOption(await loadQuote(deposit));
       if (fresh && fresh.feeSats > chosen.feeSats) {
         // A fee that outran the ceiling explains itself: the sheet has already
-        // repriced, so the raw SDK message would only repeat it worse.
-        setFeeRequoted(true);
+        // repriced, so the raw SDK message would only repeat it worse. The old
+        // figure is kept so the line can say which way it moved.
+        setInstantFeeFrom(chosen.feeSats);
         return;
       }
       setInstantError(e instanceof Error ? e.message : 'Failed to claim transfer');
@@ -415,9 +537,13 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
       <BottomSheetCard>
         <DialogHeader title="BTC Transfer" onClose={handleClose} />
         <SheetBody>
-          <div className="space-y-4 flex-1 min-h-0 overflow-y-auto overscroll-y-none touch-pan-y">
-          {/* Transaction ID */}
-          <PaymentInfoCard>
+          {/* The scroller sits in its own box so a fade can sit over its bottom
+              edge. Without it a cut lands flush against the footer and reads as
+              a clipped card rather than as more content below. */}
+          <div className="relative flex-1 min-h-0 flex flex-col">
+          <div ref={scrollRef} className="space-y-3 flex-1 min-h-0 overflow-y-auto overscroll-y-none touch-pan-y">
+          {/* Which transfer this is, before anything priced about it. */}
+          <PaymentInfoCard compact>
             <CollapsibleCodeField
               label="Transaction ID"
               value={deposit.txid}
@@ -426,6 +552,7 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
               href={explorerTxUrl(deposit.txid)}
             />
           </PaymentInfoCard>
+
 
           {/* Show fee breakdown only when we have a required fee from claim error */}
           {!claimError && requiredFeeSats !== null && (
@@ -456,53 +583,67 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
           {/* Confirming or pending automatic claim */}
           {!claimError && requiredFeeSats === null && (
             <>
+              {/* Both speeds, named, in one group. Waiting takes no action, but
+                  it is what the deposit does, and leaving it unnamed left the
+                  paid route as the only thing on screen with a name. */}
+              {offer && quote && (
+                <div id={INSTANT_OFFER_ID} data-testid="delivery-speed" className="space-y-2">
+                  <span className="block text-sm text-spark-text-secondary">Speed</span>
+                  <div role="radiogroup" aria-label="Speed" className="space-y-2">
+                    <SpeedOption
+                      label="Standard delivery"
+                      detail={matureWait ?? 'Claimed automatically'}
+                      feeSats={quote.mature.feeSats}
+                      isEstimate={quote.mature.isEstimate}
+                      selected={!chosenIsEarly}
+                      onSelect={() => chooseSpeed(false)}
+                    />
+                    <SpeedOption
+                      label="Instant delivery"
+                      detail={offer.locked
+                        ? `Unlocks in ${formatWait(blocksToWait(offer.option, confirmations))}`
+                        : 'Arrives in seconds'}
+                      feeSats={offer.option.feeSats}
+                      isEstimate={offer.option.isEstimate}
+                      selected={chosenIsEarly}
+                      locked={offer.locked}
+                      onSelect={() => chooseSpeed(true)}
+                    />
+                  </div>
+                </div>
+              )}
+
               <FeeBreakdownCard
-                items={chosen
+                items={receipt
                   ? [
                       { label: 'Amount', value: depositAmount },
-                      // Same estimate caveat as the option cards above: an
-                      // unpriced maturity fee is marked, not presented as firm.
-                      { label: chosenIsEarly ? 'Priority fee' : 'Network fee', value: chosen.feeSats, prefix: chosen.isEstimate ? '~' : undefined },
+                      { label: 'Delivery fee', value: receipt.feeSats, emphasis: true },
+                      { label: 'You receive', value: receipt.creditAmountSats, highlight: true },
+                    ]
+                  : chosen
+                  ? [
+                      { label: 'Amount', value: depositAmount },
+                      // Same estimate caveat as the row above: an unpriced
+                      // maturity fee is marked, not presented as firm.
+                      // The one row the checkbox above changes, so it is lifted
+                      // without taking the accent that marks what lands.
+                      { label: chosenIsEarly ? 'Delivery fee' : 'Network fee', value: chosen.feeSats, prefix: chosen.isEstimate ? '~' : undefined, emphasis: chosenIsEarly },
                       { label: 'You receive', value: chosen.creditAmountSats, highlight: true },
                     ]
                   : [{ label: 'Amount', value: depositAmount, highlight: true }]}
               />
 
-              {/* Both ways of claiming, priced. The pair always renders: with no
-                  early route the provider declined to front this deposit, and
-                  fading that card says so more plainly than dropping it. */}
-              {quote && !isClaimInFlight && (
-                <div className="flex gap-2" role="radiogroup" aria-label="How to claim">
-                  <DeliveryOption
-                    label="Priority"
-                    active={Boolean(early) && preferEarly}
-                    onSelect={() => chooseRoute(true)}
-                    option={early}
-                    wait={early ? formatWait(blocksToWait(early, confirmations)) : null}
-                  />
-                  <DeliveryOption
-                    label="Standard"
-                    active={!early || !preferEarly}
-                    onSelect={() => chooseRoute(false)}
-                    option={quote.mature}
-                    wait={formatWait(blocksToWait(quote.mature, confirmations))}
-                  />
-                </div>
+              {claimFailure && (
+                <p ref={failureRef} className="text-sm text-spark-primary">{claimFailure}</p>
               )}
 
               {statusLine && (
                 <p className="text-spark-text-muted text-sm text-center">{statusLine}</p>
               )}
 
-              {feeRequoted && (
-                /* The figure is in the breakdown and on the cards above, both
-                   already repriced, so this only needs to say what to do. */
-                <AlertCard variant="warning" title="Fee changed">
-                  <p className="text-sm">Claim again to accept the new fee.</p>
-                </AlertCard>
-              )}
-
-              <FormError error={instantError} />
+              {/* Sits under the figures it refers to, which the failed claim
+                  re-quoted: the new fee is already in the row and the breakdown,
+                  so only the one it moved from is still worth naming. */}
             </>
           )}
 
@@ -515,22 +656,36 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
           )}
 
           </div>
+          {moreBelow && (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-t from-spark-surface to-transparent"
+            />
+          )}
+          </div>
 
           <div className="shrink-0 space-y-4 pt-4">
-            {/* Only the early route is the user's to commit. Waiting is claimed
-                automatically at maturity, so a button for it would race the
-                SDK's own claim to do the same thing a moment sooner. A recorded
-                fee means that automatic claim has already run and been refused,
-                so the approve panel below owns the sheet. */}
-            {isConfirming && !isClaimInFlight && chosenIsEarly && chosenReady && requiredFeeSats === null && (
-              <PrimaryButton onClick={handleQuotedClaim} disabled={isProcessing} className="w-full">
+            {/* Only the early route is the user's to commit: waiting is claimed
+                at maturity by the SDK, so the button is inert under Standard
+                rather than absent, which would leave the group deciding
+                nothing. A recorded fee means that automatic claim has already
+                run and been refused, so the approve panel below owns the sheet. */}
+            {isConfirming && !isClaimInFlight && offer !== null && requiredFeeSats === null && !claimError && (
+              // Described by the group rather than labelled with a price, so the
+              // label stays the plain action and a screen reader still hears it.
+              <PrimaryButton
+                onClick={handleQuotedClaim}
+                disabled={isProcessing || !chosenIsEarly}
+                aria-describedby={INSTANT_OFFER_ID}
+                className="w-full"
+              >
                 {isProcessing ? (
                   <span className="flex items-center justify-center gap-2">
                     <SpinnerIcon size="md" />
                     Processing...
                   </span>
                 ) : (
-                  'Claim now'
+                  'Claim Now'
                 )}
               </PrimaryButton>
             )}

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -70,7 +70,13 @@ const WalletPage: React.FC<WalletPageProps> = ({
   const [isQrScannerOpen, setIsQrScannerOpen] = useState(false);
   const [scannerOpenedFromSend, setScannerOpenedFromSend] = useState(false);
   const [selectedPayment, setSelectedPayment] = useState<Payment | null>(null);
-  const [selectedDeposit, setSelectedDeposit] = useState<DepositInfo | null>(null);
+  // The outpoint, not the record: held as a copy the deposit's maturity, fee
+  // error and claim status all freeze at tap time, and the sheet spends its
+  // life offering routes for a state the deposit has already left.
+  const [selectedOutpoint, setSelectedOutpoint] = useState<string | null>(null);
+  const selectedDeposit = selectedOutpoint
+    ? unclaimedDeposits.find(d => `${d.txid}:${d.vout}` === selectedOutpoint) ?? null
+    : null;
   const [paymentInput, setPaymentInput] = useState<string | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isBuyBitcoinOpen, setIsBuyBitcoinOpen] = useState(false);
@@ -127,14 +133,14 @@ const WalletPage: React.FC<WalletPageProps> = ({
       setIsSendDialogOpen(false);
       setIsReceiveDialogOpen(false);
       setSelectedPayment(null);
-      setSelectedDeposit(null);
+      setSelectedOutpoint(null);
       return;
     }
 
     // Check if this is an unclaimed deposit
     if (isUnclaimedDepositPayment(payment) && payment.depositInfo) {
       // Open deposit details dialog
-      setSelectedDeposit(payment.depositInfo);
+      setSelectedOutpoint(`${payment.depositInfo.txid}:${payment.depositInfo.vout}`);
     } else {
       // Open regular payment details
       setSelectedPayment(payment);
@@ -146,11 +152,11 @@ const WalletPage: React.FC<WalletPageProps> = ({
   }, []);
 
   const handleDepositDetailsClose = useCallback(() => {
-    setSelectedDeposit(null);
+    setSelectedOutpoint(null);
   }, []);
 
   const handleDepositChanged = useCallback(async () => {
-    setSelectedDeposit(null);
+    setSelectedOutpoint(null);
     onDepositChanged?.();
     await refreshWalletData(false);
   }, [onDepositChanged, refreshWalletData]);

--- a/src/services/depositState.ts
+++ b/src/services/depositState.ts
@@ -78,3 +78,79 @@ export function clearRejectedDeposits(): void {
   localStorage.removeItem(REJECTED_DEPOSITS_KEY);
   cachedDeposits = [];
 }
+
+// ---------------------------------------------------------------------------
+// Submitted claim receipts
+// ---------------------------------------------------------------------------
+
+/**
+ * What an early claim was priced at when it was sent. The SDK reports a
+ * submitted claim as `{ type: 'submitted', claimId }` and keeps no fee on the
+ * deposit, so once the sheet is reopened mid-settlement the figure the user
+ * agreed to is unrecoverable. A fresh quote is a different number, not that one.
+ */
+const CLAIM_FEES_KEY = 'deposit_claim_fees_v1';
+
+export interface ClaimReceipt {
+  feeSats: number;
+  creditAmountSats: number;
+  claimedAt: number;
+}
+
+/** A settled claim leaves nothing behind to clear its receipt, so they age out. */
+const RECEIPT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const outpoint = (txid: string, vout: number) => `${txid}:${vout}`;
+
+let cachedReceipts: Record<string, ClaimReceipt> | null = null;
+
+function getReceipts(): Record<string, ClaimReceipt> {
+  if (cachedReceipts !== null) return cachedReceipts;
+  let loaded: Record<string, ClaimReceipt> = {};
+  try {
+    const raw = localStorage.getItem(CLAIM_FEES_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) loaded = parsed;
+  } catch {
+    loaded = {};
+  }
+  cachedReceipts = loaded;
+  return loaded;
+}
+
+function writeReceipts(next: Record<string, ClaimReceipt>): void {
+  localStorage.setItem(CLAIM_FEES_KEY, JSON.stringify(next));
+  cachedReceipts = next;
+}
+
+/** Records what a claim was priced at, and drops any that have aged out. */
+export function rememberClaimFee(
+  txid: string,
+  vout: number,
+  receipt: Omit<ClaimReceipt, 'claimedAt'>,
+): void {
+  const now = Date.now();
+  const kept = Object.fromEntries(
+    Object.entries(getReceipts()).filter(([, r]) => now - r.claimedAt < RECEIPT_TTL_MS),
+  );
+  kept[outpoint(txid, vout)] = { ...receipt, claimedAt: now };
+  writeReceipts(kept);
+}
+
+export function readClaimFee(txid: string, vout: number): ClaimReceipt | null {
+  const found = getReceipts()[outpoint(txid, vout)];
+  if (!found) return null;
+  return Date.now() - found.claimedAt < RECEIPT_TTL_MS ? found : null;
+}
+
+export function forgetClaimFee(txid: string, vout: number): void {
+  const next = { ...getReceipts() };
+  delete next[outpoint(txid, vout)];
+  writeReceipts(next);
+}
+
+/** Wipe all receipts. Used on logout: they are wallet-specific. */
+export function clearClaimFees(): void {
+  localStorage.removeItem(CLAIM_FEES_KEY);
+  cachedReceipts = {};
+}

--- a/src/utils/depositClaimQuote.test.ts
+++ b/src/utils/depositClaimQuote.test.ts
@@ -21,8 +21,8 @@ beforeEach(() => forgetAnnouncedClaims());
 const option = (confirmationsRequired: number, feeSats = 100): ClaimDepositQuote =>
   ({ confirmationsRequired, feeSats, creditAmountSats: 1_000 - feeSats, isEstimate: false }) as ClaimDepositQuote;
 
-const quoteOf = (instant: ClaimDepositQuote | null, mature: ClaimDepositQuote) =>
-  ({ instant: instant ?? undefined, mature, confirmations: 0 }) as FetchClaimDepositQuoteResponse;
+const quoteOf = (instant: ClaimDepositQuote | null, mature: ClaimDepositQuote, confirmations = 0) =>
+  ({ instant: instant ?? undefined, mature, confirmations }) as FetchClaimDepositQuoteResponse;
 
 const deposit = (submitted: boolean): DepositInfo => ({
   txid: 'a'.repeat(64),
@@ -78,18 +78,17 @@ describe('formatWait', () => {
     expect(formatWait(-1)).toBeNull();
   });
 
-  it('stays in minutes below the hour', () => {
-    expect(formatWait(1)).toBe('~10 min');
-    expect(formatWait(5)).toBe('~50 min');
+  it('counts blocks, singular and plural, and glosses each in minutes', () => {
+    expect(formatWait(1)).toBe('1 confirmation (~10 mins)');
+    expect(formatWait(2)).toBe('2 confirmations (~20 mins)');
   });
 
-  it('switches to hours at the hour, dropping the decimal when it is whole', () => {
-    expect(formatWait(6)).toBe('~1 hr');
-    expect(formatWait(12)).toBe('~2 hr');
-  });
-
-  it('keeps one decimal for a part hour', () => {
-    expect(formatWait(7)).toBe('~1.2 hr');
+  // The count leads because it is the exact part. Minutes on their own would
+  // read as a countdown that never counts down: block arrival is memoryless, so
+  // twenty minutes into a two-block wait the expectation is still two blocks.
+  it('leads with the count and keeps the time approximate', () => {
+    expect(formatWait(3)).toMatch(/^3 confirmations \(~/);
+    expect(formatWait(3)).toContain('~30 mins');
   });
 });
 
@@ -109,21 +108,31 @@ describe('earlyOption', () => {
   it('is offered when it genuinely arrives first', () => {
     expect(earlyOption(quoteOf(option(0), option(3)))).toMatchObject({ confirmationsRequired: 0 });
   });
+
+  // Paying the spread at maturity depth buys one sync cycle at many times the
+  // fee the SDK is about to pay on its own.
+  it('is withdrawn once the automatic claim is already due', () => {
+    expect(earlyOption(quoteOf(option(1), option(3), 3))).toBeNull();
+  });
 });
 
 describe('selectOption', () => {
   it('resolves to nothing without a quote', () => {
-    expect(selectOption(null, true)).toBeNull();
+    expect(selectOption(null)).toBeNull();
   });
 
-  it('follows the preference when both routes are real', () => {
-    const q = quoteOf(option(0, 500), option(3, 100));
-    expect(selectOption(q, true)).toMatchObject({ feeSats: 500 });
-    expect(selectOption(q, false)).toMatchObject({ feeSats: 100 });
+  it('prices the early route once it can actually be claimed', () => {
+    expect(selectOption(quoteOf(option(0, 500), option(3, 100)))).toMatchObject({ feeSats: 500 });
   });
 
-  it('falls back to waiting when early is preferred but not on offer', () => {
-    expect(selectOption(quoteOf(null, option(3, 100)), true)).toMatchObject({ feeSats: 100 });
+  // Priced before it unlocks, the early route would headline the proceeds of a
+  // purchase the user cannot make, against a wait that is what will happen.
+  it('prices the wait while the early route is still locked', () => {
+    expect(selectOption(quoteOf(option(2, 500), option(3, 100)))).toMatchObject({ feeSats: 100 });
+  });
+
+  it('prices the wait when no early route is on offer', () => {
+    expect(selectOption(quoteOf(null, option(3, 100)))).toMatchObject({ feeSats: 100 });
   });
 });
 

--- a/src/utils/depositClaimQuote.ts
+++ b/src/utils/depositClaimQuote.ts
@@ -1,8 +1,5 @@
 import type { ClaimDepositQuote, DepositInfo, FetchClaimDepositQuoteResponse, InstantClaimStatus } from '@breeztech/breez-sdk-spark';
 
-/** Rough block interval, for turning a confirmation depth into a wait. */
-const MINUTES_PER_BLOCK = 10;
-
 /**
  * Copy for a submitted early claim. Shared because the SDK raises no event for a
  * manual claim, so the sheet announces that one itself while background sync
@@ -33,13 +30,20 @@ export function isClaimable(option: ClaimDepositQuote, confirmations: number): b
   return blocksToWait(option, confirmations) === 0;
 }
 
-/** Approximate wait for `blocks`, or null when there is nothing left to wait for. */
+/** Rough block interval, for glossing a confirmation count in minutes. */
+const MINUTES_PER_BLOCK = 10;
+
+/**
+ * A wait led by its confirmation count, with the time in parentheses. The count
+ * is exact and drops each time a block lands; the minutes only say what a
+ * confirmation costs. Leading with minutes would read as a countdown that never
+ * counts down, since block arrival is memoryless: twenty minutes into a
+ * two-block wait the expectation is still two blocks, not one minute.
+ */
 export function formatWait(blocks: number): string | null {
   if (blocks <= 0) return null;
-  const minutes = blocks * MINUTES_PER_BLOCK;
-  if (minutes < 60) return `~${minutes} min`;
-  const hours = minutes / 60;
-  return `~${Number.isInteger(hours) ? hours : hours.toFixed(1)} hr`;
+  const plural = blocks === 1 ? '' : 's';
+  return `${blocks} confirmation${plural} (~${blocks * MINUTES_PER_BLOCK} mins)`;
 }
 
 /**
@@ -51,20 +55,21 @@ export function earlyOption(quote: FetchClaimDepositQuoteResponse | null): Claim
   if (!quote?.instant) return null;
   // No point offering a route that unlocks no sooner than simply waiting.
   if (quote.instant.confirmationsRequired >= quote.mature.confirmationsRequired) return null;
+  // Nothing left to skip once the automatic claim is due: the spread would buy
+  // one sync cycle at many times the fee the SDK is about to pay anyway.
+  if (blocksToWait(quote.mature, quote.confirmations) === 0) return null;
   return quote.instant;
 }
 
 /**
- * The option a preference resolves to. Shared so a re-quote can be compared
- * against the same selection the user made, not just against `instant`.
+ * The option the sheet prices. The early route only once it can actually be
+ * claimed: priced before then it would headline the proceeds of a purchase the
+ * user cannot make, against a wait that is what will really happen.
  */
-export function selectOption(
-  quote: FetchClaimDepositQuoteResponse | null,
-  preferEarly: boolean,
-): ClaimDepositQuote | null {
+export function selectOption(quote: FetchClaimDepositQuoteResponse | null): ClaimDepositQuote | null {
   if (!quote) return null;
   const early = earlyOption(quote);
-  return early && preferEarly ? early : quote.mature;
+  return early && isClaimable(early, quote.confirmations) ? early : quote.mature;
 }
 
 /** True while a claim is in flight, during which the SDK refuses a second one. */


### PR DESCRIPTION
This PR polishes the transfer claim sheet from #388.

Previously, the sheet preselected the priority route, and the total showed a fee the user hadn’t agreed to. **Standard** is now selected by default, and the **Claim Now** button stays disabled until the user explicitly selects the priority route.

It also fixes several edge cases:
- Reopening a claim now shows the agreed price.
- Fees above the automatic claim limit now show a persistent warning until the claim is refused.
- Updated pricing and confirmation states when provider requirements change.
- Fixed stale transfer data being used after the sheet was opened.
- Fixed the claim action appearing again below failure messages.

**Note:** The feature remains gated behind developer mode until QA verification