### PR TITLE
feat: edit the Lightning address in its own sheet

### DIFF
--- a/src/features/receive/LightningAddressDisplay.tsx
+++ b/src/features/receive/LightningAddressDisplay.tsx
@@ -2,23 +2,17 @@ import React from 'react';
 import type { LightningAddressInfo } from '@breeztech/breez-sdk-spark';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import { SimpleAlert } from '../../components/AlertCard';
-import { QRCodeContainer, PrimaryButton, SecondaryButton, FormError, CopyableText, TextButton } from '../../components/ui';
+import { QRCodeContainer, PrimaryButton, CopyableText, TextButton } from '../../components/ui';
 import { useToast } from '../../contexts/ToastContext';
-import { EditIcon, LightningBoltIcon } from '../../components/Icons';
-import { dismissKeyboard } from '../../utils/keyboard';
+import { EditIcon } from '../../components/Icons';
 
 export interface LightningAddressDisplayProps {
   address: LightningAddressInfo | null;
   isLoading: boolean;
-  isEditing: boolean;
-  editValue: string;
-  error: string | null;
   isSupported: boolean;
   supportMessage: string | null;
+  /** Opens the edit sheet, which also creates the first address. */
   onEdit: () => void;
-  onSave: () => void;
-  onCancel: () => void;
-  onEditValueChange: (value: string) => void;
   onCustomizeAmount: () => void;
 }
 
@@ -33,113 +27,12 @@ const EditButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
   </button>
 );
 
-// Separate component to handle keyboard visibility
-interface EditingFormProps {
-  address: LightningAddressInfo | null;
-  editValue: string;
-  error: string | null;
-  isLoading: boolean;
-  onEditValueChange: (value: string) => void;
-  onCancel: () => void;
-  onSave: () => void;
-}
-
-const EditingForm: React.FC<EditingFormProps> = ({
-  address,
-  editValue,
-  error,
-  isLoading,
-  onEditValueChange,
-  onCancel,
-  onSave,
-}) => {
-  return (
-    <div className="pt-2 space-y-5">
-      {/* Header with icon */}
-      <div className="flex flex-col items-center gap-3">
-        <div className="w-14 h-14 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-          <LightningBoltIcon className="w-7 h-7 text-spark-primary" />
-        </div>
-        <h3 className="font-display text-lg font-semibold text-spark-text-primary">
-          {address ? 'Edit Address' : 'Create Address'}
-        </h3>
-      </div>
-
-      {/* Input with suffix */}
-      <div className="space-y-4">
-        <div className="flex items-center bg-spark-dark border border-spark-border rounded-xl overflow-hidden focus-within:border-spark-primary transition-all">
-          <textarea
-            value={editValue}
-            onChange={(e) => onEditValueChange(e.target.value.toLowerCase().replace(/[^a-z0-9\n]/g, '').replace(/\n/g, ''))}
-            onKeyDown={async (e) => {
-              // Last and only field in this form — Enter submits
-              // via the same path as the Save button. Soft keyboard
-              // shows "Done" via enterKeyHint.
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                if (!isLoading && editValue.trim()) {
-                  await dismissKeyboard();
-                  onSave();
-                } else {
-                  // Empty / invalid input: still retract the
-                  // keyboard so the user can see the Save button.
-                  await dismissKeyboard();
-                }
-              }
-            }}
-            enterKeyHint="done"
-            inputMode="text"
-            // A textarea (not an input) to keep Android's autofill bar away,
-            // so it soft-wraps a long username onto a second row. wrap="off"
-            // makes it scroll horizontally like a single-line field (#328).
-            wrap="off"
-            autoCapitalize="none"
-            autoCorrect="off"
-            autoComplete="off"
-            spellCheck={false}
-            placeholder="satoshi"
-            disabled={isLoading}
-            rows={1}
-            className="flex-1 min-w-0 bg-transparent px-4 py-3 text-spark-text-primary text-lg font-mono placeholder-spark-text-muted focus:outline-hidden resize-none"
-          />
-          <span className="shrink-0 px-4 py-3 text-spark-text-muted font-medium text-sm">
-            @breez.tips
-          </span>
-        </div>
-
-        <FormError error={error} />
-      </div>
-
-      {/* Action buttons */}
-      <div className="flex gap-3 justify-center pt-2 pb-4">
-        <SecondaryButton onClick={onCancel} className="flex-1">
-          Cancel
-        </SecondaryButton>
-        <PrimaryButton
-          onClick={onSave}
-          disabled={isLoading || !editValue.trim()}
-          className="flex-1"
-          data-testid="save-address-button"
-        >
-          {isLoading ? <LoadingSpinner size="small" /> : 'Save'}
-        </PrimaryButton>
-      </div>
-    </div>
-  );
-};
-
 const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
   address,
   isLoading,
