### PR TITLE
fix: ask for an optional top-up only when the exit needs one

### DIFF
--- a/src/components/FeeBreakdownCard.tsx
+++ b/src/components/FeeBreakdownCard.tsx
@@ -19,6 +19,8 @@ export interface FeeBreakdownItem {
   emphasis?: boolean;
   /** Marks a sat figure that is an estimate. */
   approximate?: boolean;
+  /** Marks a figure taken off the one above it, with a minus sign. */
+  subtract?: boolean;
 }
 
 export interface FeeBreakdownCardProps {
@@ -58,7 +60,12 @@ export const FeeBreakdownCard: React.FC<FeeBreakdownCardProps> = ({
             <span className={`font-mono text-sm ${item.highlight ? 'font-bold text-spark-primary' : item.emphasis ? 'font-semibold text-spark-text-primary' : 'text-spark-text-primary'}`}>
               {useRawStrings || typeof item.value === 'string'
                 ? String(item.value)
-                : Number(item.value) === 0 ? '0' : <SatAmount sats={item.value} approximate={item.approximate} />
+                : Number(item.value) === 0 ? '0' : (
+                  <>
+                    {item.subtract && '−'}
+                    <SatAmount sats={item.value} approximate={item.approximate} />
+                  </>
+                )
               }
             </span>
           </div>

--- a/src/features/unilateral-exit/driver.test.ts
+++ b/src/features/unilateral-exit/driver.test.ts
@@ -13,6 +13,8 @@ import {
   nextAction,
   planFromExitResponse,
   requiredFundingOf,
+  sentFunding,
+  topUpFor,
   planProgress,
   quotedSweepFeeSat,
   savePlan,
@@ -557,6 +559,50 @@ describe('requiredFundingOf', () => {
 
   it('is null for any other failure', () => {
     expect(requiredFundingOf('signing failed')).toBeNull();
+  });
+});
+
+describe('sentFunding', () => {
+  const own = [{ type: 'p2wpkh' as const, txid: 'fund', vout: 0, value: 5_361, pubkey: '02' }];
+  const coin = (txid: string, value: number) => ({ txid, vout: 0, value });
+
+  it("counts the exit's own funding while its first transaction is unconfirmed", () => {
+    // The sdk replaces that transaction and spends the same coin again.
+    const unconfirmed = plan([tx({ txid: 'fan', kind: 'fanOut' })], { exit: { fundingInputs: own } });
+    expect(sentFunding(unconfirmed, [coin('top-up', 1_000)])).toEqual({ sat: 6_361, inputs: 2 });
+  });
+
+  it('leaves it out once a transaction confirms, since that spent it for good', () => {
+    const settled = plan([tx({ txid: 'fan', kind: 'fanOut', status: confirmed(10) })], { exit: { fundingInputs: own } });
+    expect(sentFunding(settled, [coin('top-up', 1_000)])).toEqual({ sat: 1_000, inputs: 1 });
+  });
+
+  it('counts a coin the address still lists only once', () => {
+    const unsent = plan([tx({ txid: 'fan', kind: 'fanOut' })], { exit: { fundingInputs: own } });
+    expect(sentFunding(unsent, [coin('fund', 5_361)])).toEqual({ sat: 5_361, inputs: 1 });
+  });
+});
+
+describe('topUpFor', () => {
+  it('asks for the gap plus the fee of the coin that fills it', () => {
+    // One more input is 68 vB, so 2 720 sats at 40 sat/vB.
+    expect(topUpFor({ sat: 93_122, inputs: 2 }, { sat: 6_361, inputs: 2 }, 40)).toEqual({
+      neededSat: 95_842,
+      sentSat: 6_361,
+      stillToSendSat: 89_481,
+    });
+  });
+
+  it('is covered once that coin arrives', () => {
+    expect(topUpFor({ sat: 93_122, inputs: 2 }, { sat: 95_842, inputs: 3 }, 40).stillToSendSat).toBe(0);
+  });
+
+  it('asks again, for the next coin too, when the one sent fell short', () => {
+    expect(topUpFor({ sat: 93_122, inputs: 2 }, { sat: 93_122, inputs: 3 }, 40)).toEqual({
+      neededSat: 98_562,
+      sentSat: 93_122,
+      stillToSendSat: 5_440,
+    });
   });
 });
 

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -248,6 +248,49 @@ export function requiredFundingOf(error: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
+export interface Funding {
+  sat: number;
+  inputs: number;
+}
+
+/**
+ * What a build counts as sent to the exit fee address: the exit's own funding
+ * until one of its transactions confirms, since the sdk replaces an unconfirmed
+ * spender rather than building on it, plus every confirmed coin there.
+ * ponytail: mirrors the sdk's rules; take the figure from the sdk once its
+ * shortfall error reports what it counted.
+ */
+export function sentFunding(
+  plan: UnilateralExitPlan | null,
+  confirmed: { txid: string; vout: number; value: number }[],
+): Funding {
+  const own = plan && !plan.exit.transactions.some(tx => tx.status.type === 'confirmed') ? plan.exit.fundingInputs : [];
+  const coins = new Map([...own, ...confirmed].map(coin => [`${coin.txid}:${coin.vout}`, coin.value]));
+  return { sat: [...coins.values()].reduce((total, value) => total + value, 0), inputs: coins.size };
+}
+
+/** A signed P2WPKH input: each coin at the exit fee address is one more for the build to pay for. */
+const P2WPKH_INPUT_VBYTES = 68;
+
+export interface TopUp {
+  /** What the address needs at the new rate, the coin still to send included. */
+  neededSat: number;
+  sentSat: number;
+  stillToSendSat: number;
+}
+
+/**
+ * What to send after a build fell short. The sdk sized `required` on the inputs
+ * that build had, so each coin sent since, and the one still to send, adds its
+ * own input fee.
+ */
+export function topUpFor(required: Funding, sent: Funding, feeRateSatPerVbyte: number): TopUp {
+  const inputFeeSat = Math.ceil(P2WPKH_INPUT_VBYTES * feeRateSatPerVbyte);
+  const neededNowSat = required.sat + inputFeeSat * Math.max(0, sent.inputs - required.inputs);
+  const neededSat = sent.sat >= neededNowSat ? neededNowSat : neededNowSat + inputFeeSat;
+  return { neededSat, sentSat: sent.sat, stillToSendSat: Math.max(0, neededSat - sent.sat) };
+}
+
 export interface PlanProgress {
   confirmed: number;
   total: number;

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -32,6 +32,7 @@ export type UnilateralExitPhase =
   | 'quote'
   | 'unlock'
   | 'fund'
+  | 'topUp'
   | 'building'
   | 'tracker';
 
@@ -41,6 +42,7 @@ const BACK: Partial<Record<UnilateralExitPhase, UnilateralExitPhase>> = {
   quote: 'fee',
   unlock: 'quote',
   fund: 'quote',
+  topUp: 'fund',
 };
 
 export type FeeChoice = 'slow' | 'medium' | 'fast';
@@ -194,7 +196,7 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
   }, [phase, feeRates, chain]);
 
   useEffect(() => {
-    if (phase !== 'fund' || !fundingKey) return;
+    if ((phase !== 'fund' && phase !== 'topUp') || !fundingKey) return;
     let cancelled = false;
     const check = async () => {
       try {

--- a/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
+++ b/src/features/unilateral-exit/hooks/useUnilateralExitFlow.ts
@@ -13,7 +13,11 @@ import {
   rebuildExit,
   destinationAddressOf,
   requiredFundingOf,
+  sentFunding,
+  topUpFor,
   willReceiveSat,
+  type Funding,
+  type TopUp,
   type WalletKey,
 } from '../driver';
 import { getUnilateralExitState, setUnilateralExitPlan, type UnilateralExitEngineState } from '../engine';
@@ -80,15 +84,20 @@ export interface QuoteFields {
 export interface FundingFields {
   address: string;
   requiredSat: number;
-  fundedSat: number;
   isFunded: boolean;
   hasPendingDeposit: boolean;
   /** An exit already under way keeps its funding address, and what it holds pays for the rest. */
   isResuming: boolean;
-  /** What the last build at this quote said it needs at the address, or null before one fails for want of it. */
-  requiredFundingSat: number | null;
+  /** What to send after a build at this quote fell short, or null before one does. */
+  topUp: TopUp | null;
   /** More at the address cannot pay a higher fee: see `hasFixedFeeBudget`. */
   isFeeBudgetFixed: boolean;
+  /** The quote's rate, which the build pays. */
+  feeRate: number;
+  /** The rate a resumed exit runs at until the build replaces it. */
+  currentFeeRate: number | null;
+  /** When the quote the figures come from was taken, in ms. */
+  quotedAt: number | null;
 }
 
 /**
@@ -155,9 +164,12 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
   const [fundingUtxos, setFundingUtxos] = useState<ChainUtxo[]>([]);
   const [unlockError, setUnlockError] = useState<string | null>(null);
   const [buildError, setBuildError] = useState<string | null>(null);
-  // Only the build knows what a resumed exit still needs, and it says so by
-  // refusing. Held for this quote's rate, so a new quote clears it.
-  const [requiredFundingSat, setRequiredFundingSat] = useState<number | null>(null);
+  // Only the build knows what an exit still needs, and it says so by refusing.
+  // Held with the inputs it had, for this quote's rate, so a new quote clears it.
+  const [shortfall, setShortfall] = useState<Funding | null>(null);
+  const [quotedAt, setQuotedAt] = useState<number | null>(null);
+  // A resumed exit tries its build once per quote before asking for anything.
+  const triedQuote = useRef<PrepareUnilateralExitResponse | null>(null);
   const mnemonicRef = useRef<string | null>(null);
 
   useEffect(() => () => {
@@ -225,7 +237,7 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     const request = ++quoteRequest.current;
     setIsQuoting(true);
     setQuoteError(null);
-    setRequiredFundingSat(null);
+    setShortfall(null);
     try {
       // Quoted against the backed-up leaf data, not only what the operators still report.
       if (walletKey) {
@@ -242,6 +254,7 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
       });
       if (request !== quoteRequest.current) return;
       setQuote(prepared);
+      setQuotedAt(Date.now());
     } catch (e) {
       if (request !== quoteRequest.current) return;
       logger.error(LogCategory.SDK, 'Failed to quote unilateral exit', { error: message(e) });
@@ -278,6 +291,8 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
   const fundedSat = confirmedUtxos.reduce((total, utxo) => total + utxo.value, 0);
   const isResuming = plan !== null;
   const isFeeBudgetFixed = plan !== null && hasFixedFeeBudget(plan);
+  const sent = useMemo(() => sentFunding(plan, confirmedUtxos), [plan, confirmedUtxos]);
+  const topUp = shortfall && quote ? topUpFor(shortfall, sent, quote.feeRateSatPerVbyte) : null;
   // A resumed exit is not held to a fresh exit's price: most of what the quote
   // covers is already on-chain, and only the build knows what is really needed.
   // A fresh exit's quote is a lower bound too. Once a build has said what it
@@ -285,10 +300,9 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
   // amount there helps and only a new quote can.
   const isFunded =
     quote !== null &&
-    (isResuming
-      ? confirmedUtxos.length > 0 &&
-        (requiredFundingSat === null || (!isFeeBudgetFixed && fundedSat >= requiredFundingSat))
-      : fundedSat >= Math.max(quote.singleUtxoFundingSat, requiredFundingSat ?? 0));
+    (topUp
+      ? !isFeeBudgetFixed && topUp.stillToSendSat === 0
+      : isResuming || fundedSat >= quote.singleUtxoFundingSat);
 
   const build = useCallback(async () => {
     if (!walletKey || !quote || !fundingKey || !mnemonicRef.current) return;
@@ -335,12 +349,21 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     } catch (e) {
       logger.error(LogCategory.SDK, 'Failed to build unilateral exit', { error: message(e) });
       setBuildError(message(e));
-      setRequiredFundingSat(requiredFundingOf(message(e)));
+      const required = requiredFundingOf(message(e));
+      setShortfall(required === null ? null : { sat: required, inputs: sent.inputs });
       setPhase('fund');
     } finally {
       release();
     }
-  }, [wallet, walletKey, quote, fundingKey, confirmedUtxos, network, plan, isResuming]);
+  }, [wallet, walletKey, quote, fundingKey, confirmedUtxos, sent, network, plan, isResuming]);
+
+  // What a resumed exit already holds may pay the new rate, and only a build can
+  // tell. So it tries once, and the step asks for more only when that falls short.
+  useEffect(() => {
+    if (phase !== 'fund' || !isResuming || !quote || triedQuote.current === quote) return;
+    triedQuote.current = quote;
+    void build();
+  }, [phase, isResuming, quote, build]);
 
   // Keeps the destination and the leaves, and re-enters at the fee step: the
   // reason to rebuild by hand is almost always to pay more.
@@ -399,12 +422,14 @@ export function useUnilateralExitFlow(network: string): UnilateralExitFlow {
     funding: fundingKey && {
       address: fundingKey.address,
       requiredSat: quote?.singleUtxoFundingSat ?? 0,
-      fundedSat,
       isFunded,
       hasPendingDeposit: fundingUtxos.some(utxo => !utxo.confirmed),
       isResuming,
-      requiredFundingSat,
+      topUp,
       isFeeBudgetFixed,
+      feeRate: quote?.feeRateSatPerVbyte ?? 0,
+      currentFeeRate: plan?.feeRateSatPerVbyte ?? null,
+      quotedAt,
     },
     submitDestination,
     submitFee,

--- a/src/features/unilateral-exit/steps/FundStep.test.tsx
+++ b/src/features/unilateral-exit/steps/FundStep.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { FundStep, FundingStatus } from './FundStep';
 
 const props = {
@@ -14,6 +14,8 @@ const props = {
   currentFeeRate: null,
   quotedAt: null,
   error: null,
+  isPaying: false,
+  onTopUp: () => {},
 };
 const resumed = { ...props, isResuming: true, feeRate: 42, currentFeeRate: 24 };
 const topUp = { neededSat: 7_856, sentSat: 3_000, stillToSendSat: 4_856 };
@@ -35,23 +37,31 @@ describe('FundStep', () => {
     expect(screen.queryByText(/5 898/)).not.toBeInTheDocument();
   });
 
-  it('offers a top-up as optional, and shows how its figures add up', () => {
+  it('shows what continuing now costs before anywhere to pay, since waiting is free', () => {
+    const onTopUp = vi.fn();
     render(
       <FundStep
         {...resumed}
         topUp={topUp}
-        quotedAt={Date.now() - 90_000}
+        onTopUp={onTopUp}
         error="Insufficient CPFP funding: need at least 5000 sats"
       />,
     );
-    expect(screen.getByText('Send to Continue Exit')).toBeInTheDocument();
-    expect(screen.getByText('Network fees went up')).toBeInTheDocument();
-    expect(screen.getByText(/continues on its own once fees drop/)).toHaveTextContent(/continues it now at 42 sat\/vB/);
     expect(screen.getByText('Exit fee at 42 sat/vB')).toBeInTheDocument();
     expect(screen.getByText("You've already sent").parentElement).toHaveTextContent('−');
+    expect(screen.getByText('Network fees went up')).toBeInTheDocument();
+    expect(screen.getByText(/continues on its own once fees drop/)).toHaveTextContent(/To continue now at 42 sat\/vB/);
+    expect(screen.queryByTestId('unilateral-exit-funding-address')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Insufficient CPFP funding/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('unilateral-exit-top-up'));
+    expect(onTopUp).toHaveBeenCalled();
+  });
+
+  it('asks for the amount, with where to send it, once the user chooses to top up', () => {
+    render(<FundStep {...resumed} topUp={topUp} isPaying />);
+    expect(screen.getByText('Send to Continue Exit')).toBeInTheDocument();
     expect(screen.getAllByText(/4 856/).length).toBeGreaterThan(0);
     expect(screen.getByTestId('unilateral-exit-funding-address')).toBeInTheDocument();
-    expect(screen.queryByText(/Insufficient CPFP funding/)).not.toBeInTheDocument();
   });
 
   it('turns into the receipt once the address holds enough', () => {

--- a/src/features/unilateral-exit/steps/FundStep.test.tsx
+++ b/src/features/unilateral-exit/steps/FundStep.test.tsx
@@ -1,18 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { FundStep } from './FundStep';
+import { FundStep, FundingStatus } from './FundStep';
 
 const props = {
   address: 'bcrt1qfund',
   requiredSat: 5_898,
-  fundedSat: 0,
   isFunded: false,
   hasPendingDeposit: false,
   isResuming: false,
-  requiredFundingSat: null,
+  topUp: null,
   isFeeBudgetFixed: false,
+  feeRate: 2,
+  currentFeeRate: null,
+  quotedAt: null,
   error: null,
 };
+const resumed = { ...props, isResuming: true, feeRate: 42, currentFeeRate: 24 };
+const topUp = { neededSat: 7_856, sentSat: 3_000, stillToSendSat: 4_856 };
 
 describe('FundStep', () => {
   it('names the amount a fresh exit needs', () => {
@@ -25,39 +29,63 @@ describe('FundStep', () => {
     expect(screen.getByText(/signing failed/)).toBeInTheDocument();
   });
 
-  it('does not quote a fresh exit price to an exit already under way', () => {
-    // Most of a resumed exit is already on-chain, so the quote's figure would
-    // ask for money the remaining work does not need.
-    render(<FundStep {...props} isResuming fundedSat={3_905} isFunded />);
+  it('asks a resumed exit for nothing before its build has tried what it holds', () => {
+    render(<FundStep {...resumed} />);
+    expect(screen.queryByTestId('unilateral-exit-funding-address')).not.toBeInTheDocument();
     expect(screen.queryByText(/5 898/)).not.toBeInTheDocument();
-    expect(screen.getByText(/already at this address/i)).toBeInTheDocument();
   });
 
-  it('asks a resumed exit for the gap its build named, instead of the raw error', () => {
+  it('offers a top-up as optional, and shows how its figures add up', () => {
     render(
       <FundStep
-        {...props}
-        isResuming
-        fundedSat={3_000}
-        requiredFundingSat={5_000}
+        {...resumed}
+        topUp={topUp}
+        quotedAt={Date.now() - 90_000}
         error="Insufficient CPFP funding: need at least 5000 sats"
       />,
     );
-    expect(screen.getByText('Add to exit fee')).toBeInTheDocument();
-    expect(screen.getAllByText(/2 000/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Send to Continue Exit')).toBeInTheDocument();
+    expect(screen.getByText('Network fees went up')).toBeInTheDocument();
+    expect(screen.getByText(/continues on its own once fees drop/)).toHaveTextContent(/continues it now at 42 sat\/vB/);
+    expect(screen.getByText('Exit fee at 42 sat/vB')).toBeInTheDocument();
+    expect(screen.getByText("You've already sent").parentElement).toHaveTextContent('−');
+    expect(screen.getAllByText(/4 856/).length).toBeGreaterThan(0);
+    expect(screen.getByTestId('unilateral-exit-funding-address')).toBeInTheDocument();
     expect(screen.queryByText(/Insufficient CPFP funding/)).not.toBeInTheDocument();
   });
 
-  it('asks for a lower fee rate once the fee coins are fixed, since more money cannot help', () => {
-    render(<FundStep {...props} isResuming fundedSat={3_000} requiredFundingSat={5_000} isFeeBudgetFixed />);
-    expect(screen.getByText('This fee rate is too high')).toBeInTheDocument();
-    expect(screen.queryByText('Add to exit fee')).not.toBeInTheDocument();
+  it('turns into the receipt once the address holds enough', () => {
+    render(<FundStep {...resumed} topUp={{ ...topUp, sentSat: 7_856, stillToSendSat: 0 }} isFunded />);
+    expect(screen.getByText('Exit fee received')).toBeInTheDocument();
+    expect(screen.queryByTestId('unilateral-exit-funding-address')).not.toBeInTheDocument();
+    expect(screen.queryByText('Still to send')).not.toBeInTheDocument();
+  });
+
+  it('points to a lower rate once the fee coins are fixed, since more money cannot help', () => {
+    render(<FundStep {...resumed} topUp={topUp} isFeeBudgetFixed />);
+    expect(screen.getByText(/sending more cannot raise it/)).toBeInTheDocument();
+    expect(screen.queryByTestId('unilateral-exit-funding-address')).not.toBeInTheDocument();
   });
 
   it('asks a fresh exit for the gap too, since its quote is only a lower bound', () => {
-    render(<FundStep {...props} fundedSat={5_898} requiredFundingSat={6_100} error="Insufficient CPFP funding: need at least 6100 sats" />);
-    expect(screen.getByText('Add to exit fee')).toBeInTheDocument();
-    expect(screen.getAllByText(/202/).length).toBeGreaterThan(0);
+    render(<FundStep {...props} topUp={{ neededSat: 6_236, sentSat: 5_898, stillToSendSat: 338 }} />);
+    expect(screen.getByText('Send to Exit Spark')).toBeInTheDocument();
+    expect(screen.getByText('The exit needs more')).toBeInTheDocument();
+    expect(screen.queryByText(/fees went up/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/338/).length).toBeGreaterThan(0);
     expect(screen.getByTestId('unilateral-exit-funding-address')).toBeInTheDocument();
   });
+});
+
+describe('FundingStatus', () => {
+  it('says how old the quote is while it waits', () => {
+    render(<FundingStatus {...resumed} quotedAt={Date.now() - 90_000} />);
+    expect(screen.getByTestId('unilateral-exit-funding-status')).toHaveTextContent('Watching the address · quoted 1m ago');
+  });
+
+  it("does not call the exit's own unconfirmed transactions a deposit", () => {
+    render(<FundingStatus {...resumed} hasPendingDeposit />);
+    expect(screen.getByTestId('unilateral-exit-funding-status')).toHaveTextContent('Watching the address');
+  });
+
 });

--- a/src/features/unilateral-exit/steps/FundStep.tsx
+++ b/src/features/unilateral-exit/steps/FundStep.tsx
@@ -1,126 +1,186 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { AlertCard } from '@/components/AlertCard';
+import { FeeBreakdownCard } from '@/components/FeeBreakdownCard';
 import { CopyableText, ErrorMessageBox, QRCodeContainer } from '@/components/ui';
 import { SatAmount } from '@/components/SatAmount';
 import { CheckIcon, ClockIcon } from '@/components/Icons';
 import { useToast } from '@/contexts/ToastContext';
 import type { FundingFields } from '../hooks/useUnilateralExitFlow';
 
+const QUOTE_AGE_TICK_MS = 30_000;
+
+const quoteAge = (quotedAt: number): string => {
+  const minutes = Math.floor((Date.now() - quotedAt) / 60_000);
+  if (minutes < 1) return 'quoted just now';
+  return minutes < 60 ? `quoted ${minutes}m ago` : `quoted ${Math.floor(minutes / 60)}h ago`;
+};
+
+/** A top-up still waiting for coins. The page keeps it by the action, where it stays on screen as it changes. */
+export const FundingStatus: React.FC<
+  Pick<FundingFields, 'isResuming' | 'hasPendingDeposit' | 'quotedAt'>
+> = ({ isResuming, hasPendingDeposit, quotedAt }) => {
+  // The quote's age is the one figure here that goes stale on its own.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setTick(tick => tick + 1), QUOTE_AGE_TICK_MS);
+    return () => clearInterval(timer);
+  }, []);
+  return (
+    <div className="flex items-center justify-center gap-2" data-testid="unilateral-exit-funding-status">
+      <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-spark-warning animate-pulse" />
+      <p className="text-sm text-spark-text-secondary">
+        {/* The exit's own unconfirmed transactions pay this address too, so
+            only a fresh exit can tell a pending deposit apart. */}
+        {!isResuming && hasPendingDeposit ? 'Waiting for a confirmation' : 'Watching the address'}
+        {quotedAt !== null && ` · ${quoteAge(quotedAt)}`}
+      </p>
+    </div>
+  );
+};
+
 export const FundStep: React.FC<FundingFields & { error: string | null }> = ({
   address,
   requiredSat,
-  fundedSat,
   isFunded,
   hasPendingDeposit,
   isResuming,
-  requiredFundingSat,
+  topUp,
   isFeeBudgetFixed,
+  feeRate,
+  currentFeeRate,
   error,
 }) => {
   const { showToast } = useToast();
-  // After a build names what it needs, the address is asked only for the gap.
-  const shortfallSat =
-    requiredFundingSat !== null ? Math.max(0, requiredFundingSat - fundedSat) : 0;
-  const askSat = shortfallSat > 0 ? shortfallSat : isResuming ? 0 : requiredSat;
+
+  const askSat = topUp ? topUp.stillToSendSat : isResuming ? 0 : requiredSat;
   // BIP21 so the paying wallet fills the amount in as well as the address:
   // this is money sent from somewhere else, and the figure has to be exact.
   const btc = (askSat / 100_000_000).toFixed(8).replace(/0+$/, '').replace(/\.$/, '');
   const qrValue = askSat > 0 ? `bitcoin:${address}?amount=${btc}` : address;
+  const feesRose = isResuming && currentFeeRate !== null && feeRate > currentFeeRate;
 
-  if (isResuming && requiredFundingSat !== null && isFeeBudgetFixed) {
+  if (topUp && isFeeBudgetFixed) {
     return (
-      <AlertCard variant="warning" title="This fee rate is too high">
+      <AlertCard variant="warning" title="Network fees went up">
         <p className="text-sm">
-          The rest of this exit cannot pay it. Go back and choose a lower fee rate.
+          Your exit started at {currentFeeRate} sat/vB, and its fee is fixed now, so sending more
+          cannot raise it. It continues on its own once fees drop, or you can go back and choose a
+          lower rate.
         </p>
       </AlertCard>
     );
   }
-  // A resumed exit can still be asked for more, so it keeps the paying view
-  // even once the original fee is in.
-  const isPaid = isFunded && !isResuming;
 
-  return (
-  <div className="space-y-4">
-    {isPaid ? (
-      // The send flow's result shape: an instruction to pay reads as wrong
-      // once it is paid, so the step becomes the receipt instead.
-      <div className="py-6 flex flex-col items-center">
-        <div className="relative mb-4">
-          <div className="absolute inset-0 w-20 h-20 rounded-full blur-xl bg-spark-success/30" />
-          <div className="relative w-20 h-20 rounded-full flex items-center justify-center bg-spark-success/20 border-2 border-spark-success">
-            <CheckIcon className="w-10 h-10 text-spark-success" />
-          </div>
-        </div>
-        <h3 className="font-display text-xl font-bold text-spark-text-primary">Exit fee received</h3>
-      </div>
+  // A resumed exit tries its build before asking for anything, so without a
+  // top-up there is nothing to pay here: only a failure to explain.
+  if (isResuming && !topUp) {
+    return error ? (
+      <ErrorMessageBox title="Could not continue the exit" error={error} />
     ) : (
-      <>
+      <p className="text-sm text-spark-text-secondary text-center">
+        Continue the exit at {feeRate} sat/vB.
+      </p>
+    );
+  }
+
+  const paymentTarget = (
+    // The same control the receive sheet gives a bitcoin address, so the
+    // address copies and shares rather than sitting in a row of its own.
+    <div className="flex flex-col items-center gap-4">
+      {/* Sized so the copy and share controls stay on screen with it: this
+          is the one screen that exists to copy an address, and at 180 they
+          fell below the sheet's fold on a phone. Still above what a camera
+          needs at 3x. */}
+      <QRCodeContainer value={qrValue} size={130} />
+      <CopyableText
+        text={address}
+        truncate
+        showShare
+        label="Exit fee address"
+        onCopied={() => showToast('success', 'Copied!')}
+        onShareError={() => showToast('error', 'Failed to share')}
+        data-testid="unilateral-exit-funding-address"
+      />
+    </div>
+  );
+
+  // The send flow's result shape: an instruction to pay reads as wrong once it
+  // is paid, so the step becomes the receipt instead.
+  const receipt = (
+    <div className="py-6 flex flex-col items-center">
+      <div className="relative mb-4">
+        <div className="absolute inset-0 w-20 h-20 rounded-full blur-xl bg-spark-success/30" />
+        <div className="relative w-20 h-20 rounded-full flex items-center justify-center bg-spark-success/20 border-2 border-spark-success">
+          <CheckIcon className="w-10 h-10 text-spark-success" />
+        </div>
+      </div>
+      <h3 className="font-display text-xl font-bold text-spark-text-primary">Exit fee received</h3>
+    </div>
+  );
+
+  if (topUp) {
+    if (topUp.stillToSendSat === 0) return receipt;
+    return (
+      <div className="space-y-4">
         <div className="text-center py-2">
           <p className="text-spark-text-muted text-sm mb-2">
-            {shortfallSat > 0 ? 'Add to exit fee' : 'Pay exit fee'}
+            {isResuming ? 'Send to Continue Exit' : 'Send to Exit Spark'}
           </p>
-          <SatAmount
-            sats={shortfallSat > 0 ? shortfallSat : isResuming ? fundedSat : requiredSat}
-            className="text-4xl font-bold text-spark-text-primary"
-          />
+          <SatAmount sats={topUp.stillToSendSat} className="text-4xl font-bold text-spark-text-primary" />
         </div>
 
-        {/* The same control the receive sheet gives a bitcoin address, so the
-            address copies and shares rather than sitting in a row of its own. */}
-        <div className="flex flex-col items-center gap-4">
-          {/* Sized so the copy and share controls stay on screen with it: this
-              is the one screen that exists to copy an address, and at 180 they
-              fell below the sheet's fold on a phone. Still above what a camera
-              needs at 3x. */}
-          <QRCodeContainer value={qrValue} size={130} />
-          <CopyableText
-            text={address}
-            truncate
-            showShare
-            label="Exit fee address"
-            onCopied={() => showToast('success', 'Copied!')}
-            onShareError={() => showToast('error', 'Failed to share')}
-            data-testid="unilateral-exit-funding-address"
-          />
-        </div>
+        {paymentTarget}
 
-        <div className="flex items-center justify-center gap-2">
-          {isFunded ? (
-            <CheckIcon className="shrink-0 text-spark-success" />
-          ) : (
+        <FeeBreakdownCard
+          items={[
+            { label: `Exit fee at ${feeRate} sat/vB`, value: topUp.neededSat },
+            { label: "You've already sent", value: topUp.sentSat, subtract: true },
+            { label: 'Still to send', value: topUp.stillToSendSat, highlight: true },
+          ]}
+        />
+
+        {feesRose ? (
+          <AlertCard variant="warning" title="Network fees went up">
+            <p className="text-sm">
+              Your exit started at {currentFeeRate} sat/vB and continues on its own once fees drop, but
+              they can also keep rising. Sending the amount above continues it now at {feeRate} sat/vB.
+            </p>
+          </AlertCard>
+        ) : (
+          <AlertCard variant="warning" title="The exit needs more">
+            <p className="text-sm">
+              At {feeRate} sat/vB, building the exit takes more than its quote. Sending the amount above
+              starts it.
+            </p>
+          </AlertCard>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {isFunded ? (
+        receipt
+      ) : (
+        <>
+          <div className="text-center py-2">
+            <p className="text-spark-text-muted text-sm mb-2">Pay exit fee</p>
+            <SatAmount sats={requiredSat} className="text-4xl font-bold text-spark-text-primary" />
+          </div>
+
+          {paymentTarget}
+
+          <div className="flex items-center justify-center gap-2">
             <ClockIcon className="shrink-0 text-spark-primary" />
-          )}
-          <p className="text-sm text-spark-text-secondary">
-            {isFunded
-              ? 'Exit fee received'
-              : hasPendingDeposit
-                ? 'Waiting for a confirmation'
-                : 'Waiting for your deposit'}
-          </p>
-        </div>
-      </>
-    )}
+            <p className="text-sm text-spark-text-secondary">
+              {hasPendingDeposit ? 'Waiting for a confirmation' : 'Waiting for your deposit'}
+            </p>
+          </div>
+        </>
+      )}
 
-    {/* A shortfall is the amount above, so its raw message would only repeat it. */}
-    {error && requiredFundingSat === null && (
-      <ErrorMessageBox title="Could not build the exit" error={error} />
-    )}
-
-    {requiredFundingSat !== null ? (
-      <p className="text-spark-text-muted text-xs">
-        At this fee rate the exit needs <SatAmount sats={requiredFundingSat} /> at this address, and
-        it holds <SatAmount sats={fundedSat} />.
-      </p>
-    ) : (
-      isResuming && (
-        <p className="text-spark-text-muted text-xs">
-          This exit is part-way done, and what it has left is paid for by the{' '}
-          <SatAmount sats={fundedSat} /> already at this address.
-        </p>
-      )
-    )}
-
-  </div>
+      {error && <ErrorMessageBox title="Could not build the exit" error={error} />}
+    </div>
   );
 };

--- a/src/features/unilateral-exit/steps/FundStep.tsx
+++ b/src/features/unilateral-exit/steps/FundStep.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { AlertCard } from '@/components/AlertCard';
 import { FeeBreakdownCard } from '@/components/FeeBreakdownCard';
-import { CopyableText, ErrorMessageBox, QRCodeContainer } from '@/components/ui';
+import { CopyableText, ErrorMessageBox, PrimaryButton, QRCodeContainer } from '@/components/ui';
 import { SatAmount } from '@/components/SatAmount';
 import { CheckIcon, ClockIcon } from '@/components/Icons';
 import { useToast } from '@/contexts/ToastContext';
@@ -38,7 +38,14 @@ export const FundingStatus: React.FC<
   );
 };
 
-export const FundStep: React.FC<FundingFields & { error: string | null }> = ({
+export const FundStep: React.FC<
+  FundingFields & {
+    error: string | null;
+    /** A resumed exit's top-up opens on what it costs, and shows where to pay once asked. */
+    isPaying: boolean;
+    onTopUp: () => void;
+  }
+> = ({
   address,
   requiredSat,
   isFunded,
@@ -49,6 +56,8 @@ export const FundStep: React.FC<FundingFields & { error: string | null }> = ({
   feeRate,
   currentFeeRate,
   error,
+  isPaying,
+  onTopUp,
 }) => {
   const { showToast } = useToast();
 
@@ -120,40 +129,65 @@ export const FundStep: React.FC<FundingFields & { error: string | null }> = ({
 
   if (topUp) {
     if (topUp.stillToSendSat === 0) return receipt;
+    const breakdown = (
+      <FeeBreakdownCard
+        items={[
+          { label: `Exit fee at ${feeRate} sat/vB`, value: topUp.neededSat },
+          { label: "You've already sent", value: topUp.sentSat, subtract: true },
+          { label: 'Still to send', value: topUp.stillToSendSat, highlight: true },
+        ]}
+      />
+    );
+    const ask = (label: string) => (
+      <div className="text-center py-2">
+        <p className="text-spark-text-muted text-sm mb-2">{label}</p>
+        <SatAmount sats={topUp.stillToSendSat} className="text-4xl font-bold text-spark-text-primary" />
+      </div>
+    );
+
+    // Waiting costs nothing, so a resumed exit shows what continuing now costs
+    // before it shows anywhere to pay.
+    if (isResuming && !isPaying) {
+      return (
+        <div className="space-y-4">
+          {breakdown}
+          <AlertCard variant="warning" title={feesRose ? 'Network fees went up' : 'The exit needs more'}>
+            <p className="text-sm">
+              {feesRose
+                ? `Your exit started at ${currentFeeRate} sat/vB and continues on its own once fees drop, but they can also keep rising. To continue now at ${feeRate} sat/vB, top up the exit fee address.`
+                : `At ${feeRate} sat/vB, the exit needs more at its fee address.`}
+            </p>
+            <div className="mt-3">
+              <PrimaryButton onClick={onTopUp} className="w-full" data-testid="unilateral-exit-top-up">
+                Top Up to Continue
+              </PrimaryButton>
+            </div>
+          </AlertCard>
+        </div>
+      );
+    }
+
+    if (isResuming) {
+      return (
+        <div className="space-y-4">
+          {ask('Send to Continue Exit')}
+          {paymentTarget}
+        </div>
+      );
+    }
+
+    // A fresh exit cannot start without it, so there is no choice to make first.
     return (
       <div className="space-y-4">
-        <div className="text-center py-2">
-          <p className="text-spark-text-muted text-sm mb-2">
-            {isResuming ? 'Send to Continue Exit' : 'Send to Exit Spark'}
-          </p>
-          <SatAmount sats={topUp.stillToSendSat} className="text-4xl font-bold text-spark-text-primary" />
-        </div>
-
+        {ask('Send to Exit Spark')}
         {paymentTarget}
-
-        <FeeBreakdownCard
-          items={[
-            { label: `Exit fee at ${feeRate} sat/vB`, value: topUp.neededSat },
-            { label: "You've already sent", value: topUp.sentSat, subtract: true },
-            { label: 'Still to send', value: topUp.stillToSendSat, highlight: true },
-          ]}
-        />
-
-        {feesRose ? (
-          <AlertCard variant="warning" title="Network fees went up">
-            <p className="text-sm">
-              Your exit started at {currentFeeRate} sat/vB and continues on its own once fees drop, but
-              they can also keep rising. Sending the amount above continues it now at {feeRate} sat/vB.
-            </p>
-          </AlertCard>
-        ) : (
-          <AlertCard variant="warning" title="The exit needs more">
-            <p className="text-sm">
-              At {feeRate} sat/vB, building the exit takes more than its quote. Sending the amount above
-              starts it.
-            </p>
-          </AlertCard>
-        )}
+        {breakdown}
+        <AlertCard variant="warning" title="The exit needs more">
+          <p className="text-sm">
+            At {feeRate} sat/vB, building the exit takes more than its quote. Sending the amount above
+            starts it.
+          </p>
+        </AlertCard>
       </div>
     );
   }

--- a/src/pages/UnilateralExitPage.tsx
+++ b/src/pages/UnilateralExitPage.tsx
@@ -110,11 +110,19 @@ const UnilateralExitPage: React.FC<UnilateralExitPageProps> = ({ network, onBack
           </PrimaryButton>
         );
       case 'fund':
+      case 'topUp': {
+        const funding = flow.funding;
+        const isWaiting = !!funding?.topUp && funding.topUp.stillToSendSat > 0;
+        // A resumed exit's top-up starts from the box that explains it, and one
+        // its fee coins cannot pay has no action here at all.
+        if (funding?.isResuming && funding.topUp && (funding.isFeeBudgetFixed || (flow.phase === 'fund' && isWaiting))) {
+          return null;
+        }
         return (
           <>
-            {flow.funding?.topUp && !flow.funding.isFeeBudgetFixed && flow.funding.topUp.stillToSendSat > 0 && (
+            {funding && isWaiting && !funding.isFeeBudgetFixed && (
               <div className="mb-4">
-                <FundingStatus {...flow.funding} />
+                <FundingStatus {...funding} />
               </div>
             )}
             <PrimaryButton
@@ -127,6 +135,7 @@ const UnilateralExitPage: React.FC<UnilateralExitPageProps> = ({ network, onBack
             </PrimaryButton>
           </>
         );
+      }
       default:
         return null;
     }
@@ -183,8 +192,13 @@ const UnilateralExitPage: React.FC<UnilateralExitPageProps> = ({ network, onBack
               </>
             )}
 
-            {flow.phase === 'fund' && flow.funding && (
-              <FundStep {...flow.funding} error={flow.buildError} />
+            {(flow.phase === 'fund' || flow.phase === 'topUp') && flow.funding && (
+              <FundStep
+                {...flow.funding}
+                error={flow.buildError}
+                isPaying={flow.phase === 'topUp'}
+                onTopUp={() => flow.goTo('topUp')}
+              />
             )}
 
             {flow.phase === 'building' && (

--- a/src/pages/UnilateralExitPage.tsx
+++ b/src/pages/UnilateralExitPage.tsx
@@ -16,7 +16,7 @@ import { IntroStep } from '@/features/unilateral-exit/steps/IntroStep';
 import { DestinationStep } from '@/features/unilateral-exit/steps/DestinationStep';
 import { FeeStep } from '@/features/unilateral-exit/steps/FeeStep';
 import { QuoteStep } from '@/features/unilateral-exit/steps/QuoteStep';
-import { FundStep } from '@/features/unilateral-exit/steps/FundStep';
+import { FundStep, FundingStatus } from '@/features/unilateral-exit/steps/FundStep';
 import { TrackerView } from '@/features/unilateral-exit/TrackerView';
 import { sweepTxid } from '@/features/unilateral-exit/archive';
 
@@ -111,14 +111,21 @@ const UnilateralExitPage: React.FC<UnilateralExitPageProps> = ({ network, onBack
         );
       case 'fund':
         return (
-          <PrimaryButton
+          <>
+            {flow.funding?.topUp && !flow.funding.isFeeBudgetFixed && flow.funding.topUp.stillToSendSat > 0 && (
+              <div className="mb-4">
+                <FundingStatus {...flow.funding} />
+              </div>
+            )}
+            <PrimaryButton
             onClick={() => void flow.build()}
             disabled={!flow.funding?.isFunded}
             className="w-full"
             data-testid="unilateral-exit-build"
           >
-            Exit Spark
-          </PrimaryButton>
+            {flow.funding?.isResuming ? 'Continue Exit' : 'Exit Spark'}
+            </PrimaryButton>
+          </>
         );
       default:
         return null;


### PR DESCRIPTION
**Note:** This PR is on top of #412.

This PR reworks the exit fee top-up after "Rebuild at a higher fee".

- **No blind deposit:** the screen showed "Pay exit fee ₿0" and kept the button disabled until the user sent some amount. Glow now tries the rebuild with what the exit already has, and asks for more only when it needs it.
- **Right amount:** the ask left out the exit fee the user already sent, and the fee to spend the new coin. It now asks for what is missing, and one top-up is enough.
- **Optional top-up:** the first screen shows what continuing now costs, and says the exit continues on its own once fees drop. "Top Up to Continue" opens a second screen with the amount and the QR code.
- **Smaller fixes:**
  - The button says "Continue Exit" for an exit that is under way.
  - The payment screen shows how old the quote is.
  - Once enough arrives, the screen shows the same receipt as the first payment.
  - A new exit whose build needs more than its quote shows the same breakdown.

<img width="33%" height="2622" alt="image" src="https://github.com/user-attachments/assets/ad82e610-ba4b-493e-96e3-80b1b8f39403" />
<img width="33%" height="2622" alt="image" src="https://github.com/user-attachments/assets/aa1233f1-e334-4fca-9746-d76461995419" />
<img width="33%" height="2622" alt="image" src="https://github.com/user-attachments/assets/33eba2d6-a4c9-4141-ba5f-79da7afc0b3a" />
