### PR TITLE
fix: stop reporting unconfirmed LNURL logins as failed

### DIFF
--- a/src/features/send/steps/ResultStep.test.tsx
+++ b/src/features/send/steps/ResultStep.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ResultStep from './ResultStep';
+
+const renderAuthFailure = (error: string) =>
+  render(<ResultStep result="failure" operationType="auth" error={error} onClose={vi.fn()} />);
+
+describe('ResultStep auth failure', () => {
+  it("doesn't call the login failed when Glow couldn't read the reply", () => {
+    renderAuthFailure('Operation failed: Network error: Request error: error sending request : JsValue(TypeError: Failed to fetch');
+    expect(screen.getByText('Authentication Not Confirmed')).toBeInTheDocument();
+    expect(screen.queryByText('Authentication Failed')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Failed to fetch/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the failure and its reason when the service reports an error', () => {
+    renderAuthFailure('Operation failed: Invalid signature');
+    expect(screen.getByText('Authentication Failed')).toBeInTheDocument();
+    expect(screen.getByText(/Invalid signature/)).toBeInTheDocument();
+  });
+});

--- a/src/features/send/steps/ResultStep.tsx
+++ b/src/features/send/steps/ResultStep.tsx
@@ -48,11 +48,17 @@ const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose, operati
   if (!isSuccess) {
     // Auth failure: use ErrorMessageBox card style
     if (operationType === 'auth') {
+      // The SDK's "Network error" means Glow never read the service's reply,
+      // not that the service refused. A service that sends no CORS headers
+      // still gets the login, and the WebView only hides its answer.
+      const unconfirmed = error?.includes('Network error:');
       return (
         <div className="space-y-5">
           <ErrorMessageBox
-            title={getTitle()}
-            error={error || getDefaultErrorMessage()}
+            title={unconfirmed ? 'Authentication Not Confirmed' : getTitle()}
+            error={unconfirmed
+              ? "Glow couldn't read the service's reply, so it can't confirm the login. Check the site to see if it went through."
+              : error || getDefaultErrorMessage()}
           />
           <PrimaryButton onClick={onClose} className="w-full">
             Close


### PR DESCRIPTION
This PR stops LNURL logins from showing "Authentication Failed" when Glow couldn't read the service's reply, which happens with services that send no CORS headers even though the login went through (breez/glow-app#200).

### Changes
- Show "Authentication Not Confirmed" and point the user to the site when the service's reply can't be read.
- Keep "Authentication Failed" with the service's reason when it reports an error.