-  isEditing,
-  editValue,
-  error,
   isSupported,
   supportMessage,
   onEdit,
-  onSave,
-  onCancel,
-  onEditValueChange,
   onCustomizeAmount,
 }) => {
   const { showToast } = useToast();
@@ -196,7 +89,7 @@ const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
     );
   }
 
-  if (!address && !isEditing) {
+  if (!address) {
     return (
       <div className="pt-4 space-y-6 flex flex-col items-center">
         <div className="text-center">
@@ -217,20 +110,6 @@ const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
           </TextButton>
         </div>
       </div>
-    );
-  }
-
-  if (isEditing) {
-    return (
-      <EditingForm
-        address={address}
-        editValue={editValue}
-        error={error}
-        isLoading={isLoading}
-        onEditValueChange={onEditValueChange}
-        onCancel={onCancel}
-        onSave={onSave}
-      />
     );
   }
 

--- a/src/features/receive/LightningAddressDisplay.tsx
+++ b/src/features/receive/LightningAddressDisplay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { LightningAddressInfo } from '@breeztech/breez-sdk-spark';
 import LoadingSpinner from '../../components/LoadingSpinner';
-import { SimpleAlert } from '../../components/AlertCard';
+import { AlertCard } from '../../components/AlertCard';
 import { QRCodeContainer, PrimaryButton, CopyableText, TextButton } from '../../components/ui';
 import { useToast } from '../../contexts/ToastContext';
 import { EditIcon } from '../../components/Icons';
@@ -10,7 +10,6 @@ export interface LightningAddressDisplayProps {
   address: LightningAddressInfo | null;
   isLoading: boolean;
   isSupported: boolean;
-  supportMessage: string | null;
   /** Opens the edit sheet, which also creates the first address. */
   onEdit: () => void;
   onCustomizeAmount: () => void;
@@ -31,7 +30,6 @@ const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
   address,
   isLoading,
   isSupported,
-  supportMessage,
   onEdit,
   onCustomizeAmount,
 }) => {
@@ -40,16 +38,11 @@ const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
   if (!isSupported) {
     return (
       <div className="pt-4 space-y-6 flex flex-col items-center text-center">
-        <SimpleAlert
-          variant="info"
-          className="w-full text-left"
-          dataTestId="lightning-address-unsupported"
-        >
-          <h3 className="font-display text-lg font-semibold text-spark-text-primary mb-2">Lightning Address</h3>
-          <p className="text-spark-text-secondary text-sm">
-            {supportMessage ?? 'Lightning addresses are not available in this environment.'}
+        <AlertCard variant="info" title="Lightning addresses unavailable" className="w-full text-left">
+          <p className="text-spark-text-secondary text-sm" data-testid="lightning-address-unsupported">
+            They&apos;re not supported in this environment.
           </p>
-        </SimpleAlert>
+        </AlertCard>
 
         <div className="w-full flex justify-center">
           <TextButton
@@ -71,7 +64,7 @@ const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
   // `getLightningAddress() → null`, auto-registers a random
   // username, then re-fetches. `isLoading=true` and `address=null`
   // for the full lookup→register→re-lookup span — without this
-  // branch the user saw the `!address && !isEditing` fallback
+  // branch the user saw the `!address` fallback
   // ("Create Lightning Address" button) flash during auto-creation,
   // which is confusing because they didn't ask to create anything.
   //

--- a/src/features/receive/LightningAddressEditSheet.test.tsx
+++ b/src/features/receive/LightningAddressEditSheet.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { BreezSdk, LightningAddressInfo } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { ToastProvider } from '@/contexts/ToastContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { waitForSheetOpen } from '@/test/utils/waitForSheetOpen';
+import ReceivePaymentDialog from './ReceivePaymentDialog';
+
+const address = (username: string): LightningAddressInfo => ({
+  description: `Pay to ${username}@breez.tips`,
+  lightningAddress: `${username}@breez.tips`,
+  lnurl: { url: `https://breez.tips/lnurlp/${username}`, bech32: 'lnurl1dp68gurn8ghj7' },
+  username,
+});
+
+describe('Lightning address edit sheet', () => {
+  it('changes the username from its own sheet, after confirming', async () => {
+    const client = createMockClient() as unknown as BreezSdk;
+    client.getLightningAddress = vi.fn().mockResolvedValue(address('alice'));
+
+    render(
+      <ToastProvider>
+        <WalletProvider client={client} isConnected>
+          <FiatDataProvider>
+            <StableBalanceProvider>
+              <ReceivePaymentDialog isOpen onClose={vi.fn()} />
+            </StableBalanceProvider>
+          </FiatDataProvider>
+        </WalletProvider>
+      </ToastProvider>,
+    );
+    await waitForSheetOpen();
+
+    fireEvent.click(await screen.findByTitle('Edit Lightning Address'));
+    // Let the edit sheet finish opening too, for the reason in waitForSheetOpen.
+    const title = await screen.findByText('Edit Address');
+    await waitFor(() => expect(title.closest('.react-modal-sheet-root')).toBeVisible());
+
+    fireEvent.change(screen.getByPlaceholderText('satoshi'), { target: { value: 'bob' } });
+    fireEvent.click(screen.getByTestId('save-address-button'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Change' }));
+
+    await waitFor(() =>
+      expect(client.registerLightningAddress).toHaveBeenCalledWith(expect.objectContaining({ username: 'bob' })),
+    );
+    await waitFor(() => expect(screen.queryByText('Edit Address')).toBeNull());
+  });
+});

--- a/src/features/receive/LightningAddressEditSheet.tsx
+++ b/src/features/receive/LightningAddressEditSheet.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import type { LightningAddressInfo } from '@breeztech/breez-sdk-spark';
+import { BottomSheetContainer, BottomSheetCard, DialogHeader, FormError, LoadingSpinner, PrimaryButton } from '../../components/ui';
+import { LightningBoltIcon } from '../../components/Icons';
+import { dismissKeyboard } from '../../utils/keyboard';
+
+interface LightningAddressEditSheetProps {
+  isOpen: boolean;
+  /** The current address, or null when creating the first one. */
+  address: LightningAddressInfo | null;
+  editValue: string;
+  error: string | null;
+  isLoading: boolean;
+  onEditValueChange: (value: string) => void;
+  onSave: () => void;
+  onClose: () => void;
+}
+
+const LightningAddressEditSheet: React.FC<LightningAddressEditSheetProps> = ({
+  isOpen,
+  address,
+  editValue,
+  error,
+  isLoading,
+  onEditValueChange,
+  onSave,
+  onClose,
+}) => (
+  <BottomSheetContainer isOpen={isOpen} onClose={onClose} showBackdrop>
+    <BottomSheetCard>
+      <DialogHeader
+        title={address ? 'Edit Address' : 'Create Address'}
+        onClose={onClose}
+        icon={<LightningBoltIcon />}
+      />
+
+      <div className="space-y-4">
+        <div className="flex items-center bg-spark-dark border border-spark-border rounded-xl overflow-hidden focus-within:border-spark-primary transition-all">
+          <textarea
+            value={editValue}
+            onChange={(e) => onEditValueChange(e.target.value.toLowerCase().replace(/[^a-z0-9\n]/g, '').replace(/\n/g, ''))}
+            onKeyDown={async (e) => {
+              // Last and only field in this form: Enter submits
+              // via the same path as the Save button. Soft keyboard
+              // shows "Done" via enterKeyHint.
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                if (!isLoading && editValue.trim()) {
+                  await dismissKeyboard();
+                  onSave();
+                } else {
+                  // Empty / invalid input: still retract the
+                  // keyboard so the user can see the Save button.
+                  await dismissKeyboard();
+                }
+              }
+            }}
+            enterKeyHint="done"
+            inputMode="text"
+            // A textarea (not an input) to keep Android's autofill bar away,
+            // so it soft-wraps a long username onto a second row. wrap="off"
+            // makes it scroll horizontally like a single-line field (#328).
+            wrap="off"
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="satoshi"
+            disabled={isLoading}
+            rows={1}
+            className="flex-1 min-w-0 bg-transparent px-4 py-3 text-spark-text-primary text-lg font-mono placeholder-spark-text-muted focus:outline-hidden resize-none"
+          />
+          <span className="shrink-0 px-4 py-3 text-spark-text-muted font-medium text-sm">
+            @breez.tips
+          </span>
+        </div>
+
+        <FormError error={error} />
+
+        <PrimaryButton
+          onClick={onSave}
+          disabled={isLoading || !editValue.trim()}
+          className="w-full"
+          data-testid="save-address-button"
+        >
+          {isLoading ? <LoadingSpinner size="small" /> : 'Save'}
+        </PrimaryButton>
+      </div>
+    </BottomSheetCard>
+  </BottomSheetContainer>
+);
+
+export default LightningAddressEditSheet;

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -119,7 +119,6 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
     editValue: lightningAddressEditValue,
     error: lightningAddressError,
     isSupported: isLightningAddressSupported,
-    supportMessage: lightningAddressSupportMessage,
     load: loadLightningAddress,
     beginEdit: beginEditLightningAddress,
     cancelEdit: cancelEditLightningAddress,
@@ -231,7 +230,6 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
                             address={lightningAddress}
                             isLoading={lightningAddressLoading}
                             isSupported={isLightningAddressSupported}
-                            supportMessage={lightningAddressSupportMessage}
                             onEdit={() => beginEditLightningAddress(lightningAddress)}
                             onCustomizeAmount={() => receive.setShowAmountPanel(true)}
                           />

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -23,6 +23,7 @@ import { formatWithSpaces } from '../../utils/formatNumber';
 import SparkAddressDisplay from './SparkAddressDisplay';
 import BitcoinAddressDisplay from './BitcoinAddressDisplay';
 import LightningAddressDisplay from './LightningAddressDisplay';
+import LightningAddressEditSheet from './LightningAddressEditSheet';
 import CrossChainReceiveWorkflow from './workflows/CrossChainReceiveWorkflow';
 import AmountPanel from './AmountPanel';
 import { ArrowDownIcon, LightningBoltIcon } from '../../components/Icons';
@@ -229,15 +230,9 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
                           <LightningAddressDisplay
                             address={lightningAddress}
                             isLoading={lightningAddressLoading}
-                            isEditing={isEditingLightningAddress}
-                            editValue={lightningAddressEditValue}
-                            error={lightningAddressError}
                             isSupported={isLightningAddressSupported}
                             supportMessage={lightningAddressSupportMessage}
                             onEdit={() => beginEditLightningAddress(lightningAddress)}
-                            onSave={handleSaveLightningAddress}
-                            onCancel={() => cancelEditLightningAddress()}
-                            onEditValueChange={setLightningAddressEditValue}
                             onCustomizeAmount={() => receive.setShowAmountPanel(true)}
                           />
                         )}
@@ -324,6 +319,17 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
         onCreateInvoice={receive.generateBolt11Invoice}
         onClose={receive.closeAmountPanel}
         resetCount={receive.resetCount}
+      />
+
+      <LightningAddressEditSheet
+        isOpen={isOpen && isEditingLightningAddress}
+        address={lightningAddress}
+        editValue={lightningAddressEditValue}
+        error={lightningAddressError}
+        isLoading={lightningAddressLoading}
+        onEditValueChange={setLightningAddressEditValue}
+        onSave={handleSaveLightningAddress}
+        onClose={cancelEditLightningAddress}
       />
     </>
   );

--- a/src/features/receive/hooks/useLightningAddress.ts
+++ b/src/features/receive/hooks/useLightningAddress.ts
@@ -13,7 +13,6 @@ export interface UseLightningAddress {
   editValue: string;
   error: string | null;
   isSupported: boolean;
-  supportMessage: string | null;
   load: () => Promise<void>;
   beginEdit: (currentAddress?: LightningAddressInfo | null) => void;
   cancelEdit: () => void;
@@ -22,7 +21,6 @@ export interface UseLightningAddress {
   reset: () => void;
 }
 
-const UNSUPPORTED_MESSAGE = 'Lightning addresses are not available in this environment.';
 // The SDK surfaces every failure here as one opaque string — an unreachable
 // LNURL server reads as `TypeError: Load failed`, a registration rate limit
 // and a name lost in a race both read as `Network error (status ...)`. None of
@@ -39,7 +37,7 @@ export const useLightningAddress = (): UseLightningAddress => {
   const [address, setAddress] = useState<LightningAddressInfo | null>(null);
   // Default to `true` so the first paint of the Receive sheet shows
   // the Lightning-address loading spinner instead of the
-  // `!address && !isEditing` fallback ("Create Lightning Address"
+  // `!address` fallback ("Create Lightning Address"
   // button). Without this, users briefly see the Create button flash
   // between the sheet opening and `load()`'s `setIsLoading(true)`
   // landing on the next tick — confusing on first-launch passkey
@@ -50,11 +48,9 @@ export const useLightningAddress = (): UseLightningAddress => {
   const [editValue, setEditValue] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [isSupported, setIsSupported] = useState<boolean>(true);
-  const [supportMessage, setSupportMessage] = useState<string | null>(null);
 
   const markUnsupported = useCallback(() => {
     setIsSupported(false);
-    setSupportMessage(UNSUPPORTED_MESSAGE);
     setIsEditing(false);
     setEditValue('');
     setError(null);
@@ -79,12 +75,7 @@ export const useLightningAddress = (): UseLightningAddress => {
   const loadInFlightRef = useRef(false);
 
   const load = useCallback(async () => {
-    if (!isSupported) {
-      if (!supportMessage) {
-        setSupportMessage(UNSUPPORTED_MESSAGE);
-      }
-      return;
-    }
+    if (!isSupported) return;
     // Already loaded from a prior call — skip the SDK roundtrip.
     // `load()` fires on every Receive-dialog open + every Lightning
     // tab switch; without this short-circuit each reopening pays
@@ -127,7 +118,7 @@ export const useLightningAddress = (): UseLightningAddress => {
       setIsLoading(false);
       loadInFlightRef.current = false;
     }
-  }, [wallet, isSupported, markUnsupported, supportMessage, addressRef]);
+  }, [wallet, isSupported, markUnsupported, addressRef]);
 
   // Pre-load the Lightning address as soon as the hook mounts (which
   // happens on WalletPage mount, well before the user taps Receive).
@@ -223,7 +214,6 @@ export const useLightningAddress = (): UseLightningAddress => {
     editValue,
     error,
     isSupported,
-    supportMessage,
     load,
     beginEdit,
     cancelEdit,


### PR DESCRIPTION
This PR opens Lightning address editing in its own sheet, the way Create Invoice does, instead of swapping the Lightning tab for a form under the Receive header and tabs.

### Changes
- Open Edit Address and Create Address in a child sheet, with Save full width and the sheet's close button in place of Cancel.
- Remove the form's icon tile and heading.
- Show the "not available" message as a standard alert card, with a clearer title and no icon.

### Test plan
- Receive > Lightning: tap Edit, change the username and save, confirm the change prompt, and check the new address shows.

### UI changes

| Edit Address | Not available |
|---|---|
| <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/f7cf2dcc-e77d-4fb7-aa31-b9a9f2a4c531" /> | <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/df630d5d-86b1-4ea2-9433-55f3a3a7d5f9" /> |
