### PR TITLE
feat: move sheet Back buttons into the header arrow

### DIFF
--- a/src/components/FeeRateSelector.tsx
+++ b/src/components/FeeRateSelector.tsx
@@ -1,0 +1,43 @@
+import React, { type ReactNode } from 'react';
+import { RadioCheckIcon } from './Icons';
+
+export type FeeSpeed = 'slow' | 'medium' | 'fast';
+
+const SPEEDS: { key: FeeSpeed; label: string }[] = [
+  { key: 'slow', label: 'Slow' },
+  { key: 'medium', label: 'Medium' },
+  { key: 'fast', label: 'Fast' },
+];
+
+/**
+ * Slow, Medium and Fast as three cards, `detail` giving each one's second line.
+ * The selected ring is inset: an outer one is clipped by any scrolling ancestor.
+ */
+export const FeeRateSelector: React.FC<{
+  selected: FeeSpeed | null;
+  onSelect: (speed: FeeSpeed) => void;
+  detail: (speed: FeeSpeed) => ReactNode;
+}> = ({ selected, onSelect, detail }) => (
+  <div>
+    <span className="block text-sm font-medium text-spark-text-primary mb-2">Select Fee Rate</span>
+    <div className="flex gap-2">
+      {SPEEDS.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onSelect(key)}
+          aria-pressed={selected === key}
+          className={`relative flex-1 p-3 rounded-lg border text-sm font-medium transition-colors ${
+            selected === key
+              ? 'bg-spark-primary/15 text-spark-text-primary border-spark-primary inset-ring-2 inset-ring-spark-primary'
+              : 'bg-spark-dark text-spark-text-secondary border-spark-border-light hover:border-spark-primary'
+          }`}
+        >
+          {selected === key && <RadioCheckIcon className="absolute top-2 right-2" />}
+          <div>{label}</div>
+          <div className="text-xs opacity-70">{detail(key)}</div>
+        </button>
+      ))}
+    </div>
+  </div>
+);

--- a/src/components/crossChain/CrossChainAssetStep.tsx
+++ b/src/components/crossChain/CrossChainAssetStep.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useSheetFullSnap } from '../ui/sheets/BottomSheetCardContext';
-import { PrimaryButton, SecondaryButton } from '../ui';
+import { useSheetBack, useSheetFullSnap } from '../ui/sheets/BottomSheetCardContext';
+import { PrimaryButton } from '../ui';
 import CryptoIcon from '../CryptoIcon';
 import { crossChainCardClass } from '../../utils/crossChainRoutes';
 
