### PR TITLE
feat: update the Refund flow and price refunds from current fee rates

### DIFF
--- a/src/components/DestinationField.tsx
+++ b/src/components/DestinationField.tsx
@@ -1,20 +1,25 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import { Capacitor } from '@capacitor/core';
 import { Clipboard } from '@capacitor/clipboard';
 import { SimpleAlert } from '@/components/AlertCard';
 import { ClipboardIcon, QrCodeIcon } from '@/components/Icons';
 import { logger, LogCategory } from '@/services/logger';
 import { dismissKeyboard } from '@/utils/keyboard';
-import type { DestinationFields } from '../hooks/useUnilateralExitFlow';
 
-/** The send flow's quick actions, so the two address fields read as one control. */
+/** The send flow's quick actions, so the address fields read as one control. */
 const quickAction =
   'flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-spark-surface border border-spark-border rounded-xl ' +
   'text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light transition-colors';
 
-export const DestinationStep: React.FC<
-  DestinationFields & { onSubmit: () => void; onScanQr: () => void }
-> = ({ destination, onChange, error, onSubmit, onScanQr }) => {
+/** An on-chain destination field with Paste and Scan, for the exit and refund flows. */
+export const DestinationField: React.FC<{
+  destination: string;
+  onChange: (value: string) => void;
+  error: string | null;
+  onSubmit: () => void;
+  onScanQr: () => void;
+}> = ({ destination, onChange, error, onSubmit, onScanQr }) => {
+  const id = useId();
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const handlePaste = async () => {
@@ -44,7 +49,7 @@ export const DestinationStep: React.FC<
     <div className="flex flex-col gap-4">
       <div>
         <label
-          htmlFor="unilateral-exit-destination"
+          htmlFor={id}
           className="block text-sm font-medium text-spark-text-primary mb-2"
         >
           Destination
@@ -52,7 +57,7 @@ export const DestinationStep: React.FC<
         {/* A textarea so a long address wraps instead of scrolling sideways,
             with Enter submitting: this field never takes a second line. */}
         <textarea
-          id="unilateral-exit-destination"
+          id={id}
           ref={inputRef}
           value={destination}
           onChange={event => onChange(event.target.value)}

--- a/src/features/send/steps/ResultStep.tsx
+++ b/src/features/send/steps/ResultStep.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, type ReactNode } from 'react';
 import { PrimaryButton, ErrorMessageBox } from '../../../components/ui';
 import { CloseIcon } from '../../../components/Icons';
 import GlowLogo from '../../../components/GlowLogo';
@@ -9,10 +9,12 @@ export interface ResultStepProps {
   error: string | null;
   onClose: () => void;
   /** Operation type to customize messaging (default: 'payment') */
-  operationType?: 'payment' | 'auth';
+  operationType?: 'payment' | 'auth' | 'refund';
+  /** Shown on success between the description and Done, e.g. a transaction ID. */
+  children?: ReactNode;
 }
 
-const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose, operationType = 'payment' }) => {
+const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose, operationType = 'payment', children }) => {
   const isSuccess = result === 'success';
   const [starsAnimating, setStarsAnimating] = useState(false);
 
@@ -28,6 +30,9 @@ const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose, operati
     if (operationType === 'auth') {
       return isSuccess ? 'Authenticated!' : 'Authentication Failed';
     }
+    if (operationType === 'refund') {
+      return isSuccess ? 'Refund Sent!' : 'Refund Failed';
+    }
     return isSuccess ? 'Payment Sent!' : 'Payment Failed';
   };
 
@@ -35,12 +40,18 @@ const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose, operati
     if (operationType === 'auth') {
       return 'You have successfully authenticated with the service.';
     }
+    if (operationType === 'refund') {
+      return 'Your refund has been sent to the Bitcoin network.';
+    }
     return 'Your payment has been successfully sent to the recipient.';
   };
 
   const getDefaultErrorMessage = () => {
     if (operationType === 'auth') {
       return 'There was an error during authentication. Please try again.';
+    }
+    if (operationType === 'refund') {
+      return 'There was an error processing your refund. Please try again.';
     }
     return 'There was an error processing your payment. Please try again.';
   };
