### PR TITLE
feat: merge Lightning and on-chain receive into one BTC tab

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -276,6 +276,14 @@ export const LightningBoltIcon: React.FC<IconProps> = ({ className = '', size = 
   </svg>
 );
 
+// Inset viewBox: an outlined chain at full size reads larger than the solid bolt beside it.
+export const ChainLinkIcon: React.FC<IconProps> = ({ className = '', size = 'md' }) => (
+  <svg className={`${sizeClasses[size]} ${className}`} fill="none" viewBox="-1 -1 26 26" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </svg>
+);
+
 export const WalletIcon: React.FC<IconProps> = ({ className = '', size = 'md' }) => (
   <svg className={`${sizeClasses[size]} ${className}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />

--- a/src/components/ui/QRCodeContainer.tsx
+++ b/src/components/ui/QRCodeContainer.tsx
@@ -1,25 +1,52 @@
 import React from 'react';
 import { QRCode } from 'react-qr-code';
 
+const Corners: React.FC = () => (
+  <div className="absolute -inset-3 pointer-events-none">
+    <div className="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-spark-primary/50 rounded-tl-lg" />
+    <div className="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-spark-primary/50 rounded-tr-lg" />
+    <div className="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-spark-primary/50 rounded-bl-lg" />
+    <div className="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-spark-primary/50 rounded-br-lg" />
+  </div>
+);
+
+interface QrFrameProps {
+  size?: number;
+  className?: string;
+  /** Applied to the white card alone, so it can move inside the fixed corners. */
+  cardClassName?: string;
+}
+
 /**
  * QR Code display component with decorative corners.
  * Separated from barrel file to enable lazy loading of react-qr-code library.
  */
-export const QRCodeContainer: React.FC<{
-  value: string;
-  size?: number;
-  className?: string;
-}> = ({ value, size = 200, className = "" }) => (
+export const QRCodeContainer: React.FC<QrFrameProps & { value: string }> = ({ value, size = 200, className = '', cardClassName = '' }) => (
   <div className={`relative ${className}`}>
-    {/* Decorative corners */}
-    <div className="absolute -inset-3 pointer-events-none">
-      <div className="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-spark-primary/50 rounded-tl-lg" />
-      <div className="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-spark-primary/50 rounded-tr-lg" />
-      <div className="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-spark-primary/50 rounded-bl-lg" />
-      <div className="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-spark-primary/50 rounded-br-lg" />
-    </div>
-    <div className="qr-container">
+    <Corners />
+    <div className={`qr-container ${cardClassName}`}>
       <QRCode value={value} size={size} />
+    </div>
+  </div>
+);
+
+/** Holds a QR's place while its value loads: the same frame and card, with a sweep where the code goes. */
+export const QrPlaceholder: React.FC<QrFrameProps> = ({ size = 200, className = '', cardClassName = '' }) => (
+  <div className={`relative ${className}`} aria-hidden="true">
+    <Corners />
+    <div className={`qr-container relative overflow-hidden ${cardClassName}`}>
+      <div className="relative" style={{ width: size, height: size }}>
+        {['top-0 left-0', 'top-0 right-0', 'bottom-0 left-0'].map((corner) => (
+          <div key={corner} className={`absolute ${corner} w-[21%] h-[21%] rounded-lg border-[6px] border-spark-border/15`} />
+        ))}
+      </div>
+      <div
+        className="absolute inset-0 animate-[shimmer_2s_linear_infinite] motion-reduce:animate-none"
+        style={{
+          backgroundImage: 'linear-gradient(110deg, transparent 35%, color-mix(in srgb, var(--spark-primary) 22%, transparent) 50%, transparent 65%)',
+          backgroundSize: '200% 100%',
+        }}
+      />
     </div>
   </div>
 );

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -29,7 +29,7 @@ import { STATUS_BAR_DIALOG_SCRIM } from '../../utils/statusBarManager';
 // ============================================
 
 // QR Code (lazy-loadable, contains react-qr-code dependency)
-export { QRCodeContainer } from './QRCodeContainer';
+export { QRCodeContainer, QrPlaceholder } from './QRCodeContainer';
 
 // Buttons
 export { PrimaryButton, SecondaryButton, TextButton, FloatingIconButton } from './buttons';

--- a/src/features/receive/BitcoinAddressDisplay.tsx
+++ b/src/features/receive/BitcoinAddressDisplay.tsx
@@ -1,29 +1,29 @@
 import React from 'react';
-import LoadingSpinner from '../../components/LoadingSpinner';
-import { QRCodeContainer, CopyableText } from '../../components/ui';
+import { QRCodeContainer, QrPlaceholder, CopyableText } from '../../components/ui';
 import { useToast } from '../../contexts/ToastContext';
 
 interface Props {
   address: string | null;
   isLoading: boolean;
+  /** The QR slot beside the side dock, or the address and actions under it. */
+  section: 'qr' | 'details';
+  qrSize?: number;
+  qrCardClassName?: string;
 }
 
-const BitcoinAddressDisplay: React.FC<Props> = ({ address, isLoading }) => {
+const BitcoinAddressDisplay: React.FC<Props> = ({ address, isLoading, section, qrSize, qrCardClassName }) => {
   const { showToast } = useToast();
 
-  if (isLoading || !address) {
-    return (
-      <div className="text-center py-8">
-        <LoadingSpinner text="Generating Bitcoin address..." />
-      </div>
-    );
+  if (section === 'qr') {
+    // A placeholder, not a spinner: the card's turn already covers most of the wait.
+    return !isLoading && address
+      ? <QRCodeContainer value={address} size={qrSize} cardClassName={qrCardClassName} />
+      : <QrPlaceholder size={qrSize} cardClassName={qrCardClassName} />;
   }
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <QRCodeContainer value={address} />
-
-      <div className="w-full flex flex-col items-center gap-4">
+    <div className="w-full flex flex-col items-center gap-4">
+      {!isLoading && address ? (
         <CopyableText
           text={address}
           truncate
@@ -33,10 +33,18 @@ const BitcoinAddressDisplay: React.FC<Props> = ({ address, isLoading }) => {
           onShareError={() => showToast('error', 'Failed to share')}
           data-testid="bitcoin-address-text"
         />
+      ) : (
+        <div className="flex flex-col items-center gap-4" aria-hidden="true">
+          <div className="h-4 w-48 rounded-full bg-white/5" />
+          <div className="flex gap-2">
+            <div className="h-[38px] w-[92px] rounded-xl bg-white/5" />
+            <div className="h-[38px] w-[100px] rounded-xl bg-white/5" />
+          </div>
+        </div>
+      )}
 
-        {/* Spacer to match Lightning tab height */}
-        <div className="mt-2 h-6" aria-hidden="true" />
-      </div>
+      {/* Spacer to match Lightning tab height */}
+      <div className="mt-2 h-6" aria-hidden="true" />
     </div>
   );
 };

--- a/src/features/receive/LightningAddressDisplay.tsx
+++ b/src/features/receive/LightningAddressDisplay.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import type { LightningAddressInfo } from '@breeztech/breez-sdk-spark';
-import LoadingSpinner from '../../components/LoadingSpinner';
 import { AlertCard } from '../../components/AlertCard';
-import { QRCodeContainer, PrimaryButton, CopyableText, TextButton } from '../../components/ui';
+import { QRCodeContainer, QrPlaceholder, PrimaryButton, CopyableText, TextButton } from '../../components/ui';
 import { useToast } from '../../contexts/ToastContext';
 import { EditIcon } from '../../components/Icons';
 
@@ -13,6 +12,10 @@ export interface LightningAddressDisplayProps {
   /** Opens the edit sheet, which also creates the first address. */
   onEdit: () => void;
   onCustomizeAmount: () => void;
+  /** The QR slot beside the side dock, or the address and actions under it. */
+  section: 'qr' | 'details';
+  qrSize?: number;
+  qrCardClassName?: string;
 }
 
 const EditButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
@@ -32,32 +35,36 @@ const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
   isSupported,
   onEdit,
   onCustomizeAmount,
+  section,
+  qrSize = 200,
+  qrCardClassName,
 }) => {
   const { showToast } = useToast();
+  const amountLink = (className: string) => (
+    <TextButton
+      onClick={onCustomizeAmount}
+      className={`${className} show-amount-panel-button`}
+      data-testid="show-amount-panel-button"
+    >
+      Create invoice with specific amount →
+    </TextButton>
+  );
+  // A message in the QR slot takes the card's width, so the dock and caption stay put.
+  const slot = (children: ReactNode) => <div style={{ width: qrSize + 32 }}>{children}</div>;
 
   if (!isSupported) {
-    return (
-      <div className="pt-4 space-y-6 flex flex-col items-center text-center">
-        <AlertCard variant="info" title="Lightning addresses unavailable" className="w-full text-left">
-          <p className="text-spark-text-secondary text-sm" data-testid="lightning-address-unsupported">
-            They&apos;re not supported in this environment.
-          </p>
-        </AlertCard>
-
-        <div className="w-full flex justify-center">
-          <TextButton
-            onClick={onCustomizeAmount}
-            className="text-sm show-amount-panel-button"
-            data-testid="show-amount-panel-button"
-          >
-            Create invoice with specific amount →
-          </TextButton>
-        </div>
-      </div>
+    return section === 'qr' ? slot(
+      <AlertCard variant="info" title="Lightning addresses unavailable" className="w-full text-left">
+        <p className="text-spark-text-secondary text-sm" data-testid="lightning-address-unsupported">
+          They&apos;re not supported in this environment.
+        </p>
+      </AlertCard>,
+    ) : (
+      <div className="w-full flex justify-center">{amountLink('text-sm')}</div>
     );
   }
 
-  // Loading state — gated on `!address` so we only show the spinner
+  // Loading state — gated on `!address` so we only show the placeholder
   // while the address is genuinely unknown. The first open after
   // passkey onboarding (new label, no LN address registered yet)
   // lands here: `useLightningAddress.load()` hits
@@ -69,71 +76,51 @@ const LightningAddressDisplay: React.FC<LightningAddressDisplayProps> = ({
   // which is confusing because they didn't ask to create anything.
   //
   // The earlier version of this branch gated on plain `isLoading`
-  // and caused a spinner flash on every tab switch because
+  // and caused a flash on every tab switch because
   // `load()` refires on Lightning-tab re-entry even when `address`
   // is already cached. Gating on `!address` fixes that regression
   // too: cached-address + in-flight refresh now stays on the QR
   // view.
   if (isLoading && !address) {
-    return (
-      <div className="text-center py-8">
-        <LoadingSpinner text="Loading Lightning Address..." />
-      </div>
-    );
+    return section === 'qr' ? <QrPlaceholder size={qrSize} cardClassName={qrCardClassName} /> : null;
   }
 
   if (!address) {
-    return (
-      <div className="pt-4 space-y-6 flex flex-col items-center">
-        <div className="text-center">
-          <h3 className="font-display text-lg font-semibold text-spark-text-primary mb-2">Lightning Address</h3>
-          <p className="text-spark-text-secondary text-sm mb-4">
-            Create a Lightning Address to receive payments easily
-          </p>
-          <PrimaryButton onClick={onEdit}>Create Lightning Address</PrimaryButton>
-        </div>
-
-        <div className="w-full flex justify-center">
-          <TextButton
-            onClick={onCustomizeAmount}
-            className="text-sm show-amount-panel-button"
-            data-testid="show-amount-panel-button"
-          >
-            Create invoice with specific amount →
-          </TextButton>
-        </div>
-      </div>
+    return section === 'qr' ? slot(
+      <div className="text-center">
+        <h3 className="font-display text-lg font-semibold text-spark-text-primary mb-2">Lightning Address</h3>
+        <p className="text-spark-text-secondary text-sm mb-4">
+          Create a Lightning Address to receive payments easily
+        </p>
+        <PrimaryButton onClick={onEdit}>Create Lightning Address</PrimaryButton>
+      </div>,
+    ) : (
+      <div className="w-full flex justify-center">{amountLink('text-sm')}</div>
     );
   }
 
+  if (section === 'qr') {
+    return <QRCodeContainer value={address.lnurl.bech32.toUpperCase()} size={qrSize} cardClassName={qrCardClassName} />;
+  }
+
   return (
-    <div className="flex flex-col items-center gap-6">
-      <QRCodeContainer value={address?.lnurl.bech32.toUpperCase() || ''} />
+    <div className="w-full flex flex-col items-center gap-4">
+      <CopyableText
+        text={address.lightningAddress}
+        truncate
+        showShare
+        label="Lightning Address"
+        textColor="text-spark-primary"
+        onCopied={() => showToast('success', 'Copied!')}
+        onShareError={() => showToast('error', 'Failed to share')}
+        additionalActions={<EditButton onClick={onEdit} />}
+        textToCopy={address.lightningAddress}
+        textToShare={address.lnurl.bech32}
+        shareLabel="LNURL-Pay"
+        data-testid="lightning-address-text"
+      />
 
-      <div className="w-full flex flex-col items-center gap-4">
-        <CopyableText
-          text={address?.lightningAddress || ''}
-          truncate
-          showShare
-          label="Lightning Address"
-          textColor="text-spark-primary"
-          onCopied={() => showToast('success', 'Copied!')}
-          onShareError={() => showToast('error', 'Failed to share')}
-          additionalActions={<EditButton onClick={onEdit} />}
-          textToCopy={address?.lightningAddress || ''}
-          textToShare={address?.lnurl.bech32 || ''}
-          shareLabel="LNURL-Pay"
-          data-testid="lightning-address-text"
-        />
-
-        <TextButton
-          onClick={onCustomizeAmount}
-          className="mt-2 show-amount-panel-button"
-          data-testid="show-amount-panel-button"
-        >
-          Create invoice with specific amount →
-        </TextButton>
-      </div>
+      {amountLink('mt-2')}
     </div>
   );
 };

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useToast } from '../../contexts/ToastContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import {
@@ -26,7 +26,8 @@ import LightningAddressDisplay from './LightningAddressDisplay';
 import LightningAddressEditSheet from './LightningAddressEditSheet';
 import CrossChainReceiveWorkflow from './workflows/CrossChainReceiveWorkflow';
 import AmountPanel from './AmountPanel';
-import { ArrowDownIcon, LightningBoltIcon } from '../../components/Icons';
+import { SideCaption, SideDock, type BtcMode } from './SideDock';
+import { ArrowDownIcon } from '../../components/Icons';
 import { holdIdleLock } from '@/services/appLock';
 
 interface ReceivePaymentDialogProps {
@@ -167,6 +168,64 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
   // upstream; the receive flow is still being polished).
   const showUsdTab = isCrossChainEnabled();
 
+  // The BTC tab shows Lightning or on-chain, reusing those two tab states.
+  const isBtcTab = receive.activeTab === 'lightning' || receive.activeTab === 'bitcoin';
+  const btcMode: BtcMode = receive.activeTab === 'bitcoin' ? 'bitcoin' : 'lightning';
+  // The card lags the dock by half a turn: it swaps codes while edge-on.
+  const [shownMode, setShownMode] = useState<BtcMode>(btcMode);
+  const [turning, setTurning] = useState<'out' | 'in' | null>(null);
+  const turnTimers = useRef<number[]>([]);
+  useEffect(() => () => turnTimers.current.forEach(clearTimeout), []);
+  const switchBtcMode = (mode: BtcMode) => {
+    handleTabChange(mode);
+    turnTimers.current.forEach(clearTimeout);
+    turnTimers.current = [];
+    const later = (ms: number, fn: () => void) => turnTimers.current.push(window.setTimeout(fn, ms));
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setShownMode(mode);
+      setTurning(null);
+      return;
+    }
+    if (mode === shownMode) {
+      // Switched back before the swap: turn the same card back in.
+      if (turning === 'out') {
+        setTurning('in');
+        later(160, () => setTurning(null));
+      }
+      return;
+    }
+    setTurning('out');
+    later(160, () => {
+      setShownMode(mode);
+      setTurning('in');
+    });
+    // Cleared, so a QR replacing its placeholder does not turn in again.
+    later(320, () => setTurning(null));
+  };
+  // Narrow phones get a smaller code so the dock clears the frame.
+  const qrSize = window.innerWidth < 375 ? 184 : 200;
+  const qrCardClassName = `${turning === 'out' ? 'animate-qr-turn-out' : turning === 'in' ? 'animate-qr-turn-in' : ''} motion-reduce:animate-none`;
+  const btcView = (section: 'qr' | 'details') => (shownMode === 'lightning' ? (
+    <LightningAddressDisplay
+      address={lightningAddress}
+      isLoading={lightningAddressLoading}
+      isSupported={isLightningAddressSupported}
+      onEdit={() => beginEditLightningAddress(lightningAddress)}
+      onCustomizeAmount={() => receive.setShowAmountPanel(true)}
+      section={section}
+      qrSize={qrSize}
+      qrCardClassName={qrCardClassName}
+    />
+  ) : (
+    <BitcoinAddressDisplay
+      address={receive.bitcoinAddress}
+      isLoading={receive.bitcoinLoading}
+      section={section}
+      qrSize={qrSize}
+      qrCardClassName={qrCardClassName}
+    />
+  ));
+
   const getQRTitle = () => {
     switch (receive.activeTab) {
       case 'lightning': return 'Lightning Invoice';
@@ -198,22 +257,19 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
 
           {isContentReady ? (
             <TabContainer>
-              <TabList>
-                <Tab isActive={receive.activeTab === 'lightning'} onClick={() => handleTabChange('lightning')} data-testid="lightning-tab">
-                  <LightningBoltIcon size="sm" />
-                  Lightning
-                </Tab>
-                <Tab isActive={receive.activeTab === 'bitcoin'} onClick={() => handleTabChange('bitcoin')} data-testid="bitcoin-tab">
-                  <span className="font-bold text-sm">₿</span>
-                  Bitcoin
-                </Tab>
-                {showUsdTab && (
+              {/* One tab would be a bar with nothing to pick, so BTC stands alone. */}
+              {showUsdTab && (
+                <TabList>
+                  <Tab isActive={isBtcTab} onClick={() => { if (!isBtcTab) { handleTabChange('lightning'); setShownMode('lightning'); } }} data-testid="btc-tab">
+                    <span className="font-bold text-sm">₿</span>
+                    BTC
+                  </Tab>
                   <Tab isActive={receive.activeTab === 'usd'} onClick={() => handleTabChange('usd')} data-testid="usd-tab">
                     <span className="font-bold text-sm">$</span>
                     USD
                   </Tab>
-                )}
-              </TabList>
+                </TabList>
+              )}
 
               {/* The USD tab sits outside StepContainer: its steps size to their
                   own content (matching the cross-chain send flow), so the 280px
@@ -225,22 +281,20 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
                   <>
                     {receive.currentStep === 'input' && (
                       <div className="pt-6">
-                        {receive.activeTab === 'lightning' && (
-                          <LightningAddressDisplay
-                            address={lightningAddress}
-                            isLoading={lightningAddressLoading}
-                            isSupported={isLightningAddressSupported}
-                            onEdit={() => beginEditLightningAddress(lightningAddress)}
-                            onCustomizeAmount={() => receive.setShowAmountPanel(true)}
-                          />
+                        {isBtcTab && (
+                          <div className="flex flex-col items-center gap-6">
+                            {/* Dock, code, caption: the grid keeps the code centered between them. */}
+                            <div className="-mx-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center self-stretch">
+                              <SideDock mode={btcMode} onChange={switchBtcMode} />
+                              {btcView('qr')}
+                              <SideCaption shown={shownMode} mode={btcMode} onChange={switchBtcMode} />
+                            </div>
+                            {btcView('details')}
+                          </div>
                         )}
 
                         {receive.activeTab === 'spark' && (
                           <SparkAddressDisplay address={receive.sparkAddress} isLoading={receive.sparkLoading} />
-                        )}
-
-                        {receive.activeTab === 'bitcoin' && (
-                          <BitcoinAddressDisplay address={receive.bitcoinAddress} isLoading={receive.bitcoinLoading} />
                         )}
                       </div>
                     )}

--- a/src/features/receive/SideDock.tsx
+++ b/src/features/receive/SideDock.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ChainLinkIcon, LightningBoltIcon } from '../../components/Icons';
+
+export type BtcMode = 'lightning' | 'bitcoin';
+
+const LABEL: Record<BtcMode, string> = { lightning: 'Lightning', bitcoin: 'On-chain' };
+const other = (mode: BtcMode): BtcMode => (mode === 'lightning' ? 'bitcoin' : 'lightning');
+
+/**
+ * Lightning / on-chain switch docked left of the receive QR. Each half of
+ * the 44 x 90 dock is a 44 px target; the gold thumb slides between them.
+ * The test ids keep the old tab ids so e2e flows still pick a format.
+ */
+export const SideDock: React.FC<{ mode: BtcMode; onChange: (mode: BtcMode) => void }> = ({ mode, onChange }) => (
+  <div className="relative h-[90px] w-11 rounded-[22px] border border-spark-border bg-spark-dark/50">
+    <div
+      aria-hidden="true"
+      className={`absolute left-[3px] top-1 size-9 rounded-full bg-spark-primary shadow-[0_0_16px_var(--glow-primary)] transition-transform duration-[320ms] ease-m3-emphasized motion-reduce:transition-none ${mode === 'bitcoin' ? 'translate-y-11' : ''}`}
+    />
+    {(['lightning', 'bitcoin'] as const).map((m) => (
+      <button
+        key={m}
+        type="button"
+        onClick={() => onChange(m)}
+        aria-label={LABEL[m]}
+        aria-pressed={mode === m}
+        data-testid={m === 'lightning' ? 'lightning-tab' : 'bitcoin-tab'}
+        className={`relative flex h-11 w-full items-center justify-center rounded-[22px] outline-none transition-colors duration-[320ms] focus-visible:ring-2 focus-visible:ring-spark-primary/60 ${mode === m ? 'text-black' : 'text-spark-text-muted'}`}
+      >
+        {m === 'lightning' ? <LightningBoltIcon size="sm" /> : <ChainLinkIcon size="sm" />}
+      </button>
+    ))}
+  </div>
+);
+
+/**
+ * Names the code on screen. The margin switches too, with no visual cue:
+ * the dock stays the one visible control.
+ */
+export const SideCaption: React.FC<{ shown: BtcMode; mode: BtcMode; onChange: (mode: BtcMode) => void }> = ({ shown, mode, onChange }) => (
+  <button
+    type="button"
+    onClick={() => onChange(other(mode))}
+    aria-label={`Switch to ${LABEL[other(mode)]}`}
+    className="flex w-11 items-center justify-center self-stretch justify-self-end rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-spark-primary/60"
+  >
+    <span className="text-spark-text-muted text-xs font-display font-medium tracking-widest uppercase [writing-mode:vertical-rl]">
+      {LABEL[shown]}
+    </span>
+  </button>
+);

--- a/src/index.css
+++ b/src/index.css
@@ -229,6 +229,8 @@
   --animate-spin-slow: spin 3s linear infinite;
   --animate-bounce-subtle: bounce-subtle 2s ease-in-out infinite;
   --animate-pin-shake: pin-shake 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+  --animate-qr-turn-out: qr-turn-out 160ms cubic-bezier(0.3, 0, 0.8, 0.15) forwards;
+  --animate-qr-turn-in: qr-turn-in 160ms cubic-bezier(0.05, 0.7, 0.1, 1);
 
   --backdrop-blur-xs: 2px;
 
@@ -269,6 +271,18 @@
     }
     50% {
       transform: translateY(-5px);
+    }
+  }
+  /* The receive QR card turning between Lightning and on-chain, in two
+     halves: the code swaps while the card is edge-on. */
+  @keyframes qr-turn-out {
+    to {
+      transform: perspective(900px) rotateY(90deg);
+    }
+  }
+  @keyframes qr-turn-in {
+    from {
+      transform: perspective(900px) rotateY(-90deg);
     }
   }
   /* Wrong-PIN feedback: the dots row shudders horizontally, iOS

--- a/src/index.css
+++ b/src/index.css
@@ -274,15 +274,16 @@
     }
   }
   /* The receive QR card turning between Lightning and on-chain, in two
-     halves: the code swaps while the card is edge-on. */
+     halves: the code swaps while the card is edge-on. The edge beside the
+     dock goes back first, as if the tap pushed it. */
   @keyframes qr-turn-out {
     to {
-      transform: perspective(900px) rotateY(90deg);
+      transform: perspective(900px) rotateY(-90deg);
     }
   }
   @keyframes qr-turn-in {
     from {
-      transform: perspective(900px) rotateY(-90deg);
+      transform: perspective(900px) rotateY(90deg);
     }
   }
   /* Wrong-PIN feedback: the dots row shudders horizontally, iOS


### PR DESCRIPTION
This PR merges the Lightning and Bitcoin receive tabs into one BTC tab. A switch beside the QR changes between Lightning and on-chain, and the QR stays in the center.

- **Switch:** A dock on the left of the QR shows Lightning and on-chain. Tap one to switch. The label on the right shows which code is on screen. Tap it to switch too.
- **Turn:** The QR card turns over to show the other code.
- **Loading:** While the on-chain address loads, a placeholder shows where the QR goes. It replaces the "Generating Bitcoin address..." spinner.
- **Tabs:** The sheet shows BTC and USD tabs. The tab bar hides while the dev-only USD setting is off.

Replaces #417.

| Lightning | Address loading | On-chain |
|---|---|---|
| <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/f7da5b16-8c08-4741-9420-da16aba14426" /> | <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/5224329a-d50d-4d5d-ba8b-057c133ef318" /> | <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/798d63c6-e6c2-451a-b1b4-f43211cc11cc" /> |