@@ -25,6 +25,7 @@ export const CrossChainAssetStep: React.FC<CrossChainAssetStepProps> = ({
   error,
 }) => {
   const isSheetFull = useSheetFullSnap();
+  useSheetBack(onBack);
   return (
   <div
     className="flex flex-col"
@@ -54,11 +55,8 @@ export const CrossChainAssetStep: React.FC<CrossChainAssetStepProps> = ({
         </div>
       </div>
     )}
-    <div className="flex gap-3 shrink-0 pt-2">
-      <SecondaryButton onClick={onBack} className="flex-1">
-        Back
-      </SecondaryButton>
-      <PrimaryButton onClick={onContinue} className="flex-1" disabled={!pending}>
+    <div className="shrink-0 pt-2">
+      <PrimaryButton onClick={onContinue} className="w-full" disabled={!pending}>
         Continue
       </PrimaryButton>
     </div>

--- a/src/components/crossChain/CrossChainChainStep.tsx
+++ b/src/components/crossChain/CrossChainChainStep.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import type { CrossChainRoutePair } from '@breeztech/breez-sdk-spark';
-import { PrimaryButton, SecondaryButton } from '../ui';
+import { PrimaryButton } from '../ui';
 import CryptoIcon from '../CryptoIcon';
 import { ChevronDownIcon, CopyIcon, CheckIcon } from '../Icons';
 import { crossChainCardClass } from '../../utils/crossChainRoutes';
 import { formatChainName } from '../../utils/crossChainFormat';
 import { copyToClipboard } from '../../utils/clipboard';
-import { useSheetFullSnap } from '../ui/sheets/BottomSheetCardContext';
+import { useSheetBack, useSheetFullSnap } from '../ui/sheets/BottomSheetCardContext';
 
 interface CrossChainChainStepProps {
   /** One representative route per chain group, in display order. */
@@ -38,6 +38,7 @@ export const CrossChainChainStep: React.FC<CrossChainChainStepProps> = ({
   const [expandedChain, setExpandedChain] = useState<string | null>(null);
   const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
   const isSheetFull = useSheetFullSnap();
+  useSheetBack(onBack);
 
   return (
     <div
@@ -102,11 +103,8 @@ export const CrossChainChainStep: React.FC<CrossChainChainStepProps> = ({
           );
         })}
       </div>
-      <div className="flex gap-3 shrink-0 pt-2">
-        <SecondaryButton onClick={onBack} className="flex-1">
-          Back
-        </SecondaryButton>
-        <PrimaryButton onClick={onContinue} className="flex-1" disabled={!pending}>
+      <div className="shrink-0 pt-2">
+        <PrimaryButton onClick={onContinue} className="w-full" disabled={!pending}>
           Continue
         </PrimaryButton>
       </div>

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, forwardRef } from 'react';
+import React, { ReactNode, forwardRef, useContext } from 'react';
 import { createPortal } from 'react-dom';
 import { logger, LogCategory } from '@/services/logger';
 import { copyToClipboard } from '@/utils/clipboard';
@@ -18,6 +18,7 @@ import {
   BackIcon,
 } from '../Icons';
 import { AlertCard } from '../AlertCard';
+import { SheetBackContext } from './sheets/BottomSheetCardContext';
 import { useBackButton } from '../../hooks/useBackButton';
 import { useStatusBarColor } from '../../hooks/useStatusBarColor';
 import { STATUS_BAR_DIALOG_SCRIM } from '../../utils/statusBarManager';
@@ -103,31 +104,36 @@ export const DialogHeader: React.FC<{
   onClose: () => void;
   onBack?: () => void;
   icon?: ReactNode;
-}> = ({ title, onClose, onBack, icon }) => (
-  <div className="flex justify-center items-center mb-5 relative px-8">
-    {onBack && (
+}> = ({ title, onClose, onBack, icon }) => {
+  // Without an explicit onBack, the step on screen can lend one (useSheetBack).
+  const stepBack = useContext(SheetBackContext);
+  const back = onBack ?? stepBack;
+  return (
+    <div className="flex justify-center items-center mb-5 relative px-8">
+      {back && (
+        <button
+          onClick={back}
+          aria-label="Back"
+          className="absolute left-0 top-1/2 -translate-y-1/2 py-2 pl-6 pr-2 -ml-6 text-spark-text-muted hover:text-spark-text-primary transition-colors rounded-lg hover:bg-white/5"
+        >
+          <BackIcon />
+        </button>
+      )}
+      <div className="flex items-center gap-2 min-w-0 max-w-full">
+        {icon && <span className="text-spark-primary shrink-0">{icon}</span>}
+        <h2 className="font-display text-lg font-bold text-spark-text-primary truncate">{title}</h2>
+        {icon && <span className="w-5 h-5 shrink-0" aria-hidden="true" />}
+      </div>
       <button
-        onClick={onBack}
-        aria-label="Back"
-        className="absolute left-0 top-1/2 -translate-y-1/2 py-2 pl-6 pr-2 -ml-6 text-spark-text-muted hover:text-spark-text-primary transition-colors rounded-lg hover:bg-white/5"
+        onClick={onClose}
+        aria-label="Close"
+        className="absolute right-0 top-1/2 -translate-y-1/2 py-2 pl-2 pr-6 -mr-6 text-spark-text-muted hover:text-spark-primary-light transition-colors rounded-lg hover:bg-white/5"
       >
-        <BackIcon />
+        <CloseIcon />
       </button>
-    )}
-    <div className="flex items-center gap-2 min-w-0 max-w-full">
-      {icon && <span className="text-spark-primary shrink-0">{icon}</span>}
-      <h2 className="font-display text-lg font-bold text-spark-text-primary truncate">{title}</h2>
-      {icon && <span className="w-5 h-5 shrink-0" aria-hidden="true" />}
     </div>
-    <button
-      onClick={onClose}
-      aria-label="Close"
-      className="absolute right-0 top-1/2 -translate-y-1/2 py-2 pl-2 pr-6 -mr-6 text-spark-text-muted hover:text-spark-primary-light transition-colors rounded-lg hover:bg-white/5"
-    >
-      <CloseIcon />
-    </button>
-  </div>
-);
+  );
+};
 
 
 // ============================================

--- a/src/components/ui/sheets/BottomSheet.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.test.tsx
@@ -1,7 +1,43 @@
+import { useState } from 'react';
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { waitForSheetOpen } from '@/test/utils/waitForSheetOpen';
 import { BottomSheetContainer, BottomSheetCard } from './BottomSheet';
+import { useSheetBack } from './BottomSheetCardContext';
+import { DialogHeader } from '../index';
+
+const Step = ({ label, onBack }: { label: string; onBack?: () => void }) => {
+  useSheetBack(onBack);
+  return <span>{label}</span>;
+};
+
+const ThreeStepSheet = () => {
+  const [step, setStep] = useState(2);
+  return (
+    <BottomSheetContainer isOpen onClose={() => {}}>
+      <BottomSheetCard>
+        <DialogHeader title="Flow" onClose={() => {}} />
+        {step === 0 && <Step label="step 0" />}
+        {step === 1 && <Step label="step 1" onBack={() => setStep(0)} />}
+        {step === 2 && <Step label="step 2" onBack={() => setStep(1)} />}
+      </BottomSheetCard>
+    </BottomSheetContainer>
+  );
+};
+
+describe('useSheetBack', () => {
+  it('hands the header back arrow from step to step', async () => {
+    render(<ThreeStepSheet />);
+    await waitForSheetOpen();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await screen.findByText('step 1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await screen.findByText('step 0');
+    expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
+  });
+});
 
 // Behavior tests for gestures/keyboard live upstream in
 // react-modal-sheet; these cover the adapter wiring only.

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -17,7 +17,12 @@ import { useStatusBarColor } from '../../../hooks/useStatusBarColor';
 import { STATUS_BAR_SURFACE } from '../../../utils/statusBarManager';
 import { useBackButton } from '../../../hooks/useBackButton';
 import { useLatest } from '../../../hooks/useLatest';
-import { BottomSheetCardContext, SheetFullSnapContext } from './BottomSheetCardContext';
+import {
+  BottomSheetCardContext,
+  SetSheetBackContext,
+  SheetBackContext,
+  SheetFullSnapContext,
+} from './BottomSheetCardContext';
 
 /**
  * Bottom sheet adapter over react-modal-sheet.
@@ -560,6 +565,7 @@ export interface BottomSheetCardProps {
 export const BottomSheetCard = forwardRef<HTMLDivElement, BottomSheetCardProps>(
   ({ children, className = '' }, ref) => {
     const [cardEl, setCardEl] = useState<HTMLDivElement | null>(null);
+    const [stepBack, setStepBack] = useState<(() => void) | null>(null);
     const reportHeight = useContext(ContentMeasureContext);
     const clearancePx = useContext(KeyboardClearanceContext);
     const handleRef = useRef<HTMLDivElement | null>(null);
@@ -667,7 +673,11 @@ export const BottomSheetCard = forwardRef<HTMLDivElement, BottomSheetCardProps>(
             className={`bottom-sheet-content-pad px-6 pt-3 ${className}`}
           >
             <BottomSheetCardContext.Provider value={cardEl}>
-              {children}
+              <SetSheetBackContext.Provider value={setStepBack}>
+                <SheetBackContext.Provider value={stepBack}>
+                  {children}
+                </SheetBackContext.Provider>
+              </SetSheetBackContext.Provider>
             </BottomSheetCardContext.Provider>
           </div>
         </Sheet.Content>

--- a/src/components/ui/sheets/BottomSheetCardContext.tsx
+++ b/src/components/ui/sheets/BottomSheetCardContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useEffect, type Dispatch, type SetStateAction } from 'react';
+import { useLatest } from '../../../hooks/useLatest';
 
 export const BottomSheetCardContext = createContext<HTMLDivElement | null>(null);
 export const useBottomSheetCardEl = () => useContext(BottomSheetCardContext);
@@ -10,3 +11,29 @@ export const useBottomSheetCardEl = () => useContext(BottomSheetCardContext);
  */
 export const SheetFullSnapContext = createContext(false);
 export const useSheetFullSnap = () => useContext(SheetFullSnapContext);
+
+type SheetBack = (() => void) | null;
+
+/** The back action the step on screen lends the sheet header's arrow. */
+export const SheetBackContext = createContext<SheetBack>(null);
+export const SetSheetBackContext = createContext<Dispatch<SetStateAction<SheetBack>> | null>(null);
+
+/**
+ * Puts `onBack` behind the sheet header's back arrow, in place of a Back
+ * button beside the step's call to action. `undefined` hides the arrow, e.g.
+ * while the step is busy. One step at a time: a workflow whose sub-step
+ * registers its own must pass `undefined` meanwhile.
+ */
+export function useSheetBack(onBack: (() => void) | undefined): void {
+  const setBack = useContext(SetSheetBackContext);
+  const latest = useLatest(onBack);
+  const active = onBack !== undefined;
+  useEffect(() => {
+    if (!setBack || !active) return;
+    // A stable wrapper, so a parent's inline handler does not re-register
+    // (and re-render the sheet) on every render.
+    const back = () => latest.current?.();
+    setBack(() => back);
+    return () => setBack(current => (current === back ? null : current));
+  }, [setBack, active, latest]);
+}

--- a/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
+++ b/src/features/receive/workflows/CrossChainReceiveWorkflow.tsx
@@ -6,7 +6,6 @@ import type {
 } from '@breeztech/breez-sdk-spark';
 import {
   PrimaryButton,
-  SecondaryButton,
   QRCodeContainer,
   CopyableText,
   FormError,
@@ -18,7 +17,7 @@ import { useWallet } from '../../../contexts/WalletContext';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { useToast } from '../../../contexts/ToastContext';
 import { useCrossChainRouteGroups } from '../../../hooks/useCrossChainRouteGroups';
-import { useSheetFullSnap } from '../../../components/ui/sheets/BottomSheetCardContext';
+import { useSheetBack, useSheetFullSnap } from '../../../components/ui/sheets/BottomSheetCardContext';
 import {
   assetDisplayName,
   assetMatchesGroup,
@@ -187,6 +186,9 @@ const CrossChainReceiveWorkflow: React.FC = () => {
     }
   };
 
+  // The asset and chain steps lend their own.
+  useSheetBack(step === 'provider' ? goBackFromProvider : undefined);
+
   // Received amount lands as a stable token (USDB) or as BTC sats, depending on
   // the SDK's auto-pick. `route.decimals` is the *source* asset, so it can't be
   // reused here — branch on `tokenIdentifier` and format the destination asset.
@@ -342,16 +344,13 @@ const CrossChainReceiveWorkflow: React.FC = () => {
               ))}
             </div>
           </div>
-          <div className="flex gap-3 shrink-0 pt-2">
-            <SecondaryButton onClick={goBackFromProvider} className="flex-1">
-              Back
-            </SecondaryButton>
+          <div className="shrink-0 pt-2">
             <PrimaryButton
               onClick={() => {
                 const r = routesForSelection.find(x => x.provider === pendingProvider);
                 if (r) generateOrder(r);
               }}
-              className="flex-1"
+              className="w-full"
               disabled={!pendingProvider}
             >
               Continue

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import type { ConversionOptions } from '@breeztech/breez-sdk-spark';
-import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
+import { FormError, PrimaryButton } from '../../../components/ui';
+import { useSheetBack } from '../../../components/ui/sheets/BottomSheetCardContext';
 import { SpinnerIcon } from '../../../components/Icons';
 import { formatQuickAmount, pickQuickAmounts } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
@@ -59,6 +60,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
 
   const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance, fiatOverride);
   const hasPendingConversion = useHasPendingConversion();
+  useSheetBack(isLoading ? undefined : onBack);
 
   const [feesIncluded, setFeesIncluded] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -283,24 +285,18 @@ const AmountStep: React.FC<AmountStepProps> = ({
 
       <FormError error={inlineBalanceError || localError || error} />
 
-      {/* Action buttons */}
-      <div className="flex gap-3">
-        <SecondaryButton onClick={onBack} disabled={isLoading} className="flex-1">
-          Back
-        </SecondaryButton>
-        <PrimaryButton
-          onClick={handleNext}
-          disabled={isLoading || !validAmount || !!inlineBalanceError}
-          className="flex-1"
-        >
-          {isLoading ? (
-            <span className="flex items-center justify-center gap-2">
-              <SpinnerIcon />
-              Processing...
-            </span>
-          ) : 'Continue'}
-        </PrimaryButton>
-      </div>
+      <PrimaryButton
+        onClick={handleNext}
+        disabled={isLoading || !validAmount || !!inlineBalanceError}
+        className="w-full"
+      >
+        {isLoading ? (
+          <span className="flex items-center justify-center gap-2">
+            <SpinnerIcon />
+            Processing...
+          </span>
+        ) : 'Continue'}
+      </PrimaryButton>
     </div>
   );
 };

--- a/src/features/send/steps/ConfirmStep.tsx
+++ b/src/features/send/steps/ConfirmStep.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { CopyableRow, PrimaryButton, SecondaryButton, FormError } from '../../../components/ui';
+import { CopyableRow, PrimaryButton, FormError } from '../../../components/ui';
+import { useSheetBack } from '../../../components/ui/sheets/BottomSheetCardContext';
 import { FeeBreakdownCard, SimpleFeeBreakdown } from '../../../components/FeeBreakdownCard';
 import { SpinnerIcon } from '../../../components/Icons';
 import { SatAmount } from '../../../components/SatAmount';
@@ -38,6 +39,7 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
   const stableBalance = useStableBalance();
   const isTokenMode = stableBalance.isActive && !!stableBalance.displayConfig && !!conversionEstimate;
   const balance = useBalanceValidation(isTokenMode, undefined, balanceSats, tokenBalance);
+  useSheetBack(isLoading ? undefined : onBack);
 
   const amount = Number(amountSats || 0n);
   const fee = Number(feesSat || 0);
@@ -101,29 +103,21 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
 
       <FormError error={balanceError || error} />
 
-      {/* Action buttons */}
-      <div className="flex gap-3">
-        {onBack && (
-          <SecondaryButton onClick={onBack} disabled={isLoading} className="flex-1">
-            Back
-          </SecondaryButton>
+      <PrimaryButton
+        onClick={onConfirm}
+        disabled={isLoading || insufficientBalance || disableConfirm}
+        className="w-full"
+        data-testid="send-confirm-button"
+      >
+        {isLoading ? (
+          <span className="flex items-center justify-center gap-2">
+            <SpinnerIcon size="md" />
+            Processing...
+          </span>
+        ) : (
+          'Send'
         )}
-        <PrimaryButton
-          onClick={onConfirm}
-          disabled={isLoading || insufficientBalance || disableConfirm}
-          className={onBack ? 'flex-1' : 'w-full'}
-          data-testid="send-confirm-button"
-        >
-          {isLoading ? (
-            <span className="flex items-center justify-center gap-2">
-              <SpinnerIcon size="md" />
-              Processing...
-            </span>
-          ) : (
-            'Send'
-          )}
-        </PrimaryButton>
-      </div>
+      </PrimaryButton>
     </div>
   );
 };

--- a/src/features/send/workflows/BitcoinWorkflow.tsx
+++ b/src/features/send/workflows/BitcoinWorkflow.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import type { SendPaymentMethod, ConversionEstimate } from '@breeztech/breez-sdk-spark';
 import type { PaymentStep } from '../../../types/domain';
 import { PrimaryButton } from '../../../components/ui';
-import { RadioCheckIcon } from '../../../components/Icons';
+import { useSheetBack } from '../../../components/ui/sheets/BottomSheetCardContext';
+import { FeeRateSelector, type FeeSpeed } from '../../../components/FeeRateSelector';
 import ConfirmStep from '../steps/ConfirmStep';
 import { SatAmount } from '../../../components/SatAmount';
 import { getSendDestination } from '../utils';
@@ -21,7 +22,9 @@ interface BitcoinWorkflowProps {
 const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, feesIncluded, conversionEstimate, balanceSats, tokenBalance, onBack, onSend }) => {
   const [step, setStep] = useState<PaymentStep>('fee');
   // Fee selection happens here; processing/result are handled by parent
-  const [selectedFeeRate, setSelectedFeeRate] = useState<'fast' | 'medium' | 'slow' | null>(null);
+  const [selectedFeeRate, setSelectedFeeRate] = useState<FeeSpeed | null>(null);
+  // The confirm step's ConfirmStep lends its own.
+  useSheetBack(step === 'fee' ? onBack : undefined);
 
   const handleSend = async () => {
     if (!selectedFeeRate) return;
@@ -30,11 +33,11 @@ const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, f
 
   // Compute fees from prepared response and selected rate
   const fq = method.feeQuote;
-  let feesSat: number | null = null;
-  if (selectedFeeRate) {
-    const selected = selectedFeeRate === 'fast' ? fq.speedFast : selectedFeeRate === 'medium' ? fq.speedMedium : fq.speedSlow;
-    feesSat = selected.l1BroadcastFeeSat + selected.userFeeSat;
-  }
+  const feeFor = (speed: FeeSpeed) => {
+    const quote = speed === 'fast' ? fq.speedFast : speed === 'medium' ? fq.speedMedium : fq.speedSlow;
+    return quote.l1BroadcastFeeSat + quote.userFeeSat;
+  };
+  const feesSat = selectedFeeRate ? feeFor(selectedFeeRate) : null;
 
   return (
     <>
@@ -42,61 +45,19 @@ const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, f
       {step === 'fee' && (
         <>
           <div className="mb-4">
-            <label className="block text-sm font-medium text-[rgb(var(--text-white))] mb-2">Select Fee Rate</label>
-            <div className="flex gap-2">
-              <button
-                onClick={() => setSelectedFeeRate('slow')}
-                className={`relative flex-1 p-3 rounded-lg border text-sm font-medium transition-colors ${selectedFeeRate === 'slow'
-                  ? 'bg-[rgb(var(--primary-blue))] text-white border-[rgb(var(--primary-blue))] ring-2 ring-[rgb(var(--primary-blue))]'
-                  : 'bg-[rgb(var(--card-bg))] text-[rgb(var(--text-white))] border-[rgb(var(--card-border))] hover:border-[rgb(var(--primary-blue))]'
-                  }`}
-              >
-                {selectedFeeRate === 'slow' && (
-                  <RadioCheckIcon className="absolute top-2 right-2" />
-                )}
-                <div>Slow</div>
-                <div className="text-xs opacity-70"><SatAmount sats={fq.speedSlow.l1BroadcastFeeSat + fq.speedSlow.userFeeSat} /></div>
-              </button>
-              <button
-                onClick={() => setSelectedFeeRate('medium')}
-                className={`relative flex-1 p-3 rounded-lg border text-sm font-medium transition-colors ${selectedFeeRate === 'medium'
-                  ? 'bg-[rgb(var(--primary-blue))] text-white border-[rgb(var(--primary-blue))] ring-2 ring-[rgb(var(--primary-blue))]'
-                  : 'bg-[rgb(var(--card-bg))] text-[rgb(var(--text-white))] border-[rgb(var(--card-border))] hover:border-[rgb(var(--primary-blue))]'
-                  }`}
-              >
-                {selectedFeeRate === 'medium' && (
-                  <RadioCheckIcon className="absolute top-2 right-2" />
-                )}
-                <div>Medium</div>
-                <div className="text-xs opacity-70"><SatAmount sats={fq.speedMedium.l1BroadcastFeeSat + fq.speedMedium.userFeeSat} /></div>
-              </button>
-              <button
-                onClick={() => setSelectedFeeRate('fast')}
-                className={`relative flex-1 p-3 rounded-lg border text-sm font-medium transition-colors ${selectedFeeRate === 'fast'
-                  ? 'bg-[rgb(var(--primary-blue))] text-white border-[rgb(var(--primary-blue))] ring-2 ring-[rgb(var(--primary-blue))]'
-                  : 'bg-[rgb(var(--card-bg))] text-[rgb(var(--text-white))] border-[rgb(var(--card-border))] hover:border-[rgb(var(--primary-blue))]'
-                  }`}
-              >
-                {selectedFeeRate === 'fast' && (
-                  <RadioCheckIcon className="absolute top-2 right-2" />
-                )}
-                <div>Fast</div>
-                <div className="text-xs opacity-70"><SatAmount sats={fq.speedFast.l1BroadcastFeeSat + fq.speedFast.userFeeSat} /></div>
-              </button>
-            </div>
+            <FeeRateSelector
+              selected={selectedFeeRate}
+              onSelect={setSelectedFeeRate}
+              detail={speed => <SatAmount sats={feeFor(speed)} />}
+            />
           </div>
-          <div className="flex gap-3">
-            <PrimaryButton onClick={onBack} className="flex-1 bg-gray-600 hover:bg-gray-700 text-white p-3 rounded-lg" disabled={false}>
-              Back
-            </PrimaryButton>
-            <PrimaryButton
-              onClick={() => setStep('confirm')}
-              className="flex-1"
-              disabled={!selectedFeeRate}
-            >
-              Continue
-            </PrimaryButton>
-          </div>
+          <PrimaryButton
+            onClick={() => setStep('confirm')}
+            className="w-full"
+            disabled={!selectedFeeRate}
+          >
+            Continue
+          </PrimaryButton>
         </>
       )}
 

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -6,6 +6,7 @@ import type {
   PrepareSendPaymentResponse,
 } from '@breeztech/breez-sdk-spark';
 import { PrimaryButton, SecondaryButton } from '../../../components/ui';
+import { useSheetBack } from '../../../components/ui/sheets/BottomSheetCardContext';
 import { SpinnerIcon } from '../../../components/Icons';
 import { FeeBreakdownCard } from '../../../components/FeeBreakdownCard';
 import { CrossChainAssetStep } from '../../../components/crossChain/CrossChainAssetStep';
@@ -252,6 +253,9 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
     }
   };
 
+  // The asset and chain steps lend their own.
+  useSheetBack(step === 'provider' ? goBackFromProvider : step === 'confirm' ? goBackFromConfirm : undefined);
+
   const handleSend = () => {
     if (!prepareResponse) return;
     const response = prepareResponse;
@@ -389,24 +393,19 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
                 </PrimaryButton>
               </>
             ) : (
-              <>
-                <SecondaryButton onClick={goBackFromProvider} className="flex-1">
-                  Back
-                </SecondaryButton>
-                <PrimaryButton
-                  onClick={() => {
-                    const pq = pendingProvider ? providerQuotes.get(pendingProvider) : null;
-                    if (pq?.response) {
-                      setPrepareResponse(pq.response);
-                      setStep('confirm');
-                    }
-                  }}
-                  className="flex-1"
-                  disabled={!pendingProvider}
-                >
-                  Continue
-                </PrimaryButton>
-              </>
+              <PrimaryButton
+                onClick={() => {
+                  const pq = pendingProvider ? providerQuotes.get(pendingProvider) : null;
+                  if (pq?.response) {
+                    setPrepareResponse(pq.response);
+                    setStep('confirm');
+                  }
+                }}
+                className="flex-1"
+                disabled={!pendingProvider}
+              >
+                Continue
+              </PrimaryButton>
             )}
           </div>
         </div>
@@ -465,14 +464,9 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
             </div>
           )}
 
-          <div className="flex gap-3">
-            <SecondaryButton onClick={goBackFromConfirm} className="flex-1">
-              Back
-            </SecondaryButton>
-            <PrimaryButton onClick={handleSend} className="flex-1" disabled={false}>
-              Send
-            </PrimaryButton>
-          </div>
+          <PrimaryButton onClick={handleSend} className="w-full">
+            Send
+          </PrimaryButton>
         </>
       )}
 

--- a/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import type { LnurlWithdrawRequestDetails, LnurlWithdrawResponse } from '@breeztech/breez-sdk-spark';
-import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
+import { FormError, PrimaryButton } from '../../../components/ui';
+import { useSheetBack } from '../../../components/ui/sheets/BottomSheetCardContext';
 import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
 import { formatWithSpaces } from '../../../utils/formatNumber';
@@ -38,6 +39,7 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
   const [amount, setAmount] = useState<string>(String(maxSats));
   const [error, setError] = useState<string | null>(null);
   const [isWaiting, setIsWaiting] = useState(false);
+  useSheetBack(isWaiting ? undefined : onBack);
 
   const description = parsed.defaultDescription?.trim();
   const sourceHost = useMemo(() => {
@@ -137,14 +139,9 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
 
       <FormError error={inlineError || error} />
 
-      <div className="flex gap-3">
-        <SecondaryButton onClick={onBack} className="flex-1">
-          Back
-        </SecondaryButton>
-        <PrimaryButton onClick={onReceive} disabled={!validAmount} className="flex-1">
-          Receive
-        </PrimaryButton>
-      </div>
+      <PrimaryButton onClick={onReceive} disabled={!validAmount} className="w-full">
+        Receive
+      </PrimaryButton>
     </div>
   );
 };

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import type { LnurlPayRequestDetails, PrepareLnurlPayRequest, PrepareLnurlPayResponse } from '@breeztech/breez-sdk-spark';
 import type { PaymentStep } from '../../../types/domain';
-import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
+import { FormError, PrimaryButton } from '../../../components/ui';
+import { useSheetBack } from '../../../components/ui/sheets/BottomSheetCardContext';
 import ConfirmStep from '../steps/ConfirmStep';
 import { logger, LogCategory } from '@/services/logger';
 import { SpinnerIcon } from '@/components/Icons';
@@ -237,6 +238,9 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     return prepareResponse.conversionEstimate;
   }, [prepareResponse]);
 
+  // The confirm step's ConfirmStep lends its own.
+  useSheetBack(step === 'amount' && !isLoading ? onBack : undefined);
+
   if (step === 'confirm' && prepareResponse) {
     const confirmAmountSats = isSendAllToken
       ? BigInt(prepareResponse.amountSats)
@@ -401,20 +405,14 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
 
       <FormError error={inlineBalanceError || error} />
 
-      {/* Action buttons */}
-      <div className="flex gap-3">
-        <SecondaryButton onClick={onBack} disabled={isLoading} className="flex-1">
-          Back
-        </SecondaryButton>
-        <PrimaryButton onClick={onAmountNext} disabled={isLoading || !validAmount || !!inlineBalanceError} className="flex-1">
-          {isLoading ? (
-            <span className="flex items-center justify-center gap-2">
-              <SpinnerIcon />
-              Processing...
-            </span>
-          ) : 'Continue'}
-        </PrimaryButton>
-      </div>
+      <PrimaryButton onClick={onAmountNext} disabled={isLoading || !validAmount || !!inlineBalanceError} className="w-full">
+        {isLoading ? (
+          <span className="flex items-center justify-center gap-2">
+            <SpinnerIcon />
+            Processing...
+          </span>
+        ) : 'Continue'}
+      </PrimaryButton>
     </div>
   );
 };

