### PR TITLE
fix: address unilateral exit review findings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,6 +225,7 @@ const AppContent: React.FC = () => {
     switch (currentScreen) {
       case 'settings':
       case 'getRefund':
+      case 'unilateralExit':
         setUserScreen('wallet');
         return true;
       case 'backup':
@@ -232,8 +233,7 @@ const AppContent: React.FC = () => {
       case 'fiatCurrencies':
       case 'buyProviders':
       case 'passkeySettings':
-      case 'unilateralExit':
-        setUserScreen('wallet');
+        setUserScreen('settings');
         return true;
       case 'passkeyManagement':
       case 'labels':

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -9,6 +9,8 @@ import { safeAreaTop, safeAreaBottom } from '../utils/safeAreaInsets';
 import { useStatusBarColor } from '../hooks/useStatusBarColor';
 import { STATUS_BAR_SURFACE, STATUS_BAR_DIALOG_SCRIM } from '../utils/statusBarManager';
 import { useBackButton } from '../hooks/useBackButton';
+import { SimpleAlert } from './AlertCard';
+import { useUnilateralExitEngineState } from '../features/unilateral-exit/hooks/useUnilateralExitEngineLifecycle';
 import GlowLogo from './GlowLogo';
 
 // App Store Review Guidelines 5.1.1(i) requires the privacy policy to be
@@ -92,6 +94,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
   }, showLogoutConfirm);
 
   const isPasskey = isPasskeyMode();
+  const isExitInProgress = useUnilateralExitEngineState().plan !== null;
 
   // Stars animate after the 300ms slide-in delay. Derived from isOpen
   // so close flips it off immediately without a reset in an effect.
@@ -307,6 +310,15 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                       How to remove your passkey
                       <ExternalLinkIcon size="xs" />
                     </button>
+                  )}
+
+                  {/* Logout wipes the plan and the backup an exit needs, and the
+                      phrase alone cannot finish it: only saved exit data can. */}
+                  {isExitInProgress && (
+                    <SimpleAlert variant="warning" hideIcon className="mb-6 text-left">
+                      A unilateral exit is in progress, and logging out deletes what it needs to
+                      finish. Save its exit data first, from the exit&apos;s Advanced section.
+                    </SimpleAlert>
                   )}
 
                   <div className="flex gap-3">

