### PR TITLE
feat: move USD receive into the Bitcoin tab

### DIFF
--- a/src/features/receive/BitcoinAddressDisplay.tsx
+++ b/src/features/receive/BitcoinAddressDisplay.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import LoadingSpinner from '../../components/LoadingSpinner';
-import { QRCodeContainer, CopyableText } from '../../components/ui';
+import { QRCodeContainer, CopyableText, TextButton } from '../../components/ui';
 import { useToast } from '../../contexts/ToastContext';
 
 interface Props {
   address: string | null;
   isLoading: boolean;
+  /** Opens the USDC/USDT request sheet. Absent while that flow is gated off. */
+  onReceiveUsd?: () => void;
 }
 
-const BitcoinAddressDisplay: React.FC<Props> = ({ address, isLoading }) => {
+const BitcoinAddressDisplay: React.FC<Props> = ({ address, isLoading, onReceiveUsd }) => {
   const { showToast } = useToast();
 
   if (isLoading || !address) {
@@ -34,8 +36,14 @@ const BitcoinAddressDisplay: React.FC<Props> = ({ address, isLoading }) => {
           data-testid="bitcoin-address-text"
         />
 
-        {/* Spacer to match Lightning tab height */}
-        <div className="mt-2 h-6" aria-hidden="true" />
+        {onReceiveUsd ? (
+          <TextButton onClick={onReceiveUsd} className="mt-2 mb-[0.75em] cursor-pointer" data-testid="receive-usd-button">
+            Create USD request →
+          </TextButton>
+        ) : (
+          // Spacer to match Lightning tab height
+          <div className="mt-2 h-6" aria-hidden="true" />
+        )}
       </div>
     </div>
   );

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -164,15 +164,16 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
   };
 
   // Gated on the dev-only "Receive USD" toggle (cross-chain send is always-on
-  // upstream; the receive flow is still being polished).
-  const showUsdTab = isCrossChainEnabled();
+  // upstream; the receive flow is still being polished). The flow opens from
+  // the Bitcoin tab: both are onchain deposits, so they share one tab.
+  const showUsdReceive = isCrossChainEnabled();
+  const [showUsdRequest, setShowUsdRequest] = useState(false);
 
   const getQRTitle = () => {
     switch (receive.activeTab) {
       case 'lightning': return 'Lightning Invoice';
       case 'spark': return 'Spark Address';
       case 'bitcoin': return 'Bitcoin Address';
-      case 'usd': return 'USD Transfer';
       default: return 'Payment Request';
     }
   };
@@ -207,68 +208,57 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
                   <span className="font-bold text-sm">₿</span>
                   Bitcoin
                 </Tab>
-                {showUsdTab && (
-                  <Tab isActive={receive.activeTab === 'usd'} onClick={() => handleTabChange('usd')} data-testid="usd-tab">
-                    <span className="font-bold text-sm">$</span>
-                    USD
-                  </Tab>
-                )}
               </TabList>
 
-              {/* The USD tab sits outside StepContainer: its steps size to their
-                  own content (matching the cross-chain send flow), so the 280px
-                  floor would pad the short ones out with dead space. */}
-              {receive.activeTab === 'usd' ? (
-                <CrossChainReceiveWorkflow key={`usd-${receive.resetCount}`} />
-              ) : (
-                <StepContainer>
-                  <>
-                    {receive.currentStep === 'input' && (
-                      <div className="pt-6">
-                        {receive.activeTab === 'lightning' && (
-                          <LightningAddressDisplay
-                            address={lightningAddress}
-                            isLoading={lightningAddressLoading}
-                            isEditing={isEditingLightningAddress}
-                            editValue={lightningAddressEditValue}
-                            error={lightningAddressError}
-                            isSupported={isLightningAddressSupported}
-                            supportMessage={lightningAddressSupportMessage}
-                            onEdit={() => beginEditLightningAddress(lightningAddress)}
-                            onSave={handleSaveLightningAddress}
-                            onCancel={() => cancelEditLightningAddress()}
-                            onEditValueChange={setLightningAddressEditValue}
-                            onCustomizeAmount={() => receive.setShowAmountPanel(true)}
-                          />
-                        )}
-
-                        {receive.activeTab === 'spark' && (
-                          <SparkAddressDisplay address={receive.sparkAddress} isLoading={receive.sparkLoading} />
-                        )}
-
-                        {receive.activeTab === 'bitcoin' && (
-                          <BitcoinAddressDisplay address={receive.bitcoinAddress} isLoading={receive.bitcoinLoading} />
-                        )}
-                      </div>
-                    )}
-
-                    {receive.currentStep === 'loading' && (
-                      <div className="flex flex-col items-center justify-center h-40" data-testid="invoice-generation-loading">
-                        <LoadingSpinner text={`Generating ${getQRTitle().toLowerCase()}...`} />
-                      </div>
-                    )}
-
-                    {receive.currentStep === 'qr' && (
-                      <QRCodeDisplay
-                        paymentData={receive.paymentData}
-                        feeSats={receive.feeSats}
-                        title={getQRTitle()}
-                        description={getQRDescription()}
+              <StepContainer>
+                {receive.currentStep === 'input' && (
+                  <div className="pt-6">
+                    {receive.activeTab === 'lightning' && (
+                      <LightningAddressDisplay
+                        address={lightningAddress}
+                        isLoading={lightningAddressLoading}
+                        isEditing={isEditingLightningAddress}
+                        editValue={lightningAddressEditValue}
+                        error={lightningAddressError}
+                        isSupported={isLightningAddressSupported}
+                        supportMessage={lightningAddressSupportMessage}
+                        onEdit={() => beginEditLightningAddress(lightningAddress)}
+                        onSave={handleSaveLightningAddress}
+                        onCancel={() => cancelEditLightningAddress()}
+                        onEditValueChange={setLightningAddressEditValue}
+                        onCustomizeAmount={() => receive.setShowAmountPanel(true)}
                       />
                     )}
-                  </>
-                </StepContainer>
-              )}
+
+                    {receive.activeTab === 'spark' && (
+                      <SparkAddressDisplay address={receive.sparkAddress} isLoading={receive.sparkLoading} />
+                    )}
+
+                    {receive.activeTab === 'bitcoin' && (
+                      <BitcoinAddressDisplay
+                        address={receive.bitcoinAddress}
+                        isLoading={receive.bitcoinLoading}
+                        onReceiveUsd={showUsdReceive ? () => setShowUsdRequest(true) : undefined}
+                      />
+                    )}
+                  </div>
+                )}
+
+                {receive.currentStep === 'loading' && (
+                  <div className="flex flex-col items-center justify-center h-40" data-testid="invoice-generation-loading">
+                    <LoadingSpinner text={`Generating ${getQRTitle().toLowerCase()}...`} />
+                  </div>
+                )}
+
+                {receive.currentStep === 'qr' && (
+                  <QRCodeDisplay
+                    paymentData={receive.paymentData}
+                    feeSats={receive.feeSats}
+                    title={getQRTitle()}
+                    description={getQRDescription()}
+                  />
+                )}
+              </StepContainer>
             </TabContainer>
           ) : lightningAddress ? (
             // Placeholder matched to the Lightning-tab QR view when
@@ -325,6 +315,17 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
         onClose={receive.closeAmountPanel}
         resetCount={receive.resetCount}
       />
+
+      <BottomSheetContainer isOpen={isOpen && showUsdRequest} onClose={() => setShowUsdRequest(false)} showBackdrop>
+        <BottomSheetCard>
+          <DialogHeader
+            title="Receive USD"
+            onClose={() => setShowUsdRequest(false)}
+            icon={<ArrowDownIcon />}
+          />
+          <CrossChainReceiveWorkflow />
+        </BottomSheetCard>
+      </BottomSheetContainer>
     </>
   );
 };

--- a/src/features/receive/hooks/useReceivePayment.ts
+++ b/src/features/receive/hooks/useReceivePayment.ts
@@ -226,7 +226,6 @@ export function useReceivePayment(): UseReceivePaymentReturn {
     } else if (tab === 'bitcoin') {
       generateBitcoinAddress();
     }
-    // 'usd' needs no kickoff here — CrossChainReceiveWorkflow owns its own route fetching.
   }, [generateSparkAddress, generateBitcoinAddress]);
 
   return {

--- a/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
+++ b/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
@@ -227,11 +227,10 @@ const CrossChainReceiveWorkflow: React.FC = () => {
   };
 
   // Steps are content-sized: the sheet re-measures and re-snaps per step, so a
-  // short step is not padded out to the tallest one. `pt-6` is the step padding
-  // the other receive tabs use. The selection lists cap themselves against the
-  // viewport (see CrossChainAssetStep) rather than against this container.
+  // short step is not padded out to the tallest one. The selection lists cap
+  // themselves against the viewport (see CrossChainAssetStep).
   return (
-    <div className="pt-6">
+    <>
       {/* Step 1: Amount */}
       {step === 'amount' && (
         <div>
@@ -252,7 +251,6 @@ const CrossChainReceiveWorkflow: React.FC = () => {
               placeholder="Enter amount in USD"
               className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20 transition-all"
               data-testid="cross-chain-receive-amount-input"
-              autoFocus
             />
 
             {/* Quick amount buttons */}
@@ -407,7 +405,7 @@ const CrossChainReceiveWorkflow: React.FC = () => {
           )}
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -3,7 +3,7 @@
 import { InputType } from "@breeztech/breez-sdk-spark/bundler";
 
 // Supported receive tabs / methods in Receive dialog
-export type PaymentMethod = 'lightning' | 'spark' | 'bitcoin' | 'usd';
+export type PaymentMethod = 'lightning' | 'spark' | 'bitcoin';
 
 // Steps for the Receive dialog
 export type ReceiveStep = 'input' | 'qr' | 'loading';


### PR DESCRIPTION
This PR moves USD receive into the Bitcoin tab, so the receive sheet has two tabs instead of three.

- **Bitcoin tab:** A "Create USD request" link opens a "Receive USD" sheet, the same way the Lightning tab opens an invoice for a specific amount.
- **Dev setting:** USD receive is still available only when the dev-only "Receive USD" setting is on. When it is off, the Bitcoin tab does not change.

| Bitcoin tab | Receive USD |
|---|---|
| <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/45db5a5f-8429-4412-8b54-00fe96b900d2" /> | <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/9b44535c-c189-4ed5-81ce-73c5a8f30dce" /> |