--- a/src/features/unilateral-exit/steps/FeeStep.tsx
+++ b/src/features/unilateral-exit/steps/FeeStep.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { LoadingSpinner } from '@/components/ui';
-import { RadioCheckIcon } from '@/components/Icons';
-import type { FeeChoice, FeeFields } from '../hooks/useUnilateralExitFlow';
-
-const choices: { key: FeeChoice; label: string }[] = [
-  { key: 'slow', label: 'Slow' },
-  { key: 'medium', label: 'Medium' },
-  { key: 'fast', label: 'Fast' },
-];
+import { FeeRateSelector } from '@/components/FeeRateSelector';
+import type { FeeFields } from '../hooks/useUnilateralExitFlow';
 
 export const FeeStep: React.FC<FeeFields> = ({ feeRates, feeChoice, onSelect }) => {
   if (!feeRates) {
@@ -19,31 +13,6 @@ export const FeeStep: React.FC<FeeFields> = ({ feeRates, feeChoice, onSelect }) 
   }
 
   return (
-    <div className="space-y-6">
-      <div>
-        <span className="block text-sm font-medium text-spark-text-primary mb-2">
-          Select Fee Rate
-        </span>
-        <div className="flex gap-2">
-          {choices.map(choice => (
-            <button
-              key={choice.key}
-              type="button"
-              onClick={() => onSelect(choice.key)}
-              className={`relative flex-1 p-3 rounded-lg border text-sm font-medium transition-colors ${
-                feeChoice === choice.key
-                  ? 'bg-spark-primary/15 text-spark-text-primary border-spark-primary ring-2 ring-spark-primary'
-                  : 'bg-spark-dark text-spark-text-secondary border-spark-border-light hover:border-spark-primary'
-              }`}
-            >
-              {feeChoice === choice.key && <RadioCheckIcon className="absolute top-2 right-2" />}
-              <div>{choice.label}</div>
-              <div className="text-xs opacity-70">{feeRates[choice.key]} sat/vB</div>
-            </button>
-          ))}
-        </div>
-      </div>
-
-    </div>
+    <FeeRateSelector selected={feeChoice} onSelect={onSelect} detail={speed => `${feeRates[speed]} sat/vB`} />
   );
 };

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -4,7 +4,8 @@ import type { DepositInfo, Fee, SdkEvent } from '@breeztech/breez-sdk-spark';
 import { LoadingSpinner, PrimaryButton, SecondaryButton, FormInput, BottomSheetContainer, BottomSheetCard, DialogHeader, CollapsibleCodeField, PaymentInfoCard } from '../components/ui';
 import { AlertCard, SimpleAlert } from '../components/AlertCard';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