--- a/src/components/ui/sheets/BottomSheet.backButton.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.backButton.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { BottomSheetContainer, BottomSheetCard } from './BottomSheet';
+import { useBackButton } from '../../../hooks/useBackButton';
+
+// The real stack only listens on native; this one records push order.
+const stack = vi.hoisted(() => [] as Array<() => unknown>);
+vi.mock('../../../utils/backButton', () => ({
+  pushBackButtonHandler: (handler: () => unknown) => {
+    stack.push(handler);
+    return () => {
+      const index = stack.lastIndexOf(handler);
+      if (index >= 0) stack.splice(index, 1);
+    };
+  },
+}));
+
+describe('BottomSheetContainer back button', () => {
+  it('stays under a handler registered after it when the sheet re-renders', () => {
+    const stepBack = vi.fn();
+    const onClose = vi.fn();
+    const Page = ({ text }: { text: string }) => {
+      useBackButton(stepBack, true);
+      return (
+        <BottomSheetContainer isOpen onClose={() => onClose()}>
+          <BottomSheetCard>
+            <span>{text}</span>
+          </BottomSheetCard>
+        </BottomSheetContainer>
+      );
+    };
+
+    const { rerender } = render(<Page text="first" />);
+    rerender(<Page text="second" />);
+    void stack[stack.length - 1]();
+
+    expect(stepBack).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -16,6 +16,7 @@ import { Keyboard } from '@capacitor/keyboard';
 import { useStatusBarColor } from '../../../hooks/useStatusBarColor';
 import { STATUS_BAR_SURFACE } from '../../../utils/statusBarManager';
 import { useBackButton } from '../../../hooks/useBackButton';
+import { useLatest } from '../../../hooks/useLatest';
 import { BottomSheetCardContext, SheetFullSnapContext } from './BottomSheetCardContext';
 
 /**
@@ -311,10 +312,14 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
 
   // Wire the Android hardware back button to close the sheet while
   // it's open, via the shared LIFO stack so nested sheets dismiss
-  // topmost-first. No-op on non-native platforms.
-  useBackButton(() => {
-    dismiss();
-  }, isOpen);
+  // topmost-first. No-op on non-native platforms. The handler is stable:
+  // re-pushed on every render, it would jump above a handler registered
+  // after it, such as a page's step-back inside the sheet.
+  const latestDismiss = useLatest(dismiss);
+  const onBackButton = useCallback(() => {
+    latestDismiss.current();
+  }, [latestDismiss]);
+  useBackButton(onBackButton, isOpen);
 
   // System bar tinting on native: nav bar matches the sheet surface
   // for the whole time it's open (the card always meets the nav bar);

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -517,6 +517,21 @@ describe('blocksToFinish for a matured step', () => {
   });
 });
 
+describe('savePlan when the snapshot outgrows storage', () => {
+  it('keeps the plan without the snapshot rather than losing the exit', () => {
+    // The first write, the whole plan, is the one that does not fit.
+    vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+    const owner = { identityPubkey: 'snapshot-owner', network: 'regtest' };
+    savePlan(owner, plan([tx({ txid: 'a' })], { exitStateSnapshot: 'huge-snapshot' }));
+
+    const kept = loadPlan(owner);
+    expect(kept?.exit.transactions[0].txid).toBe('a');
+    expect(kept?.exitStateSnapshot).toBeUndefined();
+  });
+});
+
 describe('destinationAddressOf', () => {
   const address = { type: 'bitcoinAddress', address: 'bcrt1qdest', network: 'regtest', source: {} } as const;
 

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -5,6 +5,7 @@ import {
   broadcastReadyTransactions,
   checkExit,
   clearPlan,
+  destinationAddressOf,
   exitStages,
   hasFixedFeeBudget,
   isReady,
@@ -513,6 +514,24 @@ describe('blocksToFinish for a matured step', () => {
   it("does not count a ready step's timelock again", () => {
     // Ready means the sdk has already seen the timelock pass: one block to confirm is left.
     expect(blocksToFinish([tx({ txid: 'r', kind: 'refund', csvTimelockBlocks: 2000 })], 100)).toBe(1);
+  });
+});
+
+describe('destinationAddressOf', () => {
+  const address = { type: 'bitcoinAddress', address: 'bcrt1qdest', network: 'regtest', source: {} } as const;
+
+  it('takes a plain address as it is', () => {
+    expect(destinationAddressOf(address as never)).toBe('bcrt1qdest');
+  });
+
+  it('takes the address out of a scanned bitcoin: URI', () => {
+    const uri = { type: 'bip21', uri: 'bitcoin:bcrt1qdest?amount=1', extras: [], paymentMethods: [address] };
+    expect(destinationAddressOf(uri as never)).toBe('bcrt1qdest');
+  });
+
+  it('refuses anything that names no on-chain address', () => {
+    expect(destinationAddressOf({ type: 'bip21', uri: 'bitcoin:?lightning=lnbc1', extras: [], paymentMethods: [] } as never)).toBeUndefined();
+    expect(destinationAddressOf(null)).toBeUndefined();
   });
 });
 

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -509,6 +509,13 @@ describe('nextAction', () => {
   });
 });
 
+describe('blocksToFinish for a matured step', () => {
+  it("does not count a ready step's timelock again", () => {
+    // Ready means the sdk has already seen the timelock pass: one block to confirm is left.
+    expect(blocksToFinish([tx({ txid: 'r', kind: 'refund', csvTimelockBlocks: 2000 })], 100)).toBe(1);
+  });
+});
+
 describe('requiredFundingOf', () => {
   it("reads the amount out of the sdk's shortfall error", () => {
     expect(requiredFundingOf('Insufficient CPFP funding: need at least 5898 sats')).toBe(5898);

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -179,12 +179,15 @@ export function blocksToFinish(all: UnilateralExitTransaction[], tipHeight: numb
       after.set(tx.txid, 0);
       continue;
     }
-    // A started timelock counts down from the height the sdk gives; one that
-    // has not started lies wholly ahead of whatever its dependency waits on.
+    // A ready step's timelock has matured; a started one counts down from the
+    // height the sdk gives; one not yet started lies wholly ahead of whatever
+    // its dependency waits on.
     const timelock =
-      tx.status.type === 'waitingForTimelock' && tx.status.spendableAtHeight !== undefined
-        ? Math.max(0, tx.status.spendableAtHeight - tipHeight)
-        : (tx.csvTimelockBlocks ?? 0);
+      tx.status.type === 'ready'
+        ? 0
+        : tx.status.type === 'waitingForTimelock' && tx.status.spendableAtHeight !== undefined
+          ? Math.max(0, tx.status.spendableAtHeight - tipHeight)
+          : (tx.csvTimelockBlocks ?? 0);
     const waits = tx.dependsOn.map(id => after.get(id) ?? 0);
     const blocks = (waits.length > 0 ? Math.max(...waits) : 0) + timelock + 1;
 

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -2,6 +2,7 @@ import { singleKeyCpfpSigner } from '@breeztech/breez-sdk-spark';
 import type {
   BreezSdk,
   CheckUnilateralExitResponse,
+  InputType,
   PrepareUnilateralExitResponse,
   UnilateralExitResponse,
   UnilateralExitTransaction,
@@ -213,6 +214,13 @@ export const isReady = (tx: UnilateralExitTransaction): boolean => tx.status.typ
  */
 export const hasFixedFeeBudget = (plan: UnilateralExitPlan): boolean =>
   plan.exit.transactions.some(tx => tx.kind === 'fanOut' && tx.status.type === 'confirmed');
+
+/** The on-chain address a destination names. A scanned receive QR is a BIP21 URI, and the exit sweeps to the address in it. */
+export function destinationAddressOf(parsed: InputType | null): string | undefined {
+  if (parsed?.type === 'bitcoinAddress') return parsed.address;
+  if (parsed?.type !== 'bip21') return undefined;
+  return parsed.paymentMethods.flatMap(method => (method.type === 'bitcoinAddress' ? [method.address] : []))[0];
+}
 
 /** What a build said it needs: the sdk's error reaches the page only as its message. */
 export function requiredFundingOf(error: string): number | null {

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -10,7 +10,7 @@ import type {
 import type { ChainClient } from '@/services/chain';
 import { logger, LogCategory } from '@/services/logger';
 import { outputTotalSat } from '@/utils/rawTx';
-import { loadExitState, restoreExitState } from './exitState';
+import { loadExitState, restoreExitState, saveExitState } from './exitState';
 import { deriveFundingKey, MnemonicNeedsPasskeyError, readWalletMnemonic } from './funding';
 
 /**
@@ -84,8 +84,28 @@ export function applyExitCheck(
 export function savePlan(wallet: WalletKey, plan: UnilateralExitPlan): void {
   try {
     localStorage.setItem(storageKey(wallet), JSON.stringify(plan));
+    return;
   } catch (e) {
     logger.error(LogCategory.SDK, 'Failed to persist recovery plan', {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+  // The snapshot can outgrow localStorage. Losing the plan would lose the exit,
+  // so it is kept without the snapshot, which moves to the rolling backup that
+  // a restore falls back to and that nothing refreshes while the exit runs.
+  // ponytail: retried on every save while too big; keep the snapshot in
+  // IndexedDB from the start if that ever costs.
+  if (!plan.exitStateSnapshot) return;
+  const { exitStateSnapshot, ...rest } = plan;
+  try {
+    localStorage.setItem(storageKey(wallet), JSON.stringify(rest));
+    void saveExitState(wallet.identityPubkey, exitStateSnapshot).catch(e =>
+      logger.error(LogCategory.SDK, 'Failed to move the exit snapshot to the rolling backup', {
+        error: e instanceof Error ? e.message : String(e),
+      }),
+    );
+  } catch (e) {
+    logger.error(LogCategory.SDK, 'Failed to persist recovery plan without its snapshot', {
       error: e instanceof Error ? e.message : String(e),
     });
   }

--- a/src/features/unilateral-exit/engine.test.ts
+++ b/src/features/unilateral-exit/engine.test.ts
@@ -70,3 +70,53 @@ describe('pollIntervalMs', () => {
     expect(pollIntervalMs('regtest')).toBe(5_000);
   });
 });
+
+describe('a pass that outlives its plan', () => {
+  // A chain whose tip reads wait until released, so a pass can be held open.
+  const held = () => {
+    const pending: Array<(height: number) => void> = [];
+    const client: ChainClient = { ...chain, tipHeight: () => new Promise(resolve => pending.push(resolve)) };
+    return { client, pending };
+  };
+  const settle = async () => {
+    for (let i = 0; i < 5; i++) await new Promise(resolve => setTimeout(resolve, 0));
+  };
+  const firstTxid = () => loadPlan(wallet)?.exit.transactions[0]?.txid;
+
+  beforeEach(() => {
+    localStorage.clear();
+    stopUnilateralExitEngine();
+  });
+
+  it('does not write over a plan rebuilt while it was out', async () => {
+    const { client, pending } = held();
+    setUnilateralExitPlan(wallet, plan([tx({ txid: 'old' })], { network: 'regtest' }));
+    startUnilateralExitEngine(wallet, client);
+    setUnilateralExitPlan(wallet, plan([tx({ txid: 'new' })], { network: 'regtest' }));
+
+    pending[0](101);
+    await settle();
+    expect(firstTxid()).toBe('new');
+    expect(getUnilateralExitState().plan?.exit.transactions[0].txid).toBe('new');
+
+    // The rebuilt plan got a pass of its own, which does write.
+    pending[1](102);
+    await settle();
+    expect(getUnilateralExitState().tipHeight).toBe(102);
+    expect(firstTxid()).toBe('new');
+  });
+
+  it("does not write one wallet's plan under another started while it was out", async () => {
+    const { client, pending } = held();
+    const other = { identityPubkey: 'other', network: 'regtest' };
+    setUnilateralExitPlan(wallet, plan([tx({ txid: 'old' })], { network: 'regtest' }));
+    startUnilateralExitEngine(wallet, client);
+    stopUnilateralExitEngine();
+    startUnilateralExitEngine(other, chain);
+
+    pending[0](101);
+    await settle();
+    expect(loadPlan(other)).toBeNull();
+    expect(getUnilateralExitState().plan).toBeNull();
+  });
+});

--- a/src/features/unilateral-exit/engine.ts
+++ b/src/features/unilateral-exit/engine.ts
@@ -29,6 +29,9 @@ let wallet: WalletKey | null = null;
 let chain: ChainClient | null = null;
 let sdk: ExitSdk | null = null;
 let timer: ReturnType<typeof setInterval> | null = null;
+// Bumped whenever the wallet or its plan is replaced. A pass that started under
+// an older generation is for something no longer current, so it must not write.
+let generation = 0;
 const listeners = new Set<Listener>();
 
 const emit = (next: Partial<UnilateralExitEngineState>): void => {
@@ -62,32 +65,36 @@ export async function advanceNow(): Promise<void> {
     return;
   }
 
+  const passGeneration = generation;
+  const passWallet = wallet;
   emit({ isAdvancing: true });
   try {
     const { plan, tipHeight } = await advanceUnilateralExit(
       state.plan,
       chain,
       sdk ?? undefined,
-      wallet.identityPubkey,
+      passWallet.identityPubkey,
     );
+    // Whoever replaced the wallet or plan while this pass was out owns the state now.
+    if (generation !== passGeneration) return;
     // A finished exit hands its slot back: the record lives in the archive from
     // here, and the wizard has to be free to quote the next one.
     if (plan.phase === 'complete') {
-      const archive = archiveExit(wallet, plan);
-      clearPlan(wallet);
+      const archive = archiveExit(passWallet, plan);
+      clearPlan(passWallet);
       emit({ plan: null, archive, tipHeight, isAdvancing: false });
       stopPolling();
       return;
     }
 
-    savePlan(wallet, plan);
+    savePlan(passWallet, plan);
     emit({ plan, tipHeight, isAdvancing: false });
     if (plan.phase !== 'active') stopPolling();
   } catch (e) {
     logger.warn(LogCategory.SDK, 'Recovery engine pass failed', {
       error: e instanceof Error ? e.message : String(e),
     });
-    emit({ isAdvancing: false });
+    if (generation === passGeneration) emit({ isAdvancing: false });
   }
 }
 
@@ -100,6 +107,7 @@ export function startUnilateralExitEngine(
   client: ChainClient = createChainClient(target.network),
   driver?: ExitSdk | null,
 ): void {
+  generation++;
   wallet = target;
   chain = client;
   sdk = driver ?? null;
@@ -111,6 +119,7 @@ export function startUnilateralExitEngine(
 }
 
 export function stopUnilateralExitEngine(): void {
+  generation++;
   stopPolling();
   wallet = null;
   chain = null;
@@ -122,7 +131,10 @@ export function stopUnilateralExitEngine(): void {
 export function setUnilateralExitPlan(target: WalletKey, plan: UnilateralExitPlan): void {
   savePlan(target, plan);
   if (wallet?.identityPubkey !== target.identityPubkey || wallet.network !== target.network) return;
-  emit({ plan });
+  // A pass still out for the old plan is discarded when it lands, so this one
+  // does not wait for it.
+  generation++;
+  emit({ plan, isAdvancing: false });
   startPolling();
   void advanceNow();
 }

--- a/src/features/unilateral-exit/exitState.test.ts
+++ b/src/features/unilateral-exit/exitState.test.ts
@@ -1,4 +1,4 @@
-import { captureExitState, exitStateForExit, restoreExitState } from './exitState';
+import { backUpWhenExitLands, captureExitState, exitStateForExit, restoreExitState } from './exitState';
 import { plan } from './testFixtures';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -77,5 +77,29 @@ describe('restoreExitState', () => {
   it('lets an exit proceed even if the import fails', async () => {
     const client = { importUnilateralExitState: vi.fn(async () => { throw new Error('corrupt'); }) };
     await expect(restoreExitState(client, null, 'rolling')).resolves.toBeUndefined();
+  });
+});
+
+describe('backUpWhenExitLands', () => {
+  const setup = () => {
+    const save = vi.fn(async () => undefined);
+    const sdk = { exportUnilateralExitState: vi.fn(async () => ({ exitState: 'fresh' })) };
+    return { save, sdk, listener: backUpWhenExitLands(sdk as never, save) };
+  };
+  const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  it('takes a fresh backup when an exit lands in the archive', async () => {
+    const { save, listener } = setup();
+    listener({ plan: plan([]), archive: [] });
+    listener({ plan: null, archive: [{ id: 'sweep' }] });
+    await flush();
+    expect(save).toHaveBeenCalledWith('fresh');
+  });
+
+  it('does not count the archive it finds on start as a landing', async () => {
+    const { save, listener } = setup();
+    listener({ plan: null, archive: [{ id: 'sweep' }] });
+    await flush();
+    expect(save).not.toHaveBeenCalled();
   });
 });

--- a/src/features/unilateral-exit/exitState.ts
+++ b/src/features/unilateral-exit/exitState.ts
@@ -39,6 +39,24 @@ export async function captureExitState(
   }
 }
 
+/**
+ * A listener that takes a fresh backup when an exit lands. A finished exit
+ * leaves a backup describing leaves it has since spent, and the engine marks
+ * the landing by archiving the exit and releasing its plan. The first state it
+ * sees is only a baseline, so loading an existing archive does not count.
+ */
+export function backUpWhenExitLands(
+  sdk: ExitStateExporter,
+  save: (exitState: string) => Promise<void>,
+): (state: { plan: UnilateralExitPlan | null; archive: readonly unknown[] }) => void {
+  let archived: number | null = null;
+  return ({ plan, archive }) => {
+    const landed = archived !== null && archive.length > archived;
+    archived = archive.length;
+    if (landed) void captureExitState(sdk, plan, save);
+  };
+}
+
 /** Importing only adds data the wallet lacks, so a failure is not a reason to stop. */
 export async function restoreExitState(
   sdk: ExitStateImporter,

--- a/src/features/unilateral-exit/hooks/useUnilateralExitEngineLifecycle.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitEngineLifecycle.ts
@@ -1,4 +1,4 @@
-import { captureExitState, saveExitState } from '../exitState';
+import { backUpWhenExitLands, captureExitState, saveExitState } from '../exitState';
 import { useEffect, useState } from 'react';
 import type { BreezSdk, SdkEvent } from '@breeztech/breez-sdk-spark';
 import {
@@ -41,16 +41,11 @@ export function useUnilateralExitEngineLifecycle(
     return () => document.removeEventListener('visibilitychange', onVisible);
   }, []);
 
-  // A finished exit leaves a backup describing leaves it has since spent, so a
-  // fresh one is taken the moment it completes.
   useEffect(() => {
     if (!sdk || !identityPubkey) return;
-    let backedUp = false;
-    return subscribeUnilateralExit(({ plan }) => {
-      if (plan?.phase !== 'complete' || backedUp) return;
-      backedUp = true;
-      void captureExitState(sdk, plan, state => saveExitState(identityPubkey, state));
-    });
+    return subscribeUnilateralExit(
+      backUpWhenExitLands(sdk, state => saveExitState(identityPubkey, state)),
+    );
   }, [sdk, identityPubkey]);
 
   // Once the operators stop serving them, the leaves an exit is built from

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -257,19 +257,22 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     await refreshQuote();
   }, [refreshQuote]);
 
+  // The index, not the plan: every engine pass emits a new plan object, and
+  // the page re-runs unlock whenever this callback changes.
+  const planFundingIndex = plan?.fundingAddressIndex;
   const unlock = useCallback(async () => {
     if (!walletKey) return;
     setUnlockError(null);
     try {
       const mnemonic = await readWalletMnemonic({ interactive: true });
       mnemonicRef.current = mnemonic;
-      const index = plan?.fundingAddressIndex ?? readFundingIndex(walletKey);
+      const index = planFundingIndex ?? readFundingIndex(walletKey);
       setFundingKey(deriveFundingKey(mnemonic, network, index));
       setPhase('fund');
     } catch (e) {
       setUnlockError(message(e));
     }
-  }, [walletKey, network, plan]);
+  }, [walletKey, network, planFundingIndex]);
 
   const confirmedUtxos = useMemo(() => fundingUtxos.filter(utxo => utxo.confirmed), [fundingUtxos]);
   const fundedSat = confirmedUtxos.reduce((total, utxo) => total + utxo.value, 0);

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -11,6 +11,7 @@ import {
   planFromExitResponse,
   quotedSweepFeeSat,
   rebuildExit,
+  destinationAddressOf,
   requiredFundingOf,
   willReceiveSat,
   type WalletKey,
@@ -207,10 +208,12 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
       return;
     }
     const parsed = await wallet.parse(trimmed).catch(() => null);
-    if (parsed?.type !== 'bitcoinAddress') {
+    const address = destinationAddressOf(parsed);
+    if (!address) {
       setDestinationError('That is not an on-chain Bitcoin address');
       return;
     }
+    setDestination(address);
     setDestinationError(null);
     setPhase('fee');
   }, [destination, wallet]);

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -149,6 +149,7 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
   const [feeChoice, setFeeChoice] = useState<FeeChoice>('medium');
   const [quote, setQuote] = useState<PrepareUnilateralExitResponse | null>(null);
   const [isQuoting, setIsQuoting] = useState(false);
+  const quoteRequest = useRef(0);
   const [quoteError, setQuoteError] = useState<string | null>(null);
   const [fundingKey, setFundingKey] = useState<FundingKey | null>(null);
   const [fundingUtxos, setFundingUtxos] = useState<ChainUtxo[]>([]);
@@ -220,6 +221,8 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
 
   const refreshQuote = useCallback(async () => {
     if (effectiveFeeRate <= 0) return;
+    // Back is open while a quote is out, so a slower, older one can land last.
+    const request = ++quoteRequest.current;
     setIsQuoting(true);
     setQuoteError(null);
     setRequiredFundingSat(null);
@@ -237,13 +240,15 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
           ? { type: 'specific', leafIds: plan.exit.leaves.map(leaf => leaf.leafId) }
           : { type: 'auto' },
       });
+      if (request !== quoteRequest.current) return;
       setQuote(prepared);
     } catch (e) {
+      if (request !== quoteRequest.current) return;
       logger.error(LogCategory.SDK, 'Failed to quote unilateral exit', { error: message(e) });
       setQuoteError(message(e));
       setQuote(null);
     } finally {
-      setIsQuoting(false);
+      if (request === quoteRequest.current) setIsQuoting(false);
     }
   }, [wallet, destination, effectiveFeeRate, walletKey, plan]);
 

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -447,6 +447,9 @@ export function useBreezSdk(
       try {
         cfg = buildConnectConfig();
       } catch (e) {
+        // Only a missing key gets this message. Any other config error takes
+        // the connect failure path, so onboarding does not carry on unconnected.
+        if (import.meta.env.VITE_BREEZ_API_KEY) throw e;
         showToast('error', 'Missing API Key', formatError(e));
         setIsLoading(false);
         return;

--- a/src/services/accountDeletion.ts
+++ b/src/services/accountDeletion.ts
@@ -45,7 +45,10 @@ async function deleteExportedFiles(): Promise<void> {
     const { files } = await Filesystem.readdir({ path: '', directory: Directory.Cache });
     await Promise.allSettled(
       files
-        .filter((f) => f.name.endsWith('_glow_logs.zip') || f.name.endsWith('_sdk_state.json'))
+        .filter((f) =>
+          f.name.endsWith('_glow_logs.zip') ||
+          f.name.endsWith('_sdk_state.json') ||
+          f.name.endsWith('_glow_unilateral_exit_backup.zip'))
         .map((f) => Filesystem.deleteFile({ path: f.name, directory: Directory.Cache })),
     );
   } catch { /* best-effort */ }


### PR DESCRIPTION
**Note:** This PR is on top of #411.

This PR fixes the review findings for Unilateral Exit.

- **Exits that could be lost:** a background check could undo a rebuild, so the rebuilt exit never went out. On a wallet with many leaves, the exit could fail to save and disappear after a reload.
- **Logout during an exit:** logout deleted what an exit in progress needs to finish, but the dialog said the recovery phrase was enough. The dialog now warns about this, and logout also deletes the saved exit backup.
- **Smaller fixes:**
  - Android back goes back one screen, in the exit flow and on Settings pages.
  - The destination accepts a scanned or pasted `bitcoin:` URI.
  - Days left no longer jumps to about 14 days when a transaction is ready.
  - A second exit's quote no longer counts sats that the first exit already delivered.
  - A resumed exit asks for the passkey once, not again every few seconds.
  - A slow, older quote no longer replaces a newer one.
  - "Missing API Key" shows only when the key is missing, not for other setup errors.

<table>
  <tr>
    <td><img width="320" alt="412-2-logout-warning" src="https://github.com/user-attachments/assets/d1245147-0cef-4c26-a2c1-9d6a2edaf1ae" /></td>
    <td><img width="320" alt="412-1-days-left" src="https://github.com/user-attachments/assets/4bb2043c-e505-4312-94bf-1038b0057daf" /></td>
  </tr>
</table>

