### PR TITLE
feat: add a dev toggle for the receive dock on the right

### DIFF
--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../components/ui';
 
 import type { PaymentMethod } from '../../types/domain';
-import { isCrossChainEnabled } from '../../services/settings';
+import { getSettings, isCrossChainEnabled } from '../../services/settings';
 import { useLightningAddress } from './hooks/useLightningAddress';
 import { useReceivePayment } from './hooks/useReceivePayment';
 import { formatWithSpaces } from '../../utils/formatNumber';
@@ -202,6 +202,10 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
     // Cleared, so a QR replacing its placeholder does not turn in again.
     later(320, () => setTurning(null));
   };
+  // Dev-mode trial of the mirrored layout: dock right of the code, caption left.
+  const dockRight = getSettings().receiveDockRight === true;
+  const dock = <SideDock mode={btcMode} onChange={switchBtcMode} />;
+  const caption = <SideCaption shown={shownMode} mode={btcMode} onChange={switchBtcMode} />;
   // Narrow phones get a smaller code so the dock clears the frame.
   const qrSize = window.innerWidth < 375 ? 184 : 200;
   const qrCardClassName = `${turning === 'out' ? 'animate-qr-turn-out' : turning === 'in' ? 'animate-qr-turn-in' : ''} motion-reduce:animate-none`;