-import { CloseIcon, CheckIcon, RadioCheckIcon } from '../components/Icons';
+import { CloseIcon, CheckIcon } from '../components/Icons';
+import { FeeRateSelector, type FeeSpeed } from '../components/FeeRateSelector';
 import { isDepositRejected, removeRejectedDeposit } from '../services/depositState';
 import { SatAmount } from '../components/SatAmount';
 import { explorerTxUrl } from '../utils/explorer';
@@ -30,7 +31,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
   const [isRefundFlowOpen, setIsRefundFlowOpen] = useState<boolean>(false);
   const [refundStep, setRefundStep] = useState<RefundStep>('address');
   const [destination, setDestination] = useState<string>('');
-  const [selectedFeeRate, setSelectedFeeRate] = useState<'fast' | 'medium' | 'slow' | null>(null);
+  const [selectedFeeRate, setSelectedFeeRate] = useState<FeeSpeed | null>(null);
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const [refundError, setRefundError] = useState<string | null>(null);
   const [refundSuccess, setRefundSuccess] = useState<boolean>(false);
@@ -300,6 +301,11 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
           <DialogHeader
             title={refundStep === 'result' ? (refundSuccess ? 'Refund Sent' : 'Refund Failed') : 'Refund to Bitcoin'}
             onClose={closeRefundFlow}
