### PR TITLE
fix: hide self-recovering exit errors and ask for the missing exit fee

### DIFF
--- a/src/features/unilateral-exit/TrackerView.test.tsx
+++ b/src/features/unilateral-exit/TrackerView.test.tsx
@@ -118,11 +118,33 @@ describe('what the exit is worth right now', () => {
 });
 
 describe('TrackerView', () => {
-  it('offers a rebuild when the chain no longer matches the exit', () => {
+  it('continues a diverged exit in place, without the wizard', () => {
     const onRebuild = vi.fn();
-    renderTracker(plan([tx({ txid: 'a' })], { phase: 'redo' }), 1000, onRebuild);
+    const onContinue = vi.fn();
+    render(
+      <TrackerView plan={plan([tx({ txid: 'a' })], { phase: 'redo' })} tipHeight={1000} isAdvancing={false} onRebuild={onRebuild} onContinue={onContinue} />,
+    );
     expect(screen.getByText('Rebuild to keep going')).toBeInTheDocument();
-    screen.getByTestId('unilateral-exit-rebuild').click();
+    fireEvent.click(screen.getByTestId('unilateral-exit-rebuild'));
+    expect(onContinue).toHaveBeenCalled();
+    expect(onRebuild).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('unilateral-exit-rebuild-wizard')).not.toBeInTheDocument();
+  });
+
+  it('offers the wizard when continuing in place fails', () => {
+    const onRebuild = vi.fn();
+    render(
+      <TrackerView
+        plan={plan([tx({ txid: 'a' })], { phase: 'redo' })}
+        tipHeight={1000}
+        isAdvancing={false}
+        onRebuild={onRebuild}
+        onContinue={vi.fn()}
+        continueError="Insufficient CPFP funding: need at least 5000 sats"
+      />,
+    );
+    expect(screen.getByTestId('unilateral-exit-continue-error')).toHaveTextContent('need at least 5000 sats');
+    fireEvent.click(screen.getByTestId('unilateral-exit-rebuild-wizard'));
     expect(onRebuild).toHaveBeenCalled();
   });
 

--- a/src/features/unilateral-exit/TrackerView.test.tsx
+++ b/src/features/unilateral-exit/TrackerView.test.tsx
@@ -165,11 +165,6 @@ describe('TrackerView', () => {
     expect(screen.queryByTestId('unilateral-exit-bump-fee')).not.toBeInTheDocument();
   });
 
-  it('says so when it cannot reach the chain to check on the exit', () => {
-    renderTracker(plan([tx({ txid: 'a' })], { lastCheckError: 'esplora down' }));
-    expect(screen.getByText('Cannot read the exit right now')).toBeInTheDocument();
-  });
-
   it('keeps an off-device copy reachable, since only this device holds what an exit needs', () => {
     renderTracker(plan([tx({ txid: 'a' })]));
     expect(screen.queryByTestId('unilateral-exit-backup-save')).not.toBeInTheDocument();

--- a/src/features/unilateral-exit/TrackerView.test.tsx
+++ b/src/features/unilateral-exit/TrackerView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { TrackerView } from './TrackerView';
 
 // The backup card reads the connected wallet; the tracker itself works off the
@@ -143,6 +143,8 @@ describe('TrackerView', () => {
         continueError="Insufficient CPFP funding: need at least 5000 sats"
       />,
     );
+    expect(screen.getByText('Glow could not continue the exit.')).toBeInTheDocument();
+    fireEvent.click(within(screen.getByTestId('unilateral-exit-continue-error')).getByText('Details'));
     expect(screen.getByTestId('unilateral-exit-continue-error')).toHaveTextContent('need at least 5000 sats');
     fireEvent.click(screen.getByTestId('unilateral-exit-rebuild-wizard'));
     expect(onRebuild).toHaveBeenCalled();
@@ -169,6 +171,9 @@ describe('TrackerView', () => {
     expect(screen.getByText('Fee too low')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('unilateral-exit-refusal-rebuild'));
     expect(onRebuild).toHaveBeenCalled();
+    expect(screen.queryByText(/mempool min fee not met/)).not.toBeInTheDocument();
+    fireEvent.click(within(screen.getByTestId('unilateral-exit-fee-refusal')).getByText('Details'));
+    expect(screen.getByTestId('unilateral-exit-fee-refusal')).toHaveTextContent('mempool min fee not met');
   });
 
   it('asks only for patience once the fee coins are fixed, since more money cannot help', () => {
@@ -195,6 +200,9 @@ describe('TrackerView', () => {
   it('shows any other refusal as the node gave it, since nothing else will', () => {
     renderTracker(plan([tx({ txid: 'a' })], { refusals: { a: 'non-BIP68-final' } }));
     expect(screen.getByText('The network refused a step')).toBeInTheDocument();
+    // Folded away until asked for.
+    expect(screen.queryByText('non-BIP68-final')).not.toBeInTheDocument();
+    fireEvent.click(within(screen.getByTestId('unilateral-exit-refusal')).getByText('Details'));
     expect(screen.getByTestId('unilateral-exit-refusal')).toHaveTextContent('non-BIP68-final');
   });
 

--- a/src/features/unilateral-exit/TrackerView.test.tsx
+++ b/src/features/unilateral-exit/TrackerView.test.tsx
@@ -113,7 +113,7 @@ describe('what the exit is worth right now', () => {
 
   it('says it is rebuilding rather than moving when the chain diverged', () => {
     renderTracker(plan([tx({ txid: 'a' })], { phase: 'redo' }));
-    expect(screen.getByText('This exit needs rebuilding')).toBeInTheDocument();
+    expect(screen.getByText('Paused')).toBeInTheDocument();
   });
 });
 
@@ -124,7 +124,7 @@ describe('TrackerView', () => {
     render(
       <TrackerView plan={plan([tx({ txid: 'a' })], { phase: 'redo' })} tipHeight={1000} isAdvancing={false} onRebuild={onRebuild} onContinue={onContinue} />,
     );
-    expect(screen.getByText('Rebuild to keep going')).toBeInTheDocument();
+    expect(screen.getByText('Your exit needs an update')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('unilateral-exit-rebuild'));
     expect(onContinue).toHaveBeenCalled();
     expect(onRebuild).not.toHaveBeenCalled();

--- a/src/features/unilateral-exit/TrackerView.test.tsx
+++ b/src/features/unilateral-exit/TrackerView.test.tsx
@@ -166,7 +166,7 @@ describe('TrackerView', () => {
   it('offers a rebuild when fees went up and the exit fee address can still pay more', () => {
     const onRebuild = vi.fn();
     renderTracker(plan([tx({ txid: 'a' })], { refusals: { a: 'mempool min fee not met, 120 < 250' } }), 1000, onRebuild);
-    expect(screen.getByText('Fees went up')).toBeInTheDocument();
+    expect(screen.getByText('Fee too low')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('unilateral-exit-refusal-rebuild'));
     expect(onRebuild).toHaveBeenCalled();
   });
@@ -178,7 +178,7 @@ describe('TrackerView', () => {
         { refusals: { a: 'mempool min fee not met, 120 < 250' } },
       ),
     );
-    expect(screen.getByText('Fees went up')).toBeInTheDocument();
+    expect(screen.getByText('Fee too low')).toBeInTheDocument();
     expect(screen.queryByTestId('unilateral-exit-refusal-rebuild')).not.toBeInTheDocument();
   });
 
@@ -188,7 +188,7 @@ describe('TrackerView', () => {
         refusals: { a: 'min relay fee not met, 0 < 13; bad-txns-inputs-missingorspent' },
       }),
     );
-    expect(screen.queryByText('Fees went up')).not.toBeInTheDocument();
+    expect(screen.queryByText('Fee too low')).not.toBeInTheDocument();
     expect(screen.queryByText('The network refused a step')).not.toBeInTheDocument();
   });
 

--- a/src/features/unilateral-exit/TrackerView.test.tsx
+++ b/src/features/unilateral-exit/TrackerView.test.tsx
@@ -165,52 +165,6 @@ describe('TrackerView', () => {
     expect(screen.queryByTestId('unilateral-exit-bump-fee')).not.toBeInTheDocument();
   });
 
-  it('offers a rebuild when fees went up and the exit fee address can still pay more', () => {
-    const onRebuild = vi.fn();
-    renderTracker(plan([tx({ txid: 'a' })], { refusals: { a: 'mempool min fee not met, 120 < 250' } }), 1000, onRebuild);
-    expect(screen.getByText('Fee too low')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('unilateral-exit-refusal-rebuild'));
-    expect(onRebuild).toHaveBeenCalled();
-    expect(screen.queryByText(/mempool min fee not met/)).not.toBeInTheDocument();
-    fireEvent.click(within(screen.getByTestId('unilateral-exit-fee-refusal')).getByText('Details'));
-    expect(screen.getByTestId('unilateral-exit-fee-refusal')).toHaveTextContent('mempool min fee not met');
-  });
-
-  it('asks only for patience once the fee coins are fixed, since more money cannot help', () => {
-    renderTracker(
-      plan(
-        [tx({ txid: 'f', kind: 'fanOut', status: confirmed(10) }), tx({ txid: 'a' })],
-        { refusals: { a: 'mempool min fee not met, 120 < 250' } },
-      ),
-    );
-    expect(screen.getByText('Fee too low')).toBeInTheDocument();
-    expect(screen.queryByTestId('unilateral-exit-refusal-rebuild')).not.toBeInTheDocument();
-  });
-
-  it('says nothing about a step another copy already settled', () => {
-    renderTracker(
-      plan([tx({ txid: 'a', kind: 'refund' })], {
-        refusals: { a: 'min relay fee not met, 0 < 13; bad-txns-inputs-missingorspent' },
-      }),
-    );
-    expect(screen.queryByText('Fee too low')).not.toBeInTheDocument();
-    expect(screen.queryByText('The network refused a step')).not.toBeInTheDocument();
-  });
-
-  it('shows any other refusal as the node gave it, since nothing else will', () => {
-    renderTracker(plan([tx({ txid: 'a' })], { refusals: { a: 'non-BIP68-final' } }));
-    expect(screen.getByText('The network refused a step')).toBeInTheDocument();
-    // Folded away until asked for.
-    expect(screen.queryByText('non-BIP68-final')).not.toBeInTheDocument();
-    fireEvent.click(within(screen.getByTestId('unilateral-exit-refusal')).getByText('Details'));
-    expect(screen.getByTestId('unilateral-exit-refusal')).toHaveTextContent('non-BIP68-final');
-  });
-
-  it('drops the refusal once the exit is being rebuilt anyway', () => {
-    renderTracker(plan([tx({ txid: 'a' })], { phase: 'redo', refusals: { a: 'non-BIP68-final' } }));
-    expect(screen.queryByText('The network refused a step')).not.toBeInTheDocument();
-  });
-
   it('says so when it cannot reach the chain to check on the exit', () => {
     renderTracker(plan([tx({ txid: 'a' })], { lastCheckError: 'esplora down' }));
     expect(screen.getByText('Cannot read the exit right now')).toBeInTheDocument();

--- a/src/features/unilateral-exit/TrackerView.test.tsx
+++ b/src/features/unilateral-exit/TrackerView.test.tsx
@@ -141,14 +141,43 @@ describe('TrackerView', () => {
     expect(screen.queryByTestId('unilateral-exit-bump-fee')).not.toBeInTheDocument();
   });
 
-  it('shows why the network refused a step, since nothing else will', () => {
-    renderTracker(plan([tx({ txid: 'a' })], { refusals: { a: 'min relay fee not met, 0 < 110' } }));
+  it('offers a rebuild when fees went up and the exit fee address can still pay more', () => {
+    const onRebuild = vi.fn();
+    renderTracker(plan([tx({ txid: 'a' })], { refusals: { a: 'mempool min fee not met, 120 < 250' } }), 1000, onRebuild);
+    expect(screen.getByText('Fees went up')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('unilateral-exit-refusal-rebuild'));
+    expect(onRebuild).toHaveBeenCalled();
+  });
+
+  it('asks only for patience once the fee coins are fixed, since more money cannot help', () => {
+    renderTracker(
+      plan(
+        [tx({ txid: 'f', kind: 'fanOut', status: confirmed(10) }), tx({ txid: 'a' })],
+        { refusals: { a: 'mempool min fee not met, 120 < 250' } },
+      ),
+    );
+    expect(screen.getByText('Fees went up')).toBeInTheDocument();
+    expect(screen.queryByTestId('unilateral-exit-refusal-rebuild')).not.toBeInTheDocument();
+  });
+
+  it('says nothing about a step another copy already settled', () => {
+    renderTracker(
+      plan([tx({ txid: 'a', kind: 'refund' })], {
+        refusals: { a: 'min relay fee not met, 0 < 13; bad-txns-inputs-missingorspent' },
+      }),
+    );
+    expect(screen.queryByText('Fees went up')).not.toBeInTheDocument();
+    expect(screen.queryByText('The network refused a step')).not.toBeInTheDocument();
+  });
+
+  it('shows any other refusal as the node gave it, since nothing else will', () => {
+    renderTracker(plan([tx({ txid: 'a' })], { refusals: { a: 'non-BIP68-final' } }));
     expect(screen.getByText('The network refused a step')).toBeInTheDocument();
-    expect(screen.getByTestId('unilateral-exit-refusal')).toHaveTextContent('min relay fee not met');
+    expect(screen.getByTestId('unilateral-exit-refusal')).toHaveTextContent('non-BIP68-final');
   });
 
   it('drops the refusal once the exit is being rebuilt anyway', () => {
-    renderTracker(plan([tx({ txid: 'a' })], { phase: 'redo', refusals: { a: 'txn-mempool-conflict' } }));
+    renderTracker(plan([tx({ txid: 'a' })], { phase: 'redo', refusals: { a: 'non-BIP68-final' } }));
     expect(screen.queryByText('The network refused a step')).not.toBeInTheDocument();
   });
 

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -4,7 +4,7 @@ import { AlertCard } from '@/components/AlertCard';
 import { SatAmount } from '@/components/SatAmount';
 import { CollapsibleSection, PrimaryButton } from '@/components/ui';
 import { RefreshIcon } from '@/components/Icons';
-import { blocksToFinish, exitStages, nextAction, planProgress } from './driver';
+import { blocksToFinish, exitStages, hasFixedFeeBudget, nextAction, planProgress, refusalKind } from './driver';
 import type { NextAction, PlanProgress, UnilateralExitPlan } from './driver';
 import { formatDaysLeft } from '@/utils/blockTime';
 import { formatWithSpaces } from '@/utils/formatNumber';
@@ -120,7 +120,9 @@ export const TrackerView: React.FC<{
   const { transactions } = plan.exit;
   const [advanced, setAdvanced] = useState(false);
   const progress = useMemo(() => planProgress(plan), [plan]);
-  const refusal = Object.values(plan.refusals)[0];
+  const refusals = Object.values(plan.refusals);
+  const feeRefused = refusals.some(reason => refusalKind(reason) === 'fee');
+  const otherRefusal = refusals.find(reason => refusalKind(reason) === 'other');
   const next = useMemo(
     () => (tipHeight === null ? null : nextAction(transactions, tipHeight)),
     [transactions, tipHeight],
@@ -140,15 +142,36 @@ export const TrackerView: React.FC<{
         isAdvancing={isAdvancing}
       />
 
-      {plan.phase === 'active' && refusal && (
+      {/* A step another copy already settled shows nothing: the next check adopts it. */}
+      {plan.phase === 'active' && feeRefused && (
+        <AlertCard variant="warning" title="Fees went up">
+          {hasFixedFeeBudget(plan) ? (
+            <p className="text-sm">
+              A step&apos;s fee is now too low for the network. Glow keeps retrying, and the step
+              goes through once network fees come down.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm">
+                A step&apos;s fee is now too low for the network. Rebuild the exit at a higher fee to
+                keep it moving.
+              </p>
+              <div className="mt-3">
+                <PrimaryButton onClick={onRebuild} className="w-full" data-testid="unilateral-exit-refusal-rebuild">
+                  Rebuild at a Higher Fee
+                </PrimaryButton>
+              </div>
+            </>
+          )}
+        </AlertCard>
+      )}
+
+      {plan.phase === 'active' && !feeRefused && otherRefusal && (
         <AlertCard variant="warning" title="The network refused a step">
           <p className="text-xs font-mono break-all" data-testid="unilateral-exit-refusal">
-            {refusal}
+            {otherRefusal}
           </p>
-          <p className="text-sm mt-2">
-            Glow keeps retrying, and another copy of the step may confirm instead. If this
-            persists, rebuild the exit at a higher fee.
-          </p>
+          <p className="text-sm mt-2">Glow keeps retrying.</p>
         </AlertCard>
       )}
 

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { BackupActions, ExitActionRow } from './BackupCard';
 import { AlertCard } from '@/components/AlertCard';
 import { SatAmount } from '@/components/SatAmount';
-import { CollapsibleSection, PrimaryButton } from '@/components/ui';
+import { CollapsibleSection, PrimaryButton, SecondaryButton } from '@/components/ui';
 import { RefreshIcon } from '@/components/Icons';
 import { blocksToFinish, exitStages, hasFixedFeeBudget, nextAction, planProgress, refusalKind } from './driver';
 import type { NextAction, PlanProgress, UnilateralExitPlan } from './driver';
@@ -115,8 +115,13 @@ export const TrackerView: React.FC<{
   plan: UnilateralExitPlan;
   tipHeight: number | null;
   isAdvancing: boolean;
+  /** Opens the wizard, for a new fee rate. */
   onRebuild: () => void;
-}> = ({ plan, tipHeight, isAdvancing, onRebuild }) => {
+  /** Rebuilds a diverged exit in place, at its own fee rate. */
+  onContinue?: () => void;
+  isContinuing?: boolean;
+  continueError?: string | null;
+}> = ({ plan, tipHeight, isAdvancing, onRebuild, onContinue, isContinuing = false, continueError = null }) => {
   const { transactions } = plan.exit;
   const [advanced, setAdvanced] = useState(false);
   const progress = useMemo(() => planProgress(plan), [plan]);
@@ -181,10 +186,26 @@ export const TrackerView: React.FC<{
             The blockchain no longer matches the transactions saved here. Your money is safe:
             it is still in the tree, or already in an output you control.
           </p>
-          <div className="mt-3">
-            <PrimaryButton onClick={onRebuild} className="w-full" data-testid="unilateral-exit-rebuild">
-              Rebuild the Exit
+          {continueError && (
+            <p className="text-sm mt-2" data-testid="unilateral-exit-continue-error">
+              {continueError}
+            </p>
+          )}
+          <div className="mt-3 space-y-2">
+            <PrimaryButton
+              onClick={onContinue ?? onRebuild}
+              disabled={isContinuing}
+              className="w-full"
+              data-testid="unilateral-exit-rebuild"
+            >
+              {isContinuing ? 'Rebuilding...' : 'Continue Exit'}
             </PrimaryButton>
+            {/* When the exit's own fee rate no longer works, the wizard can pick another. */}
+            {continueError && (
+              <SecondaryButton onClick={onRebuild} className="w-full" data-testid="unilateral-exit-rebuild-wizard">
+                Choose a Different Fee
+              </SecondaryButton>
+            )}
           </div>
         </AlertCard>
       )}

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -185,15 +185,6 @@ export const TrackerView: React.FC<{
         </AlertCard>
       )}
 
-      {plan.lastCheckError && (
-        <AlertCard variant="warning" title="Cannot read the exit right now">
-          <p className="text-sm">
-            Glow could not reach the blockchain to check on this exit, so what you see may be out
-            of date. It keeps trying.
-          </p>
-        </AlertCard>
-      )}
-
       <CollapsibleSection
         label="Advanced"
         isVisible={advanced}

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -75,7 +75,7 @@ const ExitSummary: React.FC<{
       ? 'Waiting for confirmations'
       : next.blocks > 0
         ? 'Waiting for timelock'
-        : `Sending ${next.transactions === 1 ? 'the next step' : `${next.transactions} steps`}`;
+        : `Sending ${next.transactions === 1 ? 'a transaction' : `${next.transactions} transactions`}`;
 
   return (
     <div className="space-y-6">
@@ -157,8 +157,8 @@ export const TrackerView: React.FC<{
       {plan.phase === 'redo' && (
         <AlertCard variant="warning" title="Your exit needs an update">
           <p className="text-sm">
-            Part of your exit already went through on the network, so the remaining steps need
-            updating. Your money is safe.
+            Part of your exit already went through, so the remaining transactions need an update.
+            Your money is safe.
           </p>
           {continueError && (
             <>

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -71,7 +71,7 @@ const ExitSummary: React.FC<{
     <div className="space-y-6">
       <div className="text-center py-4">
         <p className="text-spark-text-muted text-sm mb-2">
-          {plan.phase === 'redo' ? 'This exit needs rebuilding' : 'Processing'}
+          {plan.phase === 'redo' ? 'Paused' : 'Processing'}
         </p>
         <SatAmount
           sats={stages.willReceive}
@@ -181,9 +181,10 @@ export const TrackerView: React.FC<{
       )}
 
       {plan.phase === 'redo' && (
-        <AlertCard variant="warning" title="Rebuild to keep going">
+        <AlertCard variant="warning" title="Your exit needs an update">
           <p className="text-sm">
-            Some steps went through another way. Your money is safe.
+            Part of your exit already went through on the network, so the remaining steps need
+            updating. Your money is safe.
           </p>
           {continueError && (
             <p className="text-sm mt-2" data-testid="unilateral-exit-continue-error">

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -149,17 +149,17 @@ export const TrackerView: React.FC<{
 
       {/* A step another copy already settled shows nothing: the next check adopts it. */}
       {plan.phase === 'active' && feeRefused && (
-        <AlertCard variant="warning" title="Fees went up">
+        <AlertCard variant="warning" title="Fee too low">
           {hasFixedFeeBudget(plan) ? (
             <p className="text-sm">
-              A step&apos;s fee is now too low for the network. Glow keeps retrying, and the step
-              goes through once network fees come down.
+              A step&apos;s fee is below the minimum the network accepts right now. Glow keeps
+              retrying, and the step goes through once the network accepts its fee.
             </p>
           ) : (
             <>
               <p className="text-sm">
-                A step&apos;s fee is now too low for the network. Rebuild the exit at a higher fee to
-                keep it moving.
+                A step&apos;s fee is below the minimum the network accepts right now. Rebuild the exit
+                at a higher fee to keep it moving.
               </p>
               <div className="mt-3">
                 <PrimaryButton onClick={onRebuild} className="w-full" data-testid="unilateral-exit-refusal-rebuild">

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -4,7 +4,7 @@ import { AlertCard } from '@/components/AlertCard';
 import { SatAmount } from '@/components/SatAmount';
 import { CollapsibleCodeField, CollapsibleSection, PrimaryButton, SecondaryButton } from '@/components/ui';
 import { RefreshIcon } from '@/components/Icons';
-import { blocksToFinish, exitStages, hasFixedFeeBudget, nextAction, planProgress, refusalKind } from './driver';
+import { blocksToFinish, exitStages, nextAction, planProgress } from './driver';
 import type { NextAction, PlanProgress, UnilateralExitPlan } from './driver';
 import { formatDaysLeft } from '@/utils/blockTime';
 import { formatWithSpaces } from '@/utils/formatNumber';
@@ -135,10 +135,6 @@ export const TrackerView: React.FC<{
   const { transactions } = plan.exit;
   const [advanced, setAdvanced] = useState(false);
   const progress = useMemo(() => planProgress(plan), [plan]);
-  const refusals = Object.values(plan.refusals);
-  const feeRefusal = refusals.find(reason => refusalKind(reason) === 'fee');
-  const feeRefused = feeRefusal !== undefined;
-  const otherRefusal = refusals.find(reason => refusalKind(reason) === 'other');
   const next = useMemo(
     () => (tipHeight === null ? null : nextAction(transactions, tipHeight)),
     [transactions, tipHeight],
@@ -157,38 +153,6 @@ export const TrackerView: React.FC<{
         progress={progress}
         isAdvancing={isAdvancing}
       />
-
-      {/* A step another copy already settled shows nothing: the next check adopts it. */}
-      {plan.phase === 'active' && feeRefused && (
-        <AlertCard variant="warning" title="Fee too low">
-          {hasFixedFeeBudget(plan) ? (
-            <p className="text-sm">
-              A step&apos;s fee is below the minimum the network accepts right now. Glow keeps
-              retrying, and the step goes through once the network accepts its fee.
-            </p>
-          ) : (
-            <>
-              <p className="text-sm">
-                A step&apos;s fee is below the minimum the network accepts right now. Rebuild the exit
-                at a higher fee to keep it moving.
-              </p>
-              <div className="mt-3">
-                <PrimaryButton onClick={onRebuild} className="w-full" data-testid="unilateral-exit-refusal-rebuild">
-                  Rebuild at a Higher Fee
-                </PrimaryButton>
-              </div>
-            </>
-          )}
-          {feeRefusal && <ErrorDetails text={feeRefusal} testId="unilateral-exit-fee-refusal" />}
-        </AlertCard>
-      )}
-
-      {plan.phase === 'active' && !feeRefused && otherRefusal && (
-        <AlertCard variant="warning" title="The network refused a step">
-          <p className="text-sm">Glow keeps retrying.</p>
-          <ErrorDetails text={otherRefusal} testId="unilateral-exit-refusal" />
-        </AlertCard>
-      )}
 
       {plan.phase === 'redo' && (
         <AlertCard variant="warning" title="Your exit needs an update">

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -183,8 +183,7 @@ export const TrackerView: React.FC<{
       {plan.phase === 'redo' && (
         <AlertCard variant="warning" title="Rebuild to keep going">
           <p className="text-sm">
-            The blockchain no longer matches the transactions saved here. Your money is safe:
-            it is still in the tree, or already in an output you control.
+            Some steps went through another way. Your money is safe.
           </p>
           {continueError && (
             <p className="text-sm mt-2" data-testid="unilateral-exit-continue-error">

--- a/src/features/unilateral-exit/TrackerView.tsx
+++ b/src/features/unilateral-exit/TrackerView.tsx
@@ -2,12 +2,22 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { BackupActions, ExitActionRow } from './BackupCard';
 import { AlertCard } from '@/components/AlertCard';
 import { SatAmount } from '@/components/SatAmount';
-import { CollapsibleSection, PrimaryButton, SecondaryButton } from '@/components/ui';
+import { CollapsibleCodeField, CollapsibleSection, PrimaryButton, SecondaryButton } from '@/components/ui';
 import { RefreshIcon } from '@/components/Icons';
 import { blocksToFinish, exitStages, hasFixedFeeBudget, nextAction, planProgress, refusalKind } from './driver';
 import type { NextAction, PlanProgress, UnilateralExitPlan } from './driver';
 import { formatDaysLeft } from '@/utils/blockTime';
 import { formatWithSpaces } from '@/utils/formatNumber';
+
+/** The node's or the SDK's own words, folded away: support needs them, the user rarely does. */
+const ErrorDetails: React.FC<{ text: string; testId: string }> = ({ text, testId }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-2" data-testid={testId}>
+      <CollapsibleCodeField label="Details" value={text} isVisible={open} onToggle={() => setOpen(v => !v)} />
+    </div>
+  );
+};
 
 /** One labelled figure. No icon and no marker: the label is the whole story. */
 const Row: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
@@ -126,7 +136,8 @@ export const TrackerView: React.FC<{
   const [advanced, setAdvanced] = useState(false);
   const progress = useMemo(() => planProgress(plan), [plan]);
   const refusals = Object.values(plan.refusals);
-  const feeRefused = refusals.some(reason => refusalKind(reason) === 'fee');
+  const feeRefusal = refusals.find(reason => refusalKind(reason) === 'fee');
+  const feeRefused = feeRefusal !== undefined;
   const otherRefusal = refusals.find(reason => refusalKind(reason) === 'other');
   const next = useMemo(
     () => (tipHeight === null ? null : nextAction(transactions, tipHeight)),
@@ -168,15 +179,14 @@ export const TrackerView: React.FC<{
               </div>
             </>
           )}
+          {feeRefusal && <ErrorDetails text={feeRefusal} testId="unilateral-exit-fee-refusal" />}
         </AlertCard>
       )}
 
       {plan.phase === 'active' && !feeRefused && otherRefusal && (
         <AlertCard variant="warning" title="The network refused a step">
-          <p className="text-xs font-mono break-all" data-testid="unilateral-exit-refusal">
-            {otherRefusal}
-          </p>
-          <p className="text-sm mt-2">Glow keeps retrying.</p>
+          <p className="text-sm">Glow keeps retrying.</p>
+          <ErrorDetails text={otherRefusal} testId="unilateral-exit-refusal" />
         </AlertCard>
       )}
 
@@ -187,9 +197,10 @@ export const TrackerView: React.FC<{
             updating. Your money is safe.
           </p>
           {continueError && (
-            <p className="text-sm mt-2" data-testid="unilateral-exit-continue-error">
-              {continueError}
-            </p>
+            <>
+              <p className="text-sm mt-2">Glow could not continue the exit.</p>
+              <ErrorDetails text={continueError} testId="unilateral-exit-continue-error" />
+            </>
           )}
           <div className="mt-3 space-y-2">
             <PrimaryButton

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -65,10 +65,9 @@ describe('applyExitCheck', () => {
     expect(next.refusals).toEqual({});
   });
 
-  it('sets the phase and clears a stale check error', () => {
-    const next = applyExitCheck(plan([tx({ txid: 'a' })], { lastCheckError: 'esplora down' }), checked([{ txid: 'a' }]), 'complete');
+  it('sets the phase', () => {
+    const next = applyExitCheck(plan([tx({ txid: 'a' })]), checked([{ txid: 'a' }]), 'complete');
     expect(next.phase).toBe('complete');
-    expect(next.lastCheckError).toBeUndefined();
   });
 });
 
@@ -392,7 +391,6 @@ describe('advanceUnilateralExit', () => {
       '02abc',
     );
     expect(next.phase).toBe('redo');
-    expect(next.lastCheckError).toBeUndefined();
     localStorage.removeItem('passkeyLabel');
   });
 
@@ -405,7 +403,6 @@ describe('advanceUnilateralExit', () => {
     });
     const { plan: next } = await advanceUnilateralExit(plan([tx({ txid: 'a' })]), chain(), driver, '02abc');
     expect(next.phase).toBe('redo');
-    expect(next.lastCheckError).toMatch(/recovery phrase/);
   });
 
   it('keeps going on the set it holds when the check fails', async () => {
@@ -416,7 +413,6 @@ describe('advanceUnilateralExit', () => {
     });
     const { plan: next } = await advanceUnilateralExit(plan([tx({ txid: 'a' })]), chain(), failing);
     expect(next.exit.transactions).toHaveLength(1);
-    expect(next.lastCheckError).toMatch(/unavailable/);
   });
 
   it('sends nothing once the exit is complete', async () => {

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -12,6 +12,7 @@ import {
   nextAction,
   planFromExitResponse,
   refusalKind,
+  requiredFundingOf,
   planProgress,
   quotedSweepFeeSat,
   savePlan,
@@ -534,6 +535,16 @@ describe('refusalKind', () => {
   it('leaves anything else to be shown as the node said it', () => {
     expect(refusalKind('non-BIP68-final')).toBe('other');
     expect(refusalKind('broadcast failed with status 502')).toBe('other');
+  });
+});
+
+describe('requiredFundingOf', () => {
+  it("reads the amount out of the sdk's shortfall error", () => {
+    expect(requiredFundingOf('Insufficient CPFP funding: need at least 5898 sats')).toBe(5898);
+  });
+
+  it('is null for any other failure', () => {
+    expect(requiredFundingOf('signing failed')).toBeNull();
   });
 });
 

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -6,10 +6,12 @@ import {
   checkExit,
   clearPlan,
   exitStages,
+  hasFixedFeeBudget,
   isReady,
   loadPlan,
   nextAction,
   planFromExitResponse,
+  refusalKind,
   planProgress,
   quotedSweepFeeSat,
   savePlan,
@@ -508,5 +510,40 @@ describe('nextAction', () => {
 
   it('ignores a timelock whose starting height could not be read', () => {
     expect(nextAction([tx({ txid: 'c', status: locked() })], 100)).toBeNull();
+  });
+});
+
+describe('refusalKind', () => {
+  it('reads a spent input as another copy having gone through', () => {
+    // What a node answers once the operators' watchtower has published the refund.
+    expect(refusalKind('min relay fee not met, 0 < 13; bad-txns-inputs-missingorspent')).toBe('settled');
+    expect(refusalKind('bad-txns-inputs-missingorspent; bad-txns-inputs-missingorspent')).toBe('settled');
+    expect(refusalKind('txn-mempool-conflict')).toBe('settled');
+  });
+
+  it('reads an underpaid step as a fee problem', () => {
+    expect(refusalKind('mempool min fee not met, 120 < 250')).toBe('fee');
+    expect(refusalKind('min relay fee not met, 100 < 130')).toBe('fee');
+    expect(refusalKind('insufficient fee, rejecting replacement')).toBe('fee');
+  });
+
+  it('blames the fee when the zero-fee parent is all the node reported', () => {
+    expect(refusalKind('min relay fee not met, 0 < 13')).toBe('fee');
+  });
+
+  it('leaves anything else to be shown as the node said it', () => {
+    expect(refusalKind('non-BIP68-final')).toBe('other');
+    expect(refusalKind('broadcast failed with status 502')).toBe('other');
+  });
+});
+
+describe('hasFixedFeeBudget', () => {
+  it('holds once the fan-out that splits the exit fee has confirmed', () => {
+    expect(hasFixedFeeBudget(plan([tx({ txid: 'f', kind: 'fanOut', status: confirmed(10) })]))).toBe(true);
+  });
+
+  it('does not while the fan-out is still to confirm, or there is none', () => {
+    expect(hasFixedFeeBudget(plan([tx({ txid: 'f', kind: 'fanOut' })]))).toBe(false);
+    expect(hasFixedFeeBudget(plan([tx({ txid: 'n', kind: 'node', status: confirmed(10) })]))).toBe(false);
   });
 });

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -11,7 +11,6 @@ import {
   loadPlan,
   nextAction,
   planFromExitResponse,
-  refusalKind,
   requiredFundingOf,
   planProgress,
   quotedSweepFeeSat,
@@ -511,30 +510,6 @@ describe('nextAction', () => {
 
   it('ignores a timelock whose starting height could not be read', () => {
     expect(nextAction([tx({ txid: 'c', status: locked() })], 100)).toBeNull();
-  });
-});
-
-describe('refusalKind', () => {
-  it('reads a spent input as another copy having gone through', () => {
-    // What a node answers once the operators' watchtower has published the refund.
-    expect(refusalKind('min relay fee not met, 0 < 13; bad-txns-inputs-missingorspent')).toBe('settled');
-    expect(refusalKind('bad-txns-inputs-missingorspent; bad-txns-inputs-missingorspent')).toBe('settled');
-    expect(refusalKind('txn-mempool-conflict')).toBe('settled');
-  });
-
-  it('reads an underpaid step as a fee problem', () => {
-    expect(refusalKind('mempool min fee not met, 120 < 250')).toBe('fee');
-    expect(refusalKind('min relay fee not met, 100 < 130')).toBe('fee');
-    expect(refusalKind('insufficient fee, rejecting replacement')).toBe('fee');
-  });
-
-  it('blames the fee when the zero-fee parent is all the node reported', () => {
-    expect(refusalKind('min relay fee not met, 0 < 13')).toBe('fee');
-  });
-
-  it('leaves anything else to be shown as the node said it', () => {
-    expect(refusalKind('non-BIP68-final')).toBe('other');
-    expect(refusalKind('broadcast failed with status 502')).toBe('other');
   });
 });
 

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -225,6 +225,12 @@ export function refusalKind(reason: string): RefusalKind {
 export const hasFixedFeeBudget = (plan: UnilateralExitPlan): boolean =>
   plan.exit.transactions.some(tx => tx.kind === 'fanOut' && tx.status.type === 'confirmed');
 
+/** What a build said it needs: the sdk's error reaches the page only as its message. */
+export function requiredFundingOf(error: string): number | null {
+  const match = /need at least (\d+) sats/i.exec(error);
+  return match ? Number(match[1]) : null;
+}
+
 export interface PlanProgress {
   confirmed: number;
   total: number;

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -200,6 +200,31 @@ export type ExitSdk = Pick<
 /** The sdk resolves this against the chain tip, timelock included. */
 export const isReady = (tx: UnilateralExitTransaction): boolean => tx.status.type === 'ready';
 
+/**
+ * What a refusal asks of the user. A zero-fee tree transaction fails the fee
+ * check whenever its fee-paying child is refused, so that part never names the
+ * cause. A spent or conflicting input means another copy of the step already
+ * went through, and the next check adopts it.
+ */
+export type RefusalKind = 'settled' | 'fee' | 'other';
+
+// ponytail: a spent input is read as another copy having gone through. One that
+// never clears stays silent; time how long it has been refused if that shows up.
+export function refusalKind(reason: string): RefusalKind {
+  const causes = reason.split('; ').filter(part => !/^min relay fee not met, 0 </.test(part));
+  if (causes.some(part => /missingorspent|mempool-conflict/.test(part))) return 'settled';
+  if (causes.length === 0 || causes.some(part => /fee/i.test(part))) return 'fee';
+  return 'other';
+}
+
+/**
+ * Whether each branch is down to the fee coin the fan-out gave it. From then on
+ * a rebuild cannot draw on the exit fee address, so more there cannot pay a
+ * higher fee.
+ */
+export const hasFixedFeeBudget = (plan: UnilateralExitPlan): boolean =>
+  plan.exit.transactions.some(tx => tx.kind === 'fanOut' && tx.status.type === 'confirmed');
+
 export interface PlanProgress {
   confirmed: number;
   total: number;

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -41,7 +41,6 @@ export interface UnilateralExitPlan {
   phase: ExitPhase;
   /** Frozen when the exit was built: the operators stop reporting the leaves it moves. */
   exitStateSnapshot?: string;
-  lastCheckError?: string;
 }
 
 const PLAN_VERSION = 4;
@@ -78,7 +77,7 @@ export function applyExitCheck(
   const refusals = Object.fromEntries(
     Object.entries(plan.refusals).filter(([txid]) => open.has(txid)),
   );
-  return { ...plan, exit: checked, refusals, phase, lastCheckError: undefined };
+  return { ...plan, exit: checked, refusals, phase };
 }
 
 export function savePlan(wallet: WalletKey, plan: UnilateralExitPlan): void {
@@ -351,11 +350,9 @@ export async function advanceUnilateralExit(
     try {
       next = await checkExit(next, sdk);
     } catch (e) {
-      // Kept on the plan, not only logged: an exit that silently stops reading
-      // the chain looks identical to one that is stuck.
+      // Not shown: the next pass tries again, and the log keeps the reason.
       const error = e instanceof Error ? e.message : String(e);
       logger.warn(LogCategory.SDK, `Failed to read the exit back from the sdk: ${error}`);
-      next = { ...next, lastCheckError: error };
     }
   }
 
@@ -370,7 +367,6 @@ export async function advanceUnilateralExit(
       if (e instanceof MnemonicNeedsPasskeyError) return { plan: next, tipHeight };
       const error = e instanceof Error ? e.message : String(e);
       logger.warn(LogCategory.SDK, `Failed to rebuild the exit: ${error}`);
-      next = { ...next, lastCheckError: error };
     }
   }
 

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -32,7 +32,11 @@ export interface UnilateralExitPlan {
   quotedSweepFeeSat: number;
   /** The sdk's latest word on the exit, handed back to `checkUnilateralExit` unchanged. */
   exit: UnilateralExitResponse;
-  /** Why the network last refused a step, by txid. Cleared once it is accepted or confirms. */
+  /**
+   * Why the network last refused each transaction, by txid, for diagnostics. The
+   * tracker shows none: Glow retries a refusal on every check. Cleared once the
+   * transaction is accepted or confirms.
+   */
   refusals: Record<string, string>;
   phase: ExitPhase;
   /** Frozen when the exit was built: the operators stop reporting the leaves it moves. */
@@ -199,23 +203,6 @@ export type ExitSdk = Pick<
 
 /** The sdk resolves this against the chain tip, timelock included. */
 export const isReady = (tx: UnilateralExitTransaction): boolean => tx.status.type === 'ready';
-
-/**
- * What a refusal asks of the user. A zero-fee tree transaction fails the fee
- * check whenever its fee-paying child is refused, so that part never names the
- * cause. A spent or conflicting input means another copy of the step already
- * went through, and the next check adopts it.
- */
-export type RefusalKind = 'settled' | 'fee' | 'other';
-
-// ponytail: a spent input is read as another copy having gone through. One that
-// never clears stays silent; time how long it has been refused if that shows up.
-export function refusalKind(reason: string): RefusalKind {
-  const causes = reason.split('; ').filter(part => !/^min relay fee not met, 0 </.test(part));
-  if (causes.some(part => /missingorspent|mempool-conflict/.test(part))) return 'settled';
-  if (causes.length === 0 || causes.some(part => /fee/i.test(part))) return 'fee';
-  return 'other';
-}
 
 /**
  * Whether each branch is down to the fee coin the fan-out gave it. From then on

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -287,16 +287,22 @@ export async function checkExit(plan: UnilateralExitPlan, sdk: ExitSdk): Promise
  * destination, fee rate and funding. Null when there is nothing left to build,
  * which leaves the stored exit as it was.
  *
- * Runs from a background pass, so it never asks for the recovery phrase: a
- * wallet that keeps none on the device throws, and the tracker offers the
- * rebuild as a button the user presses.
+ * A background pass never asks for the recovery phrase: a wallet that keeps
+ * none on the device throws, and the tracker offers the rebuild as a button.
+ * The button passes `interactive`, since its tap is what lets a passkey
+ * prompt run. The phrase is read first, while that tap is still fresh.
  */
 export async function rebuildExit(
   plan: UnilateralExitPlan,
   sdk: ExitSdk,
   identityPubkey: string,
+  { interactive = false }: { interactive?: boolean } = {},
 ): Promise<UnilateralExitPlan | null> {
-  const key = deriveFundingKey(await readWalletMnemonic(), plan.network, plan.fundingAddressIndex);
+  const key = deriveFundingKey(
+    await readWalletMnemonic({ interactive }),
+    plan.network,
+    plan.fundingAddressIndex,
+  );
   await restoreExitState(sdk, plan, await loadExitState(identityPubkey).catch(() => null));
 
   // Named, not reselected: `auto` can drop a leaf that is part-way out.

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -10,6 +10,7 @@ import {
   hasFixedFeeBudget,
   planFromExitResponse,
   quotedSweepFeeSat,
+  rebuildExit,
   requiredFundingOf,
   willReceiveSat,
   type WalletKey,
@@ -116,6 +117,10 @@ export interface UnilateralExitFlow {
   build: () => Promise<void>;
   buildError: string | null;
   rebuild: () => void;
+  /** Rebuilds a diverged exit in place, at its own fee rate, without the wizard. */
+  continueExit: () => Promise<void>;
+  isContinuing: boolean;
+  continueError: string | null;
   goTo: (phase: UnilateralExitPhase) => void;
   back: () => void;
 }
@@ -337,6 +342,27 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     setPhase('fee');
   }, []);
 
+  // The redo card's button: the rebuild the engine runs on its own, from a tap.
+  // A diverged exit needs no new fee rate or funding, so the wizard would only
+  // add steps, and the tap is what lets a passkey wallet sign.
+  const [isContinuing, setIsContinuing] = useState(false);
+  const [continueError, setContinueError] = useState<string | null>(null);
+  const continueExit = useCallback(async () => {
+    if (!plan || !walletKey) return;
+    setIsContinuing(true);
+    setContinueError(null);
+    try {
+      const rebuilt = await rebuildExit(plan, wallet, walletKey.identityPubkey, { interactive: true });
+      if (rebuilt) setUnilateralExitPlan(walletKey, rebuilt);
+      else setContinueError('Nothing is left to rebuild. The exit updates on its next check.');
+    } catch (e) {
+      logger.error(LogCategory.SDK, 'Failed to continue unilateral exit', { error: message(e) });
+      setContinueError(message(e));
+    } finally {
+      setIsContinuing(false);
+    }
+  }, [plan, wallet, walletKey]);
+
   const back = useCallback(() => setPhase(current => BACK[current] ?? current), []);
 
   return {
@@ -376,6 +402,9 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     build,
     buildError,
     rebuild,
+    continueExit,
+    isContinuing,
+    continueError,
     goTo: setPhase,
     back,
   };

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -6,7 +6,14 @@ import { holdIdleLock } from '@/services/appLock';
 import { createChainClient } from '@/services/chain';
 import type { ChainUtxo, FeeRates } from '@/services/chain';
 import { logger, LogCategory } from '@/services/logger';
-import { planFromExitResponse, quotedSweepFeeSat, willReceiveSat, type WalletKey } from '../driver';
+import {
+  hasFixedFeeBudget,
+  planFromExitResponse,
+  quotedSweepFeeSat,
+  requiredFundingOf,
+  willReceiveSat,
+  type WalletKey,
+} from '../driver';
 import { getUnilateralExitState, setUnilateralExitPlan, type UnilateralExitEngineState } from '../engine';
 import { loadExitState, restoreExitState } from '../exitState';
 import { bumpFundingIndex, deriveFundingKey, readFundingIndex, readWalletMnemonic, type FundingKey } from '../funding';
@@ -76,6 +83,10 @@ export interface FundingFields {
   hasPendingDeposit: boolean;
   /** An exit already under way keeps its funding address, and what it holds pays for the rest. */
   isResuming: boolean;
+  /** What the last build at this quote said it needs at the address, or null before one fails for want of it. */
+  requiredFundingSat: number | null;
+  /** More at the address cannot pay a higher fee: see `hasFixedFeeBudget`. */
+  isFeeBudgetFixed: boolean;
 }
 
 /**
@@ -137,6 +148,9 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
   const [fundingUtxos, setFundingUtxos] = useState<ChainUtxo[]>([]);
   const [unlockError, setUnlockError] = useState<string | null>(null);
   const [buildError, setBuildError] = useState<string | null>(null);
+  // Only the build knows what a resumed exit still needs, and it says so by
+  // refusing. Held for this quote's rate, so a new quote clears it.
+  const [requiredFundingSat, setRequiredFundingSat] = useState<number | null>(null);
   const mnemonicRef = useRef<string | null>(null);
 
   useEffect(() => () => {
@@ -200,6 +214,7 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     if (effectiveFeeRate <= 0) return;
     setIsQuoting(true);
     setQuoteError(null);
+    setRequiredFundingSat(null);
     try {
       // Quoted against the backed-up leaf data, not only what the operators still report.
       if (walletKey) {
@@ -246,10 +261,18 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
   const confirmedUtxos = useMemo(() => fundingUtxos.filter(utxo => utxo.confirmed), [fundingUtxos]);
   const fundedSat = confirmedUtxos.reduce((total, utxo) => total + utxo.value, 0);
   const isResuming = plan !== null;
+  const isFeeBudgetFixed = plan !== null && hasFixedFeeBudget(plan);
   // A resumed exit is not held to a fresh exit's price: most of what the quote
   // covers is already on-chain, and only the build knows what is really needed.
+  // A fresh exit's quote is a lower bound too. Once a build has said what it
+  // needs, the address has to hold it, unless the fee coins are fixed, when no
+  // amount there helps and only a new quote can.
   const isFunded =
-    quote !== null && (isResuming ? confirmedUtxos.length > 0 : fundedSat >= quote.singleUtxoFundingSat);
+    quote !== null &&
+    (isResuming
+      ? confirmedUtxos.length > 0 &&
+        (requiredFundingSat === null || (!isFeeBudgetFixed && fundedSat >= requiredFundingSat))
+      : fundedSat >= Math.max(quote.singleUtxoFundingSat, requiredFundingSat ?? 0));
 
   const build = useCallback(async () => {
     if (!walletKey || !quote || !fundingKey || !mnemonicRef.current) return;
@@ -296,6 +319,7 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     } catch (e) {
       logger.error(LogCategory.SDK, 'Failed to build unilateral exit', { error: message(e) });
       setBuildError(message(e));
+      setRequiredFundingSat(requiredFundingOf(message(e)));
       setPhase('fund');
     } finally {
       release();
@@ -340,6 +364,8 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
       isFunded,
       hasPendingDeposit: fundingUtxos.some(utxo => !utxo.confirmed),
       isResuming,
+      requiredFundingSat,
+      isFeeBudgetFixed,
     },
     submitDestination,
     submitFee,

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -332,6 +332,8 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     setQuote(null);
     setQuoteError(null);
     setBuildError(null);
+    // The rates read when the page opened can be hours old by now.
+    setFeeRates(null);
     setPhase('fee');
   }, []);
 

--- a/src/features/unilateral-exit/listEntries.ts
+++ b/src/features/unilateral-exit/listEntries.ts
@@ -22,7 +22,7 @@ export interface UnilateralExitEntry {
 const activeSubtitle = (state: UnilateralExitEngineState): string | null => {
   const plan = state.plan;
   if (!plan) return null;
-  if (plan.phase === 'redo') return 'The blockchain moved on. Open to rebuild it.';
+  if (plan.phase === 'redo') return 'Open to continue it.';
 
   const { confirmed, total } = planProgress(plan);
   const blocks =
@@ -55,7 +55,7 @@ export function unilateralExitEntries(state: UnilateralExitEngineState): Unilate
   return [
     {
       id: 'active',
-      title: plan.phase === 'redo' ? 'Rebuild needed' : 'Transactions in progress',
+      title: plan.phase === 'redo' ? 'Update needed' : 'Transactions in progress',
       subtitle: activeSubtitle(state),
       amountSat: willReceiveSat(plan),
       isActive: true,

--- a/src/features/unilateral-exit/listEntries.ts
+++ b/src/features/unilateral-exit/listEntries.ts
@@ -29,8 +29,9 @@ const activeSubtitle = (state: UnilateralExitEngineState): string | null => {
     state.tipHeight === null
       ? null
       : (nextAction(plan.exit.transactions, state.tipHeight)?.blocks ?? null);
-  const steps = `${confirmed} of ${total} steps confirmed`;
-  return blocks === null ? steps : `${steps}, next ${formatBlockWait(blocks)}`;
+  // The row's title already says these are transactions.
+  const processed = `${confirmed} of ${total} processed`;
+  return blocks === null ? processed : `${processed}, next ${formatBlockWait(blocks)}`;
 };
 
 const archivedEntry = (exit: ArchivedExit): UnilateralExitEntry => ({

--- a/src/features/unilateral-exit/steps/FundStep.test.tsx
+++ b/src/features/unilateral-exit/steps/FundStep.test.tsx
@@ -9,6 +9,8 @@ const props = {
   isFunded: false,
   hasPendingDeposit: false,
   isResuming: false,
+  requiredFundingSat: null,
+  isFeeBudgetFixed: false,
   error: null,
 };
 
@@ -29,5 +31,33 @@ describe('FundStep', () => {
     render(<FundStep {...props} isResuming fundedSat={3_905} isFunded />);
     expect(screen.queryByText(/5 898/)).not.toBeInTheDocument();
     expect(screen.getByText(/already at this address/i)).toBeInTheDocument();
+  });
+
+  it('asks a resumed exit for the gap its build named, instead of the raw error', () => {
+    render(
+      <FundStep
+        {...props}
+        isResuming
+        fundedSat={3_000}
+        requiredFundingSat={5_000}
+        error="Insufficient CPFP funding: need at least 5000 sats"
+      />,
+    );
+    expect(screen.getByText('Add to exit fee')).toBeInTheDocument();
+    expect(screen.getAllByText(/2 000/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Insufficient CPFP funding/)).not.toBeInTheDocument();
+  });
+
+  it('asks for a lower fee rate once the fee coins are fixed, since more money cannot help', () => {
+    render(<FundStep {...props} isResuming fundedSat={3_000} requiredFundingSat={5_000} isFeeBudgetFixed />);
+    expect(screen.getByText('This fee rate is too high')).toBeInTheDocument();
+    expect(screen.queryByText('Add to exit fee')).not.toBeInTheDocument();
+  });
+
+  it('asks a fresh exit for the gap too, since its quote is only a lower bound', () => {
+    render(<FundStep {...props} fundedSat={5_898} requiredFundingSat={6_100} error="Insufficient CPFP funding: need at least 6100 sats" />);
+    expect(screen.getByText('Add to exit fee')).toBeInTheDocument();
+    expect(screen.getAllByText(/202/).length).toBeGreaterThan(0);
+    expect(screen.getByTestId('unilateral-exit-funding-address')).toBeInTheDocument();
   });
 });

--- a/src/features/unilateral-exit/steps/FundStep.tsx
+++ b/src/features/unilateral-exit/steps/FundStep.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AlertCard } from '@/components/AlertCard';
 import { CopyableText, ErrorMessageBox, QRCodeContainer } from '@/components/ui';
 import { SatAmount } from '@/components/SatAmount';
 import { CheckIcon, ClockIcon } from '@/components/Icons';
@@ -12,13 +13,29 @@ export const FundStep: React.FC<FundingFields & { error: string | null }> = ({
   isFunded,
   hasPendingDeposit,
   isResuming,
+  requiredFundingSat,
+  isFeeBudgetFixed,
   error,
 }) => {
   const { showToast } = useToast();
+  // After a build names what it needs, the address is asked only for the gap.
+  const shortfallSat =
+    requiredFundingSat !== null ? Math.max(0, requiredFundingSat - fundedSat) : 0;
+  const askSat = shortfallSat > 0 ? shortfallSat : isResuming ? 0 : requiredSat;
   // BIP21 so the paying wallet fills the amount in as well as the address:
   // this is money sent from somewhere else, and the figure has to be exact.
-  const btc = (requiredSat / 100_000_000).toFixed(8).replace(/0+$/, '').replace(/\.$/, '');
-  const qrValue = isResuming ? address : `bitcoin:${address}?amount=${btc}`;
+  const btc = (askSat / 100_000_000).toFixed(8).replace(/0+$/, '').replace(/\.$/, '');
+  const qrValue = askSat > 0 ? `bitcoin:${address}?amount=${btc}` : address;
+
+  if (isResuming && requiredFundingSat !== null && isFeeBudgetFixed) {
+    return (
+      <AlertCard variant="warning" title="This fee rate is too high">
+        <p className="text-sm">
+          The rest of this exit cannot pay it. Go back and choose a lower fee rate.
+        </p>
+      </AlertCard>
+    );
+  }
   // A resumed exit can still be asked for more, so it keeps the paying view
   // even once the original fee is in.
   const isPaid = isFunded && !isResuming;
@@ -40,9 +57,11 @@ export const FundStep: React.FC<FundingFields & { error: string | null }> = ({
     ) : (
       <>
         <div className="text-center py-2">
-          <p className="text-spark-text-muted text-sm mb-2">Pay exit fee</p>
+          <p className="text-spark-text-muted text-sm mb-2">
+            {shortfallSat > 0 ? 'Add to exit fee' : 'Pay exit fee'}
+          </p>
           <SatAmount
-            sats={isResuming ? fundedSat : requiredSat}
+            sats={shortfallSat > 0 ? shortfallSat : isResuming ? fundedSat : requiredSat}
             className="text-4xl font-bold text-spark-text-primary"
           />
         </div>
@@ -83,14 +102,23 @@ export const FundStep: React.FC<FundingFields & { error: string | null }> = ({
       </>
     )}
 
-    {error && <ErrorMessageBox title="Could not build the exit" error={error} />}
+    {/* A shortfall is the amount above, so its raw message would only repeat it. */}
+    {error && requiredFundingSat === null && (
+      <ErrorMessageBox title="Could not build the exit" error={error} />
+    )}
 
-    {isResuming && (
+    {requiredFundingSat !== null ? (
       <p className="text-spark-text-muted text-xs">
-        This exit is part-way done, and what it has left is paid for by the{' '}
-        <SatAmount sats={fundedSat} /> already at this address. Add more only if a step is later
-        rejected for want of fees.
+        At this fee rate the exit needs <SatAmount sats={requiredFundingSat} /> at this address, and
+        it holds <SatAmount sats={fundedSat} />.
       </p>
+    ) : (
+      isResuming && (
+        <p className="text-spark-text-muted text-xs">
+          This exit is part-way done, and what it has left is paid for by the{' '}
+          <SatAmount sats={fundedSat} /> already at this address.
+        </p>
+      )
     )}
 
   </div>

--- a/src/pages/UnilateralExitPage.tsx
+++ b/src/pages/UnilateralExitPage.tsx
@@ -195,6 +195,9 @@ const UnilateralExitPage: React.FC<UnilateralExitPageProps> = ({ network, onBack
                 tipHeight={flow.engine.tipHeight}
                 isAdvancing={flow.engine.isAdvancing}
                 onRebuild={flow.rebuild}
+                onContinue={() => void flow.continueExit()}
+                isContinuing={flow.isContinuing}
+                continueError={flow.continueError}
               />
             )}
 


### PR DESCRIPTION
This PR shows a problem to the user only when they can act on it.

- **Hidden errors:** the tracker no longer shows network refusals or failed checks. These recover on their own. They are still in the logs, so we can look into it if something is out of the ordinary and the user reaches out.
- **Exit fee shortfall:** when the exit fee is too small, the fee step asks for the missing amount, also in the QR, instead of failing with a raw error. If the fan-out already confirmed, more money cannot help, so it asks for a lower fee rate.
- **Continue Exit:** when the rest of the exit needs a rebuild, a web passkey wallet continues with one tap. Users do not need to go through the whole wizard again.
- **Smaller fixes:**
  - "Rebuild at a higher fee" in Advanced uses current fee rates, not the rates from when the exit page opened.
  - The exit screens say "transaction" instead of "step".

<table>
  <tr>
    <td><img width="320" alt="image" src="https://github.com/user-attachments/assets/31e805a1-6db4-4794-87ac-4a261d567eaa" /></td>
    <td><img width="320" alt="image" src="https://github.com/user-attachments/assets/32448944-73a4-4ead-b786-90c50110b84a" /></td>
  </tr>
</table>

<table>
  <tr>
    <td><img width="320" alt="New exit with fee shortfall" src="https://github.com/user-attachments/assets/765d258e-cfb3-49ff-9b7d-276ec09954aa" /></td>
    <td><img width="320" alt="Resumed exit with fee shortfall" src="https://github.com/user-attachments/assets/324aaa10-aa6f-4360-93a7-e0799bd15673" /></td>
    <td><img width="320" alt="Fee rate too high" src="https://github.com/user-attachments/assets/92f2cffb-df6f-4b00-bb57-311f76fbf90e" /></td>
  </tr>
</table>