@@ -284,10 +288,10 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
                         {isBtcTab && (
                           <div className="flex flex-col items-center gap-6">
                             {/* Dock, code, caption: the grid keeps the code centered between them. */}
-                            <div className="-mx-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center self-stretch">
-                              <SideDock mode={btcMode} onChange={switchBtcMode} />
+                            <div className={`-mx-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center self-stretch ${dockRight ? '[--qr-turn:1]' : ''}`}>
+                              {dockRight ? caption : dock}
                               {btcView('qr')}
-                              <SideCaption shown={shownMode} mode={btcMode} onChange={switchBtcMode} />
+                              {dockRight ? dock : caption}
                             </div>
                             {btcView('details')}
                           </div>

--- a/src/features/receive/SideDock.tsx
+++ b/src/features/receive/SideDock.tsx
@@ -7,12 +7,12 @@ const LABEL: Record<BtcMode, string> = { lightning: 'Lightning', bitcoin: 'On-ch
 const other = (mode: BtcMode): BtcMode => (mode === 'lightning' ? 'bitcoin' : 'lightning');
 
 /**
- * Lightning / on-chain switch docked left of the receive QR. Each half of
+ * Lightning / on-chain switch docked beside the receive QR. Each half of
  * the 44 x 90 dock is a 44 px target; the gold thumb slides between them.
  * The test ids keep the old tab ids so e2e flows still pick a format.
  */
 export const SideDock: React.FC<{ mode: BtcMode; onChange: (mode: BtcMode) => void }> = ({ mode, onChange }) => (
-  <div className="relative h-[90px] w-11 rounded-[22px] border border-spark-border bg-spark-dark/50">
+  <div className="relative h-[90px] w-11 rounded-[22px] border border-spark-border bg-spark-dark/50 last:justify-self-end">
     <div
       aria-hidden="true"
       className={`absolute left-[3px] top-1 size-9 rounded-full bg-spark-primary shadow-[0_0_16px_var(--glow-primary)] transition-transform duration-[320ms] ease-m3-emphasized motion-reduce:transition-none ${mode === 'bitcoin' ? 'translate-y-11' : ''}`}
@@ -35,14 +35,15 @@ export const SideDock: React.FC<{ mode: BtcMode; onChange: (mode: BtcMode) => vo
 
 /**
  * Names the code on screen. The margin switches too, with no visual cue:
- * the dock stays the one visible control.
+ * the dock stays the one visible control. Left of the code it turns over,
+ * so the text runs bottom to top and its baseline still faces the code.
  */
 export const SideCaption: React.FC<{ shown: BtcMode; mode: BtcMode; onChange: (mode: BtcMode) => void }> = ({ shown, mode, onChange }) => (
   <button
     type="button"
     onClick={() => onChange(other(mode))}
     aria-label={`Switch to ${LABEL[other(mode)]}`}
-    className="flex w-11 items-center justify-center self-stretch justify-self-end rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-spark-primary/60"
+    className="flex w-11 items-center justify-center self-stretch rounded-lg outline-none first:rotate-180 last:justify-self-end focus-visible:ring-2 focus-visible:ring-spark-primary/60"
   >
     <span className="text-spark-text-muted text-xs font-display font-medium tracking-widest uppercase [writing-mode:vertical-rl]">
       {LABEL[shown]}

--- a/src/index.css
+++ b/src/index.css
@@ -275,15 +275,16 @@
   }
   /* The receive QR card turning between Lightning and on-chain, in two
      halves: the code swaps while the card is edge-on. The edge beside the
-     dock goes back first, as if the tap pushed it. */
+     dock goes back first, as if the tap pushed it. `--qr-turn` is 1 when
+     the dock sits right of the card. */
   @keyframes qr-turn-out {
     to {
-      transform: perspective(900px) rotateY(-90deg);
+      transform: perspective(900px) rotateY(calc(var(--qr-turn, -1) * 90deg));
     }
   }
   @keyframes qr-turn-in {
     from {
-      transform: perspective(900px) rotateY(90deg);
+      transform: perspective(900px) rotateY(calc(var(--qr-turn, -1) * -90deg));
     }
   }
   /* Wrong-PIN feedback: the dots row shudders horizontally, iOS

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -99,6 +99,12 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     setCrossChainEnabled(next);
     saveSettings({ ...getSettings(), crossChainEnabled: next });
   };
+  const [receiveDockRight, setReceiveDockRight] = useState<boolean>(() => getSettings().receiveDockRight === true);
+  const toggleReceiveDockRight = () => {
+    const next = !receiveDockRight;
+    setReceiveDockRight(next);
+    saveSettings({ ...getSettings(), receiveDockRight: next });
+  };
   const [isDownloadingLogs, setIsDownloadingLogs] = useState<boolean>(false);
   const [isExportingDb, setIsExportingDb] = useState<boolean>(false);
 
@@ -434,6 +440,22 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                 <Switch
                   checked={crossChainEnabled}
                   onChange={toggleCrossChain}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Receive dock side: a layout trial */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <span className="font-display font-medium text-spark-text-primary block">Receive dock on the right</span>
+                  <span className="text-sm text-spark-text-muted">Move the Lightning / on-chain switch to the right of the QR</span>
+                </div>
+                <Switch
+                  checked={receiveDockRight}
+                  onChange={toggleReceiveDockRight}
                 />
               </div>
             </div>

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -67,6 +67,8 @@ export interface UserSettings {
   lnurlDomain?: string;
   preferSparkOverLightning?: boolean;
   crossChainEnabled?: boolean;
+  /** Dev-mode layout trial: the receive side dock sits right of the QR. */
+  receiveDockRight?: boolean;
   /**
    * TEMPORARY: gates the priority deposit claim while it is being tested.
    * Absent means off, so the deposit sheet behaves as it did before it.
@@ -203,6 +205,7 @@ export function getSettings(): UserSettings {
       lnurlDomain: typeof parsed.lnurlDomain === 'string' ? parsed.lnurlDomain : undefined,
       preferSparkOverLightning: typeof parsed.preferSparkOverLightning === 'boolean' ? parsed.preferSparkOverLightning : undefined,
       crossChainEnabled: typeof parsed.crossChainEnabled === 'boolean' ? parsed.crossChainEnabled : undefined,
+      receiveDockRight: typeof parsed.receiveDockRight === 'boolean' ? parsed.receiveDockRight : undefined,
       priorityDepositClaimEnabled:
         typeof parsed.priorityDepositClaimEnabled === 'boolean' ? parsed.priorityDepositClaimEnabled : undefined,
     };


### PR DESCRIPTION
This PR adds a dev-mode setting that puts the receive dock on the right of the QR. The team can use it to compare the two layouts on a phone.

- **Setting:** "Receive dock on the right" shows in Settings in dev mode only. It is off by default, so the approved layout stays the same.
- **Turn:** On both sides, the QR card turns away from the dock.

Stacked on #423.

| Dock left (default) | Dock right | Setting |
|---|---|---|
| <img width="92%" height="80%" alt="image" src="https://github.com/user-attachments/assets/14535344-ce9a-46cb-92fd-ec62c2895f4c" /> | <img width="100%" height="1028" alt="image" src="https://github.com/user-attachments/assets/16593f0d-239e-40d6-927f-42d29ce868d2" /> | <img width="780" height="652" alt="image" src="https://github.com/user-attachments/assets/df9390fe-b1d8-4495-803d-8ac31a3ef13d" /> |