+            onBack={
+              refundStep === 'fee' ? () => setRefundStep('address')
+                : refundStep === 'confirm' ? () => setRefundStep('fee')
+                  : undefined
+            }
           />
 
           <div className="space-y-6">
@@ -340,65 +346,19 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
             {/* Step 2: Fee Selection */}
             {refundStep === 'fee' && (
               <>
-                <div>
-                  <label className="block text-sm font-medium text-[rgb(var(--text-white))] mb-2">
-                    Select Fee Rate
-                  </label>
-                  <div className="grid grid-cols-3 gap-2">
-                    <button
-                      onClick={() => setSelectedFeeRate('slow')}
-                      className={`relative p-3 rounded-lg border text-sm font-medium transition-colors ${selectedFeeRate === 'slow'
-                        ? 'bg-[rgb(var(--primary-blue))] text-white border-[rgb(var(--primary-blue))] ring-2 ring-[rgb(var(--primary-blue))]'
-                        : 'bg-[rgb(var(--card-bg))] text-[rgb(var(--text-white))] border-[rgb(var(--card-border))] hover:border-[rgb(var(--primary-blue))]'
-                        }`}
-                    >
-                      {selectedFeeRate === 'slow' && (
-                        <RadioCheckIcon className="absolute top-2 right-2" />
-                      )}
-                      <div>Slow</div>
-                      <div className="text-xs opacity-70"><SatAmount sats={feeEstimates.slow} /></div>
-                    </button>
-                    <button
-                      onClick={() => setSelectedFeeRate('medium')}
-                      className={`relative p-3 rounded-lg border text-sm font-medium transition-colors ${selectedFeeRate === 'medium'
-                        ? 'bg-[rgb(var(--primary-blue))] text-white border-[rgb(var(--primary-blue))] ring-2 ring-[rgb(var(--primary-blue))]'
-                        : 'bg-[rgb(var(--card-bg))] text-[rgb(var(--text-white))] border-[rgb(var(--card-border))] hover:border-[rgb(var(--primary-blue))]'
-                        }`}
-                    >
-                      {selectedFeeRate === 'medium' && (
-                        <RadioCheckIcon className="absolute top-2 right-2" />
-                      )}
-                      <div>Medium</div>
-                      <div className="text-xs opacity-70"><SatAmount sats={feeEstimates.medium} /></div>
-                    </button>
-                    <button
-                      onClick={() => setSelectedFeeRate('fast')}
-                      className={`relative p-3 rounded-lg border text-sm font-medium transition-colors ${selectedFeeRate === 'fast'
-                        ? 'bg-[rgb(var(--primary-blue))] text-white border-[rgb(var(--primary-blue))] ring-2 ring-[rgb(var(--primary-blue))]'
-                        : 'bg-[rgb(var(--card-bg))] text-[rgb(var(--text-white))] border-[rgb(var(--card-border))] hover:border-[rgb(var(--primary-blue))]'
-                        }`}
-                    >
-                      {selectedFeeRate === 'fast' && (
-                        <RadioCheckIcon className="absolute top-2 right-2" />
-                      )}
-                      <div>Fast</div>
-                      <div className="text-xs opacity-70"><SatAmount sats={feeEstimates.fast} /></div>
-                    </button>
-                  </div>
-                </div>
+                <FeeRateSelector
+                  selected={selectedFeeRate}
+                  onSelect={setSelectedFeeRate}
+                  detail={speed => <SatAmount sats={feeEstimates[speed]} />}
+                />
 
-                <div className="flex gap-3">
-                  <PrimaryButton onClick={() => setRefundStep('address')} className="flex-1 bg-gray-600 hover:bg-gray-700 text-white" disabled={false}>
-                    Back
-                  </PrimaryButton>
-                  <PrimaryButton
-                    onClick={() => setRefundStep('confirm')}
-                    disabled={!selectedFeeRate}
-                    className="flex-1"
-                  >
-                    Continue
-                  </PrimaryButton>
-                </div>
+                <PrimaryButton
+                  onClick={() => setRefundStep('confirm')}
+                  disabled={!selectedFeeRate}
+                  className="w-full"
+                >
+                  Continue
+                </PrimaryButton>
               </>
             )}
 