@@ -122,6 +133,8 @@ const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose, operati
       <p className="text-spark-text-secondary text-center max-w-xs mb-8">
         {getSuccessDescription()}
       </p>
+
+      {children && <div className="w-full mb-8">{children}</div>}
 
       {/* Action button */}
       <PrimaryButton onClick={onClose} className="min-w-[200px]">

--- a/src/features/unilateral-exit/driver.ts
+++ b/src/features/unilateral-exit/driver.ts
@@ -2,7 +2,6 @@ import { singleKeyCpfpSigner } from '@breeztech/breez-sdk-spark';
 import type {
   BreezSdk,
   CheckUnilateralExitResponse,
-  InputType,
   PrepareUnilateralExitResponse,
   UnilateralExitResponse,
   UnilateralExitTransaction,
@@ -235,12 +234,7 @@ export const isReady = (tx: UnilateralExitTransaction): boolean => tx.status.typ
 export const hasFixedFeeBudget = (plan: UnilateralExitPlan): boolean =>
   plan.exit.transactions.some(tx => tx.kind === 'fanOut' && tx.status.type === 'confirmed');
 
-/** The on-chain address a destination names. A scanned receive QR is a BIP21 URI, and the exit sweeps to the address in it. */
-export function destinationAddressOf(parsed: InputType | null): string | undefined {
-  if (parsed?.type === 'bitcoinAddress') return parsed.address;
-  if (parsed?.type !== 'bip21') return undefined;
-  return parsed.paymentMethods.flatMap(method => (method.type === 'bitcoinAddress' ? [method.address] : []))[0];
-}
+export { destinationAddressOf } from '@/utils/destinationAddress';
 
 /** What a build said it needs: the sdk's error reaches the page only as its message. */
 export function requiredFundingOf(error: string): number | null {

--- a/src/pages/GetRefundPage.test.tsx
+++ b/src/pages/GetRefundPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import type { BreezSdk, DepositInfo } from '@breeztech/breez-sdk-spark';
 import { WalletProvider } from '@/contexts/WalletContext';
 import { createMockClient } from '@/test/mocks/mockWalletApi';
@@ -20,6 +20,7 @@ async function renderPage() {
   client.listUnclaimedDeposits = vi
     .fn()
     .mockResolvedValue({ deposits: [DEPOSIT] });
+  client.refundDeposit = vi.fn().mockResolvedValue({ txId: 'b'.repeat(64), txHex: '00' });
 
   render(
     <WalletProvider client={client} isConnected>
@@ -31,7 +32,7 @@ async function renderPage() {
   fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
   const destination = await screen.findByPlaceholderText('bc1q...');
   await waitForSheetOpen();
-  return { destination };
+  return { destination, client };
 }
 
 // The deposit card behind the sheet has its own Continue button: scope
@@ -89,5 +90,27 @@ describe('GetRefundPage address step', () => {
     fireEvent.click(refundSheet().getByLabelText('Close'));
 
     expect(refundSheet().getByText('Continue')).toBeDisabled();
+  });
+});
+
+describe('GetRefundPage fee', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('pays the picked speed at the current rate as a fixed fee', async () => {
+    const { destination, client } = await renderPage();
+    fireEvent.change(destination, { target: { value: 'bc1qdest' } });
+    fireEvent.click(refundSheet().getByText('Continue'));
+
+    // The mock's half-hour rate is 15 sat/vB, over a 111 vB refund.
+    fireEvent.click(await refundSheet().findByRole('button', { name: /^Medium/ }));
+    fireEvent.click(refundSheet().getByText('Continue'));
+    fireEvent.click(await refundSheet().findByText('Refund'));
+
+    await waitFor(() =>
+      expect(client.refundDeposit).toHaveBeenCalledWith(
+        expect.objectContaining({ destinationAddress: 'bc1qdest', fee: { type: 'fixed', amount: 1665 } }),
+      ),
+    );
+    expect(await refundSheet().findByText('Refund Sent!')).toBeInTheDocument();
   });
 });

--- a/src/pages/GetRefundPage.test.tsx
+++ b/src/pages/GetRefundPage.test.tsx
@@ -101,14 +101,14 @@ describe('GetRefundPage fee', () => {
     fireEvent.change(destination, { target: { value: 'bc1qdest' } });
     fireEvent.click(refundSheet().getByText('Continue'));
 
-    // The mock's half-hour rate is 15 sat/vB, over a 111 vB refund.
+    // The mock's half-hour rate is 15 sat/vB: 1 665 sats over a 111 vB refund, shown as 1 700.
     fireEvent.click(await refundSheet().findByRole('button', { name: /^Medium/ }));
     fireEvent.click(refundSheet().getByText('Continue'));
     fireEvent.click(await refundSheet().findByText('Refund'));
 
     await waitFor(() =>
       expect(client.refundDeposit).toHaveBeenCalledWith(
-        expect.objectContaining({ destinationAddress: 'bc1qdest', fee: { type: 'fixed', amount: 1665 } }),
+        expect.objectContaining({ destinationAddress: 'bc1qdest', fee: { type: 'fixed', amount: 1700 } }),
       ),
     );
     expect(await refundSheet().findByText('Refund Sent!')).toBeInTheDocument();

--- a/src/pages/GetRefundPage.test.tsx
+++ b/src/pages/GetRefundPage.test.tsx
@@ -35,10 +35,9 @@ async function renderPage() {
 }
 
 // The deposit card behind the sheet has its own Continue button: scope
-// to the step's action row.
-function sheetButton(label: string) {
-  const actions = screen.getByText('Cancel').parentElement as HTMLElement;
-  return within(actions).getByText(label);
+// to the sheet.
+function refundSheet() {
+  return within(screen.getByText('Refund to Bitcoin').closest('.react-modal-sheet-root') as HTMLElement);
 }
 
 // SlideInPage wraps the page in a z-60 opaque overlay. The sheet
@@ -74,21 +73,21 @@ describe('GetRefundPage address step', () => {
     const { destination } = await renderPage();
     fireEvent.change(destination, { target: { value: 'bc1qdest' } });
 
-    const continueButton = sheetButton('Continue');
+    const continueButton = refundSheet().getByText('Continue');
     expect(continueButton).toBeEnabled();
 
     fireEvent.click(continueButton);
     expect(await screen.findByText('Select Fee Rate')).toBeInTheDocument();
   });
 
-  it('disables Continue after Cancel clears the selected deposit', async () => {
+  it('disables Continue after closing clears the selected deposit', async () => {
     const { destination } = await renderPage();
     fireEvent.change(destination, { target: { value: 'bc1qdest' } });
 
-    // Cancel nulls selectedDeposit, but the sheet body stays mounted
+    // Closing nulls selectedDeposit, but the sheet body stays mounted
     // through the close animation and keeps the typed destination.
-    fireEvent.click(sheetButton('Cancel'));
+    fireEvent.click(refundSheet().getByLabelText('Close'));
 
-    expect(sheetButton('Continue')).toBeDisabled();
+    expect(refundSheet().getByText('Continue')).toBeDisabled();
   });
 });

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -1,13 +1,18 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useWallet } from '../contexts/WalletContext';
 import type { DepositInfo, Fee, SdkEvent } from '@breeztech/breez-sdk-spark';
-import { LoadingSpinner, PrimaryButton, SecondaryButton, FormInput, BottomSheetContainer, BottomSheetCard, DialogHeader, CollapsibleCodeField, PaymentInfoCard } from '../components/ui';
+import { LoadingSpinner, PrimaryButton, BottomSheetContainer, BottomSheetCard, DialogHeader, CollapsibleCodeField, CopyableRow, PaymentInfoCard } from '../components/ui';
 import { AlertCard, SimpleAlert } from '../components/AlertCard';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
-import { CloseIcon, CheckIcon } from '../components/Icons';
+import { CheckIcon } from '../components/Icons';
 import { FeeRateSelector, type FeeSpeed } from '../components/FeeRateSelector';
 import { isDepositRejected, removeRejectedDeposit } from '../services/depositState';
 import { SatAmount } from '../components/SatAmount';
+import { DestinationField } from '../components/DestinationField';
+import QrScannerDialog from '../components/QrScannerDialog';
+import ResultStep from '../features/send/steps/ResultStep';
+import { destinationAddressOf } from '../utils/destinationAddress';
+import { truncateAddress } from '../utils/crossChainFormat';
 import { explorerTxUrl } from '../utils/explorer';
 import SlideInPage from '@/components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
@@ -31,10 +36,11 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
   const [isRefundFlowOpen, setIsRefundFlowOpen] = useState<boolean>(false);
   const [refundStep, setRefundStep] = useState<RefundStep>('address');
   const [destination, setDestination] = useState<string>('');
+  const [destinationError, setDestinationError] = useState<string | null>(null);
+  const [isScanning, setIsScanning] = useState<boolean>(false);
   const [selectedFeeRate, setSelectedFeeRate] = useState<FeeSpeed | null>(null);
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const [refundError, setRefundError] = useState<string | null>(null);
-  const [refundSuccess, setRefundSuccess] = useState<boolean>(false);
   const [refundTxId, setRefundTxId] = useState<string | null>(null);
   const [isTxIdVisible, setIsTxIdVisible] = useState<boolean>(false);
 
@@ -135,9 +141,9 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
   const openRefundFlow = (deposit: DepositInfo) => {
     setSelectedDeposit(deposit);
     setDestination('');
+    setDestinationError(null);
     setSelectedFeeRate(null);
     setRefundError(null);
-    setRefundSuccess(false);
     setRefundTxId(null);
     setRefundStep('address');
     setIsRefundFlowOpen(true);
@@ -148,8 +154,17 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
     setSelectedDeposit(null);
   };
 
-  const handleContinueToFeeSelection = () => {
-    if (!selectedDeposit || !destination.trim()) return;
+  // The exit flow's parse: a scanned receive QR is a BIP21 URI.
+  const handleContinueToFeeSelection = async () => {
+    const trimmed = destination.trim();
+    if (!selectedDeposit || !trimmed) return;
+    const address = destinationAddressOf(await wallet.parse(trimmed).catch(() => null));
+    if (!address) {
+      setDestinationError('That is not an on-chain Bitcoin address');
+      return;
+    }
+    setDestination(address);
+    setDestinationError(null);
     setRefundStep('fee');
   };
 
@@ -167,7 +182,6 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
       // Remove from rejected list after successful refund
       removeRejectedDeposit(selectedDeposit.txid, selectedDeposit.vout);
 
-      setRefundSuccess(true);
       setRefundTxId(result.txId || null);
       setRefundStep('result');
 
@@ -299,7 +313,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
       <BottomSheetContainer isOpen={isRefundFlowOpen} onClose={closeRefundFlow} zIndex={70} showBackdrop>
         <BottomSheetCard>
           <DialogHeader
-            title={refundStep === 'result' ? (refundSuccess ? 'Refund Sent' : 'Refund Failed') : 'Refund to Bitcoin'}
+            title="Refund to Bitcoin"
             onClose={closeRefundFlow}
             onBack={
               refundStep === 'fee' ? () => setRefundStep('address')
@@ -312,34 +326,21 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
             {/* Step 1: Address Input */}
             {refundStep === 'address' && (
               <>
-                <div>
-                  <label className="block text-sm font-medium text-spark-text-secondary mb-2">
-                    Destination
-                  </label>
-                  <FormInput
-                    id="refund-destination"
-                    type="text"
-                    value={destination}
-                    onChange={(e) => setDestination(e.target.value)}
-                    placeholder="bc1q..."
-                  />
-                  <p className="text-spark-text-muted text-xs mt-2">
-                    Enter the Bitcoin address where you want to receive the refund.
-                  </p>
-                </div>
+                <DestinationField
+                  destination={destination}
+                  onChange={setDestination}
+                  error={destinationError}
+                  onSubmit={() => void handleContinueToFeeSelection()}
+                  onScanQr={() => setIsScanning(true)}
+                />
 
-                <div className="flex gap-3">
-                  <SecondaryButton onClick={closeRefundFlow} className="flex-1">
-                    Cancel
-                  </SecondaryButton>
-                  <PrimaryButton
-                    onClick={handleContinueToFeeSelection}
-                    disabled={!selectedDeposit || !destination.trim()}
-                    className="flex-1"
-                  >
-                    Continue
-                  </PrimaryButton>
-                </div>
+                <PrimaryButton
+                  onClick={() => void handleContinueToFeeSelection()}
+                  disabled={!selectedDeposit || !destination.trim()}
+                  className="w-full"
+                >
+                  Continue
+                </PrimaryButton>
               </>
             )}
 
@@ -365,7 +366,8 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
             {/* Step 3: Confirm */}
             {refundStep === 'confirm' && selectedDeposit && (
               <>
-                {/* Breakdown */}
+                <CopyableRow label="To address" value={destination} display={truncateAddress(destination, 32)} />
+
                 <FeeBreakdownCard
                   items={[
                     { label: 'Amount', value: selectedDeposit.amountSats },
@@ -399,36 +401,8 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
 
             {/* Step 5: Result */}
             {refundStep === 'result' && (
-              <>
-                <div className="text-center py-4">
-                  {refundSuccess ? (
-                    <>
-                      <div className="w-16 h-16 rounded-full bg-spark-success/20 flex items-center justify-center mx-auto mb-4">
-                        <CheckIcon size="xl" className="text-spark-success" />
-                      </div>
-                      <h3 className="font-display font-semibold text-spark-text-primary text-lg mb-2">
-                        Refund Broadcast
-                      </h3>
-                      <p className="text-spark-text-muted text-sm">
-                        Your refund has been sent to the Bitcoin network.
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <div className="w-16 h-16 rounded-full bg-spark-primary/20 flex items-center justify-center mx-auto mb-4">
-                        <CloseIcon size="xl" className="text-spark-primary" />
-                      </div>
-                      <h3 className="font-display font-semibold text-spark-text-primary text-lg mb-2">
-                        Refund Failed
-                      </h3>
-                      <p className="text-spark-primary text-sm">
-                        {refundError || 'An error occurred while processing your refund.'}
-                      </p>
-                    </>
-                  )}
-                </div>
-
-                {refundSuccess && refundTxId && (
+              <ResultStep result="success" error={null} onClose={closeRefundFlow} operationType="refund">
+                {refundTxId && (
                   <PaymentInfoCard>
                     <CollapsibleCodeField
                       label="Transaction ID"
@@ -439,15 +413,22 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                     />
                   </PaymentInfoCard>
                 )}
-
-                <PrimaryButton onClick={closeRefundFlow} className="w-full">
-                  Done
-                </PrimaryButton>
-              </>
+              </ResultStep>
             )}
           </div>
         </BottomSheetCard>
       </BottomSheetContainer>
+
+      {/* Over the refund sheet, which is itself over the page. */}
+      <QrScannerDialog
+        isOpen={isScanning}
+        zIndex={80}
+        onClose={() => setIsScanning(false)}
+        onScan={scanned => {
+          setDestination(scanned.trim());
+          setIsScanning(false);
+        }}
+      />
     </SlideInPage>
   );
 };

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -30,6 +30,12 @@ type RefundStep = 'address' | 'fee' | 'confirm' | 'processing' | 'result';
 // the largest size never pays below the rate picked.
 const REFUND_VSIZE = 111;
 
+/** Up to two significant figures (111 to 120, 1 665 to 1 700): round, and never below the rate. */
+const roundUpFee = (sats: number) => {
+  const step = Math.max(10, 10 ** (String(Math.ceil(sats)).length - 2));
+  return Math.ceil(sats / step) * step;
+};
+
 const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirection = 'left' }) => {
   const wallet = useWallet();
 
@@ -191,7 +197,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
   };
 
   // Paid as a fixed amount, so confirm shows the exact fee and what arrives.
-  const feeFor = (speed: FeeSpeed) => (feeRates ? Math.ceil(feeRates[speed] * REFUND_VSIZE) : 0);
+  const feeFor = (speed: FeeSpeed) => (feeRates ? roundUpFee(feeRates[speed] * REFUND_VSIZE) : 0);
 
   const handleRefund = async () => {
     if (!selectedDeposit || !selectedFeeRate || !destination.trim()) return;

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -24,6 +24,11 @@ interface GetRefundPageProps {
 
 type RefundStep = 'address' | 'fee' | 'confirm' | 'processing' | 'result';
 
+// A refund spends the deposit's one taproot input to one output: 111 vB when
+// that output is taproot or P2WSH, less for other address types. Pricing at
+// the largest size never pays below the rate picked.
+const REFUND_VSIZE = 111;
+
 const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirection = 'left' }) => {
   const wallet = useWallet();
 
@@ -44,12 +49,8 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
   const [refundTxId, setRefundTxId] = useState<string | null>(null);
   const [isTxIdVisible, setIsTxIdVisible] = useState<boolean>(false);
 
-  // Fee estimates (simplified - in real implementation, get from SDK)
-  const feeEstimates = {
-    slow: 500,
-    medium: 1000,
-    fast: 2000
-  };
+  const [feeRates, setFeeRates] = useState<Record<FeeSpeed, number> | null>(null);
+  const [feeRatesError, setFeeRatesError] = useState<string | null>(null);
 
   // State for expandable transaction ID fields in examples
   const [expandedTxIds, setExpandedTxIds] = useState<Record<string, boolean>>({});
@@ -166,7 +167,30 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
     setDestination(address);
     setDestinationError(null);
     setRefundStep('fee');
+    void loadFeeRates();
   };
+
+  // Current rates on every visit from the address step, as the exit flow reads them.
+  const loadFeeRates = async () => {
+    setFeeRates(null);
+    setFeeRatesError(null);
+    try {
+      const fees = await wallet.recommendedFees();
+      setFeeRates({
+        slow: Math.max(1, fees.hourFee),
+        medium: Math.max(1, fees.halfHourFee),
+        fast: Math.max(1, fees.fastestFee),
+      });
+    } catch (e) {
+      logger.error(LogCategory.PAYMENT, 'Failed to read fee rates for a refund', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      setFeeRatesError("Couldn't read the current fee rates. Go back and try again.");
+    }
+  };
+
+  // Paid as a fixed amount, so confirm shows the exact fee and what arrives.
+  const feeFor = (speed: FeeSpeed) => (feeRates ? Math.ceil(feeRates[speed] * REFUND_VSIZE) : 0);
 
   const handleRefund = async () => {
     if (!selectedDeposit || !selectedFeeRate || !destination.trim()) return;
@@ -176,7 +200,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
     setRefundStep('processing');
 
     try {
-      const fee: Fee = { type: 'fixed', amount: feeEstimates[selectedFeeRate] };
+      const fee: Fee = { type: 'fixed', amount: feeFor(selectedFeeRate) };
       const result = await wallet.refundDeposit({ txid: selectedDeposit.txid, vout: selectedDeposit.vout, destinationAddress: destination.trim(), fee });
 
       // Remove from rejected list after successful refund
@@ -197,10 +221,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
     }
   };
 
-  const getSelectedFee = () => {
-    if (!selectedFeeRate) return 0;
-    return feeEstimates[selectedFeeRate];
-  };
+  const getSelectedFee = () => (selectedFeeRate ? feeFor(selectedFeeRate) : 0);
 
   const getRefundAmount = () => {
     if (!selectedDeposit) return 0;
@@ -347,15 +368,23 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
             {/* Step 2: Fee Selection */}
             {refundStep === 'fee' && (
               <>
-                <FeeRateSelector
-                  selected={selectedFeeRate}
-                  onSelect={setSelectedFeeRate}
-                  detail={speed => <SatAmount sats={feeEstimates[speed]} />}
-                />
+                {feeRatesError ? (
+                  <SimpleAlert variant="error">{feeRatesError}</SimpleAlert>
+                ) : feeRates ? (
+                  <FeeRateSelector
+                    selected={selectedFeeRate}
+                    onSelect={setSelectedFeeRate}
+                    detail={speed => <SatAmount sats={feeFor(speed)} />}
+                  />
+                ) : (
+                  <div className="py-8 flex justify-center">
+                    <LoadingSpinner text="Reading current fee rates..." />
+                  </div>
+                )}
 
                 <PrimaryButton
                   onClick={() => setRefundStep('confirm')}
-                  disabled={!selectedFeeRate}
+                  disabled={!selectedFeeRate || !feeRates}
                   className="w-full"
                 >
                   Continue

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -10,6 +10,7 @@ import { isDepositRejected, removeRejectedDeposit } from '../services/depositSta
 import { SatAmount } from '../components/SatAmount';
 import { DestinationField } from '../components/DestinationField';
 import QrScannerDialog from '../components/QrScannerDialog';
+import ProcessingStep from '../features/send/steps/ProcessingStep';
 import ResultStep from '../features/send/steps/ResultStep';
 import { destinationAddressOf } from '../utils/destinationAddress';
 import { truncateAddress } from '../utils/crossChainFormat';
@@ -422,11 +423,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
             )}
 
             {/* Step 4: Processing */}
-            {refundStep === 'processing' && (
-              <div className="py-8 flex flex-col items-center justify-center">
-                <LoadingSpinner text="Processing refund..." />
-              </div>
-            )}
+            {refundStep === 'processing' && <ProcessingStep />}
 
             {/* Step 5: Result */}
             {refundStep === 'result' && (

--- a/src/pages/UnilateralExitPage.tsx
+++ b/src/pages/UnilateralExitPage.tsx
@@ -13,7 +13,7 @@ import { useBackButton } from '@/hooks/useBackButton';
 import { isPinEnabled } from '@/services/appLock';
 import { canContinueFromQuote, useUnilateralExitFlow } from '@/features/unilateral-exit/hooks/useUnilateralExitFlow';
 import { IntroStep } from '@/features/unilateral-exit/steps/IntroStep';
-import { DestinationStep } from '@/features/unilateral-exit/steps/DestinationStep';
+import { DestinationField } from '@/components/DestinationField';
 import { FeeStep } from '@/features/unilateral-exit/steps/FeeStep';
 import { QuoteStep } from '@/features/unilateral-exit/steps/QuoteStep';
 import { FundStep, FundingStatus } from '@/features/unilateral-exit/steps/FundStep';
@@ -170,7 +170,7 @@ const UnilateralExitPage: React.FC<UnilateralExitPageProps> = ({ network, onBack
             {flow.phase === 'intro' && <IntroStep />}
 
             {flow.phase === 'destination' && (
-              <DestinationStep
+              <DestinationField
                 {...flow.destination}
                 onSubmit={() => void flow.submitDestination()}
                 onScanQr={() => setIsScanning(true)}

--- a/src/utils/destinationAddress.ts
+++ b/src/utils/destinationAddress.ts
@@ -1,0 +1,8 @@
+import type { InputType } from '@breeztech/breez-sdk-spark';
+
+/** The on-chain address a destination names. A scanned receive QR is a BIP21 URI, so the address comes out of it. */
+export function destinationAddressOf(parsed: InputType | null): string | undefined {
+  if (parsed?.type === 'bitcoinAddress') return parsed.address;
+  if (parsed?.type !== 'bip21') return undefined;
+  return parsed.paymentMethods.flatMap(method => (method.type === 'bitcoinAddress' ? [method.address] : []))[0];
+}


### PR DESCRIPTION
This PR brings the Refund flow in line with Send and Unilateral Exit, and prices refunds from current fee rates instead of fixed amounts. It builds on #420.

### Changes
- Use Unilateral Exit's destination field, with Paste and Scan, and take the address from a scanned `bitcoin:` QR code.
- Remove Cancel from the destination step, since the header's close button covers it.
- Show the refund address on the confirm step.
- Use Send's processing and result screens, keeping the transaction ID on the result.
- Price each speed from the network's current fee rates instead of 500, 1 000 and 2 000 sats, rounded up to a round amount. The fee is still paid as a fixed amount, so the confirm step shows the exact fee and the amount received.

### Test plan
- Refund a rejected deposit on mainnet: paste or scan an address, pick a speed, check the fee and the amount received on confirm, then refund.

### UI changes
| Destination | Fee* | Confirm | Result |
|---|---|---|---|
| <img width="80%" alt="image" src="https://github.com/user-attachments/assets/555e59c8-0fe8-475b-b3c2-297a76dcb8a1" /> | <img width="100%" alt="image" src="https://github.com/user-attachments/assets/75686f50-f4dd-45eb-920e-9e50967647fe" />| <img width="90%" alt="image" src="https://github.com/user-attachments/assets/35809011-6ffc-414c-b224-daca7dd20d08" /> | <img width="95%" alt="image" src="https://github.com/user-attachments/assets/cbeb6bd6-0eea-49dc-bd47-137370c83b1f" /> |
|  | <sub>On regtest every speed is 1 sat/vB, so all three read ₿120. On mainnet they differ.</sub> |