### PR TITLE
fix: pay unified QR codes over Lightning instead of on-chain

### DIFF
--- a/src/features/send/hooks/useSendPayment.test.tsx
+++ b/src/features/send/hooks/useSendPayment.test.tsx
@@ -66,4 +66,24 @@ describe('processInput destinations', () => {
       ),
     );
   });
+
+  const onchain = { type: 'bitcoinAddress', address: 'bc1qtest' };
+  const spark = { type: 'sparkAddress', address: 'sp1test' };
+
+  it.each([
+    { rail: 'Lightning', methods: [onchain, spark, bolt11Details(BOLT11)], paid: BOLT11 },
+    { rail: 'on-chain', methods: [spark, onchain], paid: 'bc1qtest' },
+  ])('pays a unified BIP21 over $rail whatever order the parser lists it in', async ({ methods, paid }) => {
+    const { client, result } = renderSendPayment(
+      async (uri) => ({ type: 'bip21', uri, amountSat: 1000, paymentMethods: methods }) as unknown as InputType,
+    );
+
+    await act(() => result.current.processInput('bitcoin:bc1qtest?amount=0.00001'));
+
+    await waitFor(() =>
+      expect(client.prepareSendPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentRequest: { type: 'input', input: paid } }),
+      ),
+    );
+  });
 });

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -155,9 +155,13 @@ export function useSendPayment(): UseSendPaymentReturn {
       let effective = parseResult;
       let prefillAmountSat: number | undefined;
       if (parseResult.type === 'bip21') {
-        const method = parseResult.paymentMethods.find(
-          (m) => m.type === 'bitcoinAddress' || m.type === 'sparkAddress' || m.type === 'bolt11Invoice',
-        );
+        // Parser order is not a preference (the address always comes first).
+        // Lightning wins, and Bolt11Workflow still settles it over Spark when
+        // the invoice allows. A bare Spark address ranks last, below on-chain,
+        // since Glow does not surface Spark to users.
+        const method = (['bolt11Invoice', 'bitcoinAddress', 'sparkAddress'] as const)
+          .map((type) => parseResult.paymentMethods.find((m) => m.type === type))
+          .find(Boolean);
         if (!method) {
           setError('Invalid payment destination');
           setCurrentStep('input');


### PR DESCRIPTION
This PR makes Glow pay unified QR codes (an on-chain address plus a Lightning invoice) over Lightning instead of on-chain.

### Changes
- Prefer the Lightning invoice in a unified QR, then the on-chain address, then a Spark address.
- Add unit tests for the ranking, whatever order the QR lists the methods in.

### Test plan
- Scan a unified QR from another app and confirm Glow pays it over Lightning.
- Scan a plain on-chain QR and confirm Glow still pays it on-chain.