@@ -420,18 +380,13 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                   </AlertCard>
                 )}
 
-                <div className="flex gap-3">
-                  <SecondaryButton onClick={() => setRefundStep('fee')} className="flex-1">
-                    Back
-                  </SecondaryButton>
-                  <PrimaryButton
-                    onClick={handleRefund}
-                    disabled={isProcessing}
-                    className="flex-1"
-                  >
-                    Refund
-                  </PrimaryButton>
-                </div>
+                <PrimaryButton
+                  onClick={handleRefund}
+                  disabled={isProcessing}
+                  className="w-full"
+                >
+                  Refund
+                </PrimaryButton>
               </>
             )}
 


### PR DESCRIPTION
This PR replaces the half-width Back buttons beside the main button in Send, Receive and Refund with the back arrow in the sheet header, as in Unilateral Exit.

### Changes
- Show the header back arrow on every step that had a Back button, and make the main button full width.
- Share one fee picker between Send BTC, Refund and Unilateral Exit, in the Unilateral Exit style.
- Stop the selected fee option's border from being cropped in Unilateral Exit.
- Preserve the Android back gesture, which still closes the sheet.

### Test plan
- Step back with the header arrow in Send (Bitcoin address, Lightning address, USD) and in Refund, including from the confirm step.
- Pick a fee in Send BTC, Refund and Unilateral Exit.

#### UI changes

| Send amount | Send BTC fee | Send confirm | Unilateral Exit fee |
|---|---|---|---|
| <img width="94%" height="844" alt="image" src="https://github.com/user-attachments/assets/e62ac013-56b1-41bb-95b4-c7cfc03c632f" /> | <img width="100%" height="844" alt="image" src="https://github.com/user-attachments/assets/004a6c15-b591-4b39-b2fb-f5d6193dafe0" /> | <img width="95%" height="844" alt="image" src="https://github.com/user-attachments/assets/c122fddb-20b3-4dda-8246-65f3141e3361" /> | <img width="92%" height="844" alt="image" src="https://github.com/user-attachments/assets/869f7bb5-b1ec-4a04-9d6d-477c56c03cc4" /> |